### PR TITLE
Fix: Resolve the errors of using the evaluation scripts in roboverse_learn

### DIFF
--- a/roboverse_learn/eval_act.py
+++ b/roboverse_learn/eval_act.py
@@ -97,10 +97,8 @@ def main():
     from metasim.cfg.sensors import PinholeCameraCfg
     from metasim.constants import SimType
     from metasim.utils.demo_util import get_traj
-    from metasim.utils.setup_util import get_robot, get_sim_env_class, get_task
+    from metasim.utils.setup_util import get_sim_env_class
 
-    task = get_task(args.task)
-    robot = get_robot(args.robot)
     camera = PinholeCameraCfg(
         name="camera",
         data_types=["rgb", "depth"],
@@ -110,11 +108,20 @@ def main():
         look_at=(0.0, 0.0, 0.0),
     )
     randomization = RandomizationCfg(camera=False, light=False, ground=False, reflection=False)
-    scenario = ScenarioCfg(task=task, robot=robot, cameras=[camera], randomization=randomization, try_add_table=True)
+    scenario = ScenarioCfg(
+        task=args.task,
+        robot=args.robot,
+        cameras=[camera],
+        random=randomization,
+        sim=args.sim,
+        num_envs=args.num_envs,
+        try_add_table=True,
+        headless=args.headless,
+    )
 
     tic = time.time()
     env_class = get_sim_env_class(SimType(args.sim))
-    env = env_class(scenario, num_envs)
+    env = env_class(scenario)
     toc = time.time()
     log.trace(f"Time to launch: {toc - tic:.2f}s")
 
@@ -173,7 +180,7 @@ def main():
         if args.temporal_agg:
             query_frequency = 1
             num_queries = policy_config["num_queries"]
-        max_timesteps = task.episode_length
+        max_timesteps = scenario.task.episode_length
         max_timesteps = int(max_timesteps * 1)
 
     ckpt_name = args.ckpt_path.split("/")[-1]
@@ -181,15 +188,17 @@ def main():
 
     ## Data
     tic = time.time()
-    assert os.path.exists(task.traj_filepath), f"Trajectory file: {task.traj_filepath} does not exist."
-    init_states, all_actions, all_states = get_traj(task, robot, env.handler)
+    assert os.path.exists(scenario.task.traj_filepath), (
+        f"Trajectory file: {scenario.task.traj_filepath} does not exist."
+    )
+    init_states, all_actions, all_states = get_traj(scenario.task, scenario.robot, env.handler)
     toc = time.time()
     log.trace(f"Time to load data: {toc - tic:.2f}s")
 
     ## cuRobo controller
-    *_, robot_ik = get_curobo_models(robot)
+    *_, robot_ik = get_curobo_models(scenario.robot)
     curobo_n_dof = len(robot_ik.robot_config.cspace.joint_names)
-    ee_n_dof = len(robot.gripper_release_q)
+    ee_n_dof = len(scenario.robot.gripper_release_q)
 
     ## Reset before first step
     TotalSuccess = 0
@@ -218,7 +227,7 @@ def main():
         with torch.no_grad():
             while step < MaxStep:
                 log.debug(f"Step {step}")
-                robot_joint_limits = robot.joint_limits
+                robot_joint_limits = scenario.robot.joint_limits
 
                 image_list.append(np.array(obs["rgb"])[0])
 
@@ -255,9 +264,9 @@ def main():
                 log.debug(f"Action: {action}")
 
                 action = torch.tensor(action, dtype=torch.float32, device="cuda")
-                actions = [{"dof_pos_target": dict(zip(robot.joint_limits.keys(), action))}]
+                actions = [{"dof_pos_target": dict(zip(scenario.robot.joint_limits.keys(), action))}]
                 obs, reward, success, time_out, extras = env.step(actions)
-                env.handler.render()
+                env.handler.refresh_render()
                 # print(reward, success, time_out)
 
                 # eval

--- a/roboverse_learn/train.py
+++ b/roboverse_learn/train.py
@@ -101,7 +101,7 @@ def main():
             for _ in range(num_envs)
         ]
         env.step(actions)
-        env.handler.render()
+        env.handler.refresh_render()
         step += 1
 
     env.close()

--- a/roboverse_learn/train.py
+++ b/roboverse_learn/train.py
@@ -54,11 +54,19 @@ def main():
         pos=(1.5, 0.0, 1.5),
         look_at=(0.0, 0.0, 0.0),
     )
-    scenario = ScenarioCfg(task=task, robot=robot, cameras=[camera])
+    scenario = ScenarioCfg(
+        task=args.task,
+        robot=args.robot,
+        cameras=[camera],
+        sim=args.sim,
+        renderer=args.render,
+        num_envs=args.num_envs,
+        try_add_table=True,
+    )
 
     tic = time.time()
     env_class = get_sim_env_class(SimType(args.sim))
-    env = env_class(scenario, num_envs)
+    env = env_class(scenario)
     toc = time.time()
     log.trace(f"Time to launch: {toc - tic:.2f}s")
 


### PR DESCRIPTION
There are some issues with the evaluation scripts (such as `eval_act.py`) in `roboverse_learn` caused by outdated usage of certain Metasim APIs.

1. The usage of `ScenarioCfg` and `env_class` in the script were incompatible with the current codebase. These references have been modified to align with the latest version.

2. When calling `env.handler.render()`, a `NotImplementedError` was raised. I have updated this to `env.handler.refresh_render()` to resolve the issue.

After making these changes, the evaluation scripts now run correctly.