### PR TITLE
Dev/states as obs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,6 @@ id_rsa*
 
 # for docker
 .env
+
+# for sapien
+*.convex.stl

--- a/get_started/0_static_scene.py
+++ b/get_started/0_static_scene.py
@@ -144,4 +144,6 @@ init_states = [
 ]
 obs, extras = env.reset(states=init_states)
 os.makedirs("get_started/output", exist_ok=True)
-imageio.imwrite(f"get_started/output/0_static_scene_{args.sim}.png", obs["rgb"][0])
+imageio.imwrite(
+    f"get_started/output/0_static_scene_{args.sim}.png", next(iter(obs[0]["cameras"].values()))["rgb"].cpu().numpy()
+)

--- a/get_started/1_control_robot.py
+++ b/get_started/1_control_robot.py
@@ -11,64 +11,23 @@ except ImportError:
 
 import os
 
-import imageio as iio
-import numpy as np
 import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from numpy.typing import NDArray
 from rich.logging import RichHandler
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
+from get_started.utils import ObsSaver
 from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg
 from metasim.constants import PhysicStateType, SimType
 from metasim.utils import configclass
 from metasim.utils.setup_util import get_sim_env_class
-
-
-class ObsSaver:
-    """Save the observations to images or videos."""
-
-    def __init__(self, image_dir: str | None = None, video_path: str | None = None):
-        """Initialize the ObsSaver."""
-        assert image_dir is not None or video_path is not None
-        self.image_dir = image_dir
-        self.video_path = video_path
-        self.images: list[NDArray] = []
-
-        self.image_idx = 0
-
-    def add(self, obs: dict):
-        """Add the observation to the list."""
-        from torchvision.utils import make_grid, save_image
-
-        if obs is None or obs.get("rgb", None) is None:
-            return
-
-        rgb_data = obs["rgb"]  # (N, H, W, C), uint8
-        image = make_grid(rgb_data.permute(0, 3, 1, 2) / 255, nrow=int(rgb_data.shape[0] ** 0.5))  # (C, H, W)
-
-        if self.image_dir is not None:
-            os.makedirs(self.image_dir, exist_ok=True)
-            save_image(image, os.path.join(self.image_dir, f"rgb_{self.image_idx:04d}.png"))
-            self.image_idx += 1
-
-        image = image.cpu().numpy().transpose(1, 2, 0)  # (H, W, C)
-        image = (image * 255).astype(np.uint8)
-        self.images.append(image)
-
-    def save(self):
-        """Save the images or videos."""
-        if self.video_path is not None:
-            log.info(f"Saving video of {len(self.images)} frames to {self.video_path}")
-            os.makedirs(os.path.dirname(self.video_path), exist_ok=True)
-            iio.mimsave(self.video_path, self.images, fps=30)
 
 
 @configclass

--- a/get_started/2_add_new_robot.py
+++ b/get_started/2_add_new_robot.py
@@ -11,18 +11,16 @@ except ImportError:
 
 import os
 
-import imageio as iio
-import numpy as np
 import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from numpy.typing import NDArray
 from rich.logging import RichHandler
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
+from get_started.utils import ObsSaver
 from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.robots.base_robot_cfg import BaseActuatorCfg, BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
@@ -30,45 +28,6 @@ from metasim.cfg.sensors import PinholeCameraCfg
 from metasim.constants import PhysicStateType, SimType
 from metasim.utils import configclass
 from metasim.utils.setup_util import get_sim_env_class
-
-
-class ObsSaver:
-    """Save the observations to images or videos."""
-
-    def __init__(self, image_dir: str | None = None, video_path: str | None = None):
-        """Initialize the ObsSaver."""
-        assert image_dir is not None or video_path is not None
-        self.image_dir = image_dir
-        self.video_path = video_path
-        self.images: list[NDArray] = []
-
-        self.image_idx = 0
-
-    def add(self, obs: dict):
-        """Add the observation to the list."""
-        from torchvision.utils import make_grid, save_image
-
-        if obs is None or obs.get("rgb", None) is None:
-            return
-
-        rgb_data = obs["rgb"]  # (N, H, W, C), uint8
-        image = make_grid(rgb_data.permute(0, 3, 1, 2) / 255, nrow=int(rgb_data.shape[0] ** 0.5))  # (C, H, W)
-
-        if self.image_dir is not None:
-            os.makedirs(self.image_dir, exist_ok=True)
-            save_image(image, os.path.join(self.image_dir, f"rgb_{self.image_idx:04d}.png"))
-            self.image_idx += 1
-
-        image = image.cpu().numpy().transpose(1, 2, 0)  # (H, W, C)
-        image = (image * 255).astype(np.uint8)
-        self.images.append(image)
-
-    def save(self):
-        """Save the images or videos."""
-        if self.video_path is not None:
-            log.info(f"Saving video of {len(self.images)} frames to {self.video_path}")
-            os.makedirs(os.path.dirname(self.video_path), exist_ok=True)
-            iio.mimsave(self.video_path, self.images, fps=30)
 
 
 @configclass

--- a/get_started/3_parallel_envs.py
+++ b/get_started/3_parallel_envs.py
@@ -11,64 +11,22 @@ except ImportError:
 
 import os
 
-import imageio as iio
-import numpy as np
 import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from numpy.typing import NDArray
 from rich.logging import RichHandler
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
-
+from get_started.utils import ObsSaver
 from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg
 from metasim.constants import PhysicStateType, SimType
 from metasim.utils import configclass
 from metasim.utils.setup_util import get_sim_env_class
-
-
-class ObsSaver:
-    """Save the observations to images or videos."""
-
-    def __init__(self, image_dir: str | None = None, video_path: str | None = None):
-        """Initialize the ObsSaver."""
-        assert image_dir is not None or video_path is not None
-        self.image_dir = image_dir
-        self.video_path = video_path
-        self.images: list[NDArray] = []
-
-        self.image_idx = 0
-
-    def add(self, obs: dict):
-        """Add the observation to the list."""
-        from torchvision.utils import make_grid, save_image
-
-        if obs is None or obs.get("rgb", None) is None:
-            return
-
-        rgb_data = obs["rgb"]  # (N, H, W, C), uint8
-        image = make_grid(rgb_data.permute(0, 3, 1, 2) / 255, nrow=int(rgb_data.shape[0] ** 0.5))  # (C, H, W)
-
-        if self.image_dir is not None:
-            os.makedirs(self.image_dir, exist_ok=True)
-            save_image(image, os.path.join(self.image_dir, f"rgb_{self.image_idx:04d}.png"))
-            self.image_idx += 1
-
-        image = image.cpu().numpy().transpose(1, 2, 0)  # (H, W, C)
-        image = (image * 255).astype(np.uint8)
-        self.images.append(image)
-
-    def save(self):
-        """Save the images or videos."""
-        if self.video_path is not None:
-            log.info(f"Saving video of {len(self.images)} frames to {self.video_path}")
-            os.makedirs(os.path.dirname(self.video_path), exist_ok=True)
-            iio.mimsave(self.video_path, self.images, fps=30)
 
 
 @configclass

--- a/get_started/5_hybrid_sim.py
+++ b/get_started/5_hybrid_sim.py
@@ -11,19 +11,17 @@ except ImportError:
 
 import os
 
-import imageio as iio
-import numpy as np
 import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from numpy.typing import NDArray
 from rich.logging import RichHandler
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
+from get_started.utils import ObsSaver
 from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg
@@ -31,45 +29,6 @@ from metasim.constants import PhysicStateType, SimType
 from metasim.sim import HybridSimEnv
 from metasim.utils import configclass
 from metasim.utils.setup_util import get_sim_env_class
-
-
-class ObsSaver:
-    """Save the observations to images or videos."""
-
-    def __init__(self, image_dir: str | None = None, video_path: str | None = None):
-        """Initialize the ObsSaver."""
-        assert image_dir is not None or video_path is not None
-        self.image_dir = image_dir
-        self.video_path = video_path
-        self.images: list[NDArray] = []
-
-        self.image_idx = 0
-
-    def add(self, obs: dict):
-        """Add the observation to the list."""
-        from torchvision.utils import make_grid, save_image
-
-        if obs is None or obs.get("rgb", None) is None:
-            return
-
-        rgb_data = obs["rgb"]  # (N, H, W, C), uint8
-        image = make_grid(rgb_data.permute(0, 3, 1, 2) / 255, nrow=int(rgb_data.shape[0] ** 0.5))  # (C, H, W)
-
-        if self.image_dir is not None:
-            os.makedirs(self.image_dir, exist_ok=True)
-            save_image(image, os.path.join(self.image_dir, f"rgb_{self.image_idx:04d}.png"))
-            self.image_idx += 1
-
-        image = image.cpu().numpy().transpose(1, 2, 0)  # (H, W, C)
-        image = (image * 255).astype(np.uint8)
-        self.images.append(image)
-
-    def save(self):
-        """Save the images or videos."""
-        if self.video_path is not None:
-            log.info(f"Saving video of {len(self.images)} frames to {self.video_path}")
-            os.makedirs(os.path.dirname(self.video_path), exist_ok=True)
-            iio.mimsave(self.video_path, self.images, fps=30)
 
 
 @configclass

--- a/get_started/6_advanced_rendering.py
+++ b/get_started/6_advanced_rendering.py
@@ -147,4 +147,7 @@ init_states = [
 ]
 obs, extras = env.reset(states=init_states)
 os.makedirs("get_started/output", exist_ok=True)
-imageio.imwrite(f"get_started/output/6_advanced_rendering_{args.sim}_{args.render.mode}.png", obs["rgb"][0])
+imageio.imwrite(
+    f"get_started/output/6_advanced_rendering_{args.sim}_{args.render.mode}.png",
+    next(iter(obs[0]["cameras"].values()))["rgb"].cpu().numpy(),
+)

--- a/get_started/example_assets/.gitignore
+++ b/get_started/example_assets/.gitignore
@@ -1,1 +1,2 @@
 !*
+*.convex.stl

--- a/get_started/utils.py
+++ b/get_started/utils.py
@@ -1,0 +1,60 @@
+"""Utils for get_started scripts."""
+
+from __future__ import annotations
+
+import os
+
+import imageio.v2 as iio
+import numpy as np
+import torch
+from loguru import logger as log
+from numpy.typing import NDArray
+from torchvision.utils import make_grid, save_image
+
+from metasim.types import EnvState
+
+
+class ObsSaver:
+    """Save the observations to images or videos."""
+
+    def __init__(self, image_dir: str | None = None, video_path: str | None = None):
+        """Initialize the ObsSaver."""
+        self.image_dir = image_dir
+        self.video_path = video_path
+        self.images: list[NDArray] = []
+
+        self.image_idx = 0
+
+    def add(self, states: list[EnvState]):
+        """Add the observation to the list."""
+        if self.image_dir is None and self.video_path is None:
+            return
+
+        rgb_data_list = []
+        for state in states:
+            for camera_name, camera_data in state["cameras"].items():
+                if "rgb" in camera_data:
+                    rgb_data_list.append(camera_data["rgb"])
+                    continue
+
+        if not rgb_data_list:
+            return
+
+        rgb_data = torch.stack(rgb_data_list, dim=0)
+        image = make_grid(rgb_data.permute(0, 3, 1, 2) / 255, nrow=int(rgb_data.shape[0] ** 0.5))  # (C, H, W)
+
+        if self.image_dir is not None:
+            os.makedirs(self.image_dir, exist_ok=True)
+            save_image(image, os.path.join(self.image_dir, f"rgb_{self.image_idx:04d}.png"))
+            self.image_idx += 1
+
+        image = image.cpu().numpy().transpose(1, 2, 0)  # (H, W, C)
+        image = (image * 255).astype(np.uint8)
+        self.images.append(image)
+
+    def save(self):
+        """Save the images or videos."""
+        if self.video_path is not None and self.images:
+            log.info(f"Saving video of {len(self.images)} frames to {self.video_path}")
+            os.makedirs(os.path.dirname(self.video_path), exist_ok=True)
+            iio.mimsave(self.video_path, self.images, fps=30)

--- a/metasim/scripts/replay_demo.py
+++ b/metasim/scripts/replay_demo.py
@@ -98,7 +98,10 @@ def get_runout(all_actions, action_idx: int):
 
 
 class ObsSaver:
+    """Save the observations to images or videos."""
+
     def __init__(self, image_dir: str | None = None, video_path: str | None = None):
+        """Initialize the ObsSaver."""
         self.image_dir = image_dir
         self.video_path = video_path
         self.images: list[NDArray] = []
@@ -106,31 +109,34 @@ class ObsSaver:
         self.image_idx = 0
 
     def add(self, states: list[EnvState]):
+        """Add the observation to the list."""
         if self.image_dir is None and self.video_path is None:
             return
 
+        rgb_data_list = []
         for state in states:
-            rgb_data_list = []
             for camera_name, camera_data in state["cameras"].items():
                 if "rgb" in camera_data:
                     rgb_data_list.append(camera_data["rgb"])
+                    continue
 
-            if not rgb_data_list:
-                continue
+        if not rgb_data_list:
+            return
 
-            rgb_data = torch.stack(rgb_data_list, dim=0)
-            image = make_grid(rgb_data.permute(0, 3, 1, 2) / 255, nrow=int(rgb_data.shape[0] ** 0.5))  # (C, H, W)
+        rgb_data = torch.stack(rgb_data_list, dim=0)
+        image = make_grid(rgb_data.permute(0, 3, 1, 2) / 255, nrow=int(rgb_data.shape[0] ** 0.5))  # (C, H, W)
 
-            if self.image_dir is not None:
-                os.makedirs(self.image_dir, exist_ok=True)
-                save_image(image, os.path.join(self.image_dir, f"rgb_{self.image_idx:04d}.png"))
-                self.image_idx += 1
+        if self.image_dir is not None:
+            os.makedirs(self.image_dir, exist_ok=True)
+            save_image(image, os.path.join(self.image_dir, f"rgb_{self.image_idx:04d}.png"))
+            self.image_idx += 1
 
-            image = image.cpu().numpy().transpose(1, 2, 0)  # (H, W, C)
-            image = (image * 255).astype(np.uint8)
-            self.images.append(image)
+        image = image.cpu().numpy().transpose(1, 2, 0)  # (H, W, C)
+        image = (image * 255).astype(np.uint8)
+        self.images.append(image)
 
     def save(self):
+        """Save the images or videos."""
         if self.video_path is not None and self.images:
             log.info(f"Saving video of {len(self.images)} frames to {self.video_path}")
             os.makedirs(os.path.dirname(self.video_path), exist_ok=True)

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -168,3 +168,10 @@ class BaseSimHandler:
         The timestep of each environment, restart from 0 when reset, plus 1 at each step.
         """
         raise NotImplementedError
+
+    @property
+    def actions_cache(self) -> list[Action]:
+        """
+        Cache of actions.
+        """
+        raise NotImplementedError

--- a/metasim/sim/env_wrapper.py
+++ b/metasim/sim/env_wrapper.py
@@ -84,11 +84,11 @@ def GymEnvWrapper(cls: type[THandler]) -> type[EnvWrapper[THandler]]:
             self._episode_length_buf += 1
             self.handler.set_dof_targets(self.handler.robot.name, actions)
             self.handler.simulate()
-            obs = self.handler.get_observation()
             reward = self._get_reward()
             success = self.handler.checker.check(self.handler)
+            states = self.handler.get_states()
             time_out = self._episode_length_buf >= self.handler.scenario.episode_length
-            return obs, reward, success, time_out, None
+            return states, reward, success, time_out, None
 
         def render(self) -> None:
             log.warning("render() is not implemented yet")

--- a/metasim/sim/env_wrapper.py
+++ b/metasim/sim/env_wrapper.py
@@ -76,8 +76,9 @@ def GymEnvWrapper(cls: type[THandler]) -> type[EnvWrapper[THandler]]:
             if states is not None:
                 self.handler.set_states(states, env_ids=env_ids)
             self.handler.checker.reset(self.handler, env_ids=env_ids)
-            obs = self.handler.get_observation()
-            return obs, None
+            self.handler.refresh_render()
+            states = self.handler.get_states()
+            return states, None
 
         def step(self, actions: list[Action]) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
             self._episode_length_buf += 1

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -122,6 +122,7 @@ class GenesisHandler(BaseSimHandler):
                         for jid, jn in enumerate(self.get_object_joint_names(obj))
                     }
                 if isinstance(obj, BaseRobotCfg):
+                    ## TODO: read from simulator instead of cache
                     if self.actions_cache:
                         obj_state["dof_pos_target"] = {
                             jn: self.actions_cache[env_id]["dof_pos_target"][jn]

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -10,6 +10,7 @@ from loguru import logger as log
 
 rootutils.setup_root(__file__, pythonpath=True)
 from metasim.cfg.objects import ArticulationObjCfg, BaseObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
+from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, GymEnvWrapper
 from metasim.types import Action, EnvState
@@ -18,6 +19,7 @@ from metasim.types import Action, EnvState
 class GenesisHandler(BaseSimHandler):
     def __init__(self, scenario: ScenarioCfg):
         super().__init__(scenario)
+        self._actions_cache: list[Action] = []
         self.object_inst_dict: dict[str, RigidEntity] = {}
         self.camera_inst_dict: dict[str, Camera] = {}
 
@@ -101,7 +103,6 @@ class GenesisHandler(BaseSimHandler):
             states_concat[obj.name]["rot"] = obj_inst.get_quat(envs_idx=env_ids).cpu()
             if isinstance(obj, ArticulationObjCfg):
                 states_concat[obj.name]["dof_pos"] = obj_inst.get_qpos(envs_idx=env_ids).cpu()
-
         camera_obs = {}
         for camera_name, camera_inst in self.camera_inst_dict.items():
             rgb, _, _, _ = camera_inst.render()
@@ -120,6 +121,14 @@ class GenesisHandler(BaseSimHandler):
                         jn: states_concat[obj.name]["dof_pos"][env_id][jid]
                         for jid, jn in enumerate(self.get_object_joint_names(obj))
                     }
+                if isinstance(obj, BaseRobotCfg):
+                    if self.actions_cache:
+                        obj_state["dof_pos_target"] = {
+                            jn: self.actions_cache[env_id]["dof_pos_target"][jn]
+                            for jid, jn in enumerate(self.get_object_joint_names(obj))
+                        }
+                    else:
+                        obj_state["dof_pos_target"] = None
                 if obj.name == self.robot.name:
                     env_state["robots"][obj.name] = obj_state
                 else:
@@ -156,6 +165,7 @@ class GenesisHandler(BaseSimHandler):
                     )
 
     def set_dof_targets(self, obj_name: str, actions: list[Action]) -> None:
+        self._actions_cache = actions
         position = [
             [actions[env_id]["dof_pos_target"][jn] for jn in self.get_object_joint_names(self.object_dict[obj_name])]
             for env_id in range(self.num_envs)
@@ -202,6 +212,10 @@ class GenesisHandler(BaseSimHandler):
     @property
     def num_envs(self) -> int:
         return self.scene_inst.n_envs
+
+    @property
+    def actions_cache(self) -> list[Action]:
+        return self._actions_cache
 
 
 GenesisEnv = GymEnvWrapper(GenesisHandler)

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -196,6 +196,11 @@ class GenesisHandler(BaseSimHandler):
         for _ in range(self.scenario.decimation):
             self.scene_inst.step()
 
+    def refresh_render(self):
+        """Refresh the render."""
+        self.scene_inst.viewer.update()
+        self.scene_inst.visualizer.update()
+
     def close(self):
         pass
 

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -198,7 +198,8 @@ class GenesisHandler(BaseSimHandler):
 
     def refresh_render(self):
         """Refresh the render."""
-        self.scene_inst.viewer.update()
+        if not self.headless:
+            self.scene_inst.viewer.update()
         self.scene_inst.visualizer.update()
 
     def close(self):

--- a/metasim/sim/hybrid.py
+++ b/metasim/sim/hybrid.py
@@ -18,8 +18,8 @@ class HybridSimEnv(EnvWrapper[BaseSimHandler]):
         states = self.sim_env1.handler.get_states()
         self.sim_env2.handler.set_states(states)
         self.sim_env2.handler.refresh_render()
-        obs = self.sim_env2.handler.get_observation()
-        return obs, reward, success, time_out, extra
+        states = self.sim_env2.handler.get_states()
+        return states, reward, success, time_out, extra
 
     def render(self):
         self.sim_env2.render()

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -437,6 +437,7 @@ class IsaacgymHandler(BaseSimHandler):
                     }
 
                 ## Actions -- for robot
+                ## TODO: read from simulator instead of cache
                 if isinstance(obj, BaseRobotCfg):
                     if self.actions_cache:
                         obj_state["dof_pos_target"] = {

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -17,6 +17,7 @@ from metasim.types import Action, EnvState
 class IsaacgymHandler(BaseSimHandler):
     def __init__(self, scenario: ScenarioCfg):
         super().__init__(scenario)
+        self._actions_cache: list[Action] = []
         self._robot: BaseRobotCfg = scenario.robot
         self._robot_names = {self._robot.name}
         self._robot_init_pose = (0, 0, 0) if not self.robot.default_position else self.robot.default_position
@@ -435,6 +436,16 @@ class IsaacgymHandler(BaseSimHandler):
                         for joint_name, global_idx in (self._joint_info[obj.name]["global_indices"]).items()
                     }
 
+                ## Actions -- for robot
+                if isinstance(obj, BaseRobotCfg):
+                    if self.actions_cache:
+                        obj_state["dof_pos_target"] = {
+                            joint_name: self.actions_cache[env_id]["dof_pos_target"][joint_name]
+                            for joint_name in self._joint_info[obj.name]["names"]
+                        }
+                    else:
+                        obj_state["dof_pos_target"] = None
+
                 ## Actuator states -- for robot
                 ## XXX: Could non-robot objects have actuators?
                 if isinstance(obj, BaseRobotCfg):
@@ -585,6 +596,7 @@ class IsaacgymHandler(BaseSimHandler):
         return action_array_all
 
     def set_dof_targets(self, obj_name: str, actions: list[Action]):
+        self._actions_cache = actions
         action_input = torch.zeros_like(self._dof_states[:, 0].clone())
         action_array_all = self._get_action_array_all(actions)
         robot_dim = action_array_all.shape[1]
@@ -811,6 +823,10 @@ class IsaacgymHandler(BaseSimHandler):
     @property
     def num_envs(self) -> int:
         return self._num_envs
+
+    @property
+    def actions_cache(self) -> list[Action]:
+        return self._actions_cache
 
 
 # TODO: try to align handler API and use GymWrapper instead

--- a/metasim/sim/isaaclab/env_overwriter.py
+++ b/metasim/sim/isaaclab/env_overwriter.py
@@ -385,7 +385,7 @@ class IsaaclabEnvOverwriter:
             joint_qpos_target = env.actions.cpu()
             joint_qpos = env.robot.data.joint_pos.cpu()
             robot_root_state = env.robot.data.root_state_w.cpu()
-            robot_body_state = env.robot.data.body_state_w.cpu()
+            robot_body_state = env.robot.data.body_link_state_w.cpu()
             robot_root_state[..., 0:3] -= env.scene.env_origins.cpu()
             robot_body_state[..., 0:3] -= env.scene.env_origins.cpu().unsqueeze(1)
             if self.robot.ee_prim_path is not None:

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -268,6 +268,7 @@ class MujocoHandler(BaseSimHandler):
             state[object_type][obj.name].update(self._get_joint_states(obj.name))
             ## Actuator states -- for robot
             if obj == self._robot:
+                ## TODO: read from simulator instead of cache
                 state[object_type][obj.name].update(self._get_actuator_states(obj.name))
                 joint_names = [
                     self.physics.model.joint(joint_id).name.split("/")[-1]

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -449,8 +449,8 @@ class MujocoHandler(BaseSimHandler):
                 actuator.ctrl = target_pos
 
     def refresh_render(self) -> None:
+        self.physics.forward()  # Recomputes the forward dynamics without advancing the simulation.
         if self.viewer is not None:
-            self.physics.forward()
             self.viewer.sync()
 
     def simulate(self):

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -17,6 +17,7 @@ from metasim.types import Action, Obs
 class MujocoHandler(BaseSimHandler):
     def __init__(self, scenario: ScenarioCfg):
         super().__init__(scenario)
+        self._actions_cache: list[Action] = []
 
         if scenario.num_envs > 1:
             raise ValueError("MujocoHandler only supports single envs, please run with --num_envs 1.")
@@ -268,6 +269,17 @@ class MujocoHandler(BaseSimHandler):
             ## Actuator states -- for robot
             if obj == self._robot:
                 state[object_type][obj.name].update(self._get_actuator_states(obj.name))
+                joint_names = [
+                    self.physics.model.joint(joint_id).name.split("/")[-1]
+                    for joint_id in range(self.physics.model.njnt)
+                    if self.physics.model.joint(joint_id).name.startswith(self._mujoco_robot_name)
+                ]
+                if self.actions_cache:
+                    state[object_type][obj.name]["dof_pos_target"] = {
+                        joint_name: self.actions_cache[0]["dof_pos_target"][joint_name] for joint_name in joint_names
+                    }
+                else:
+                    state[object_type][obj.name]["dof_pos_target"] = None
 
         ## Body states -- for both robot and object
         object_names = [obj.name for obj in self.objects]
@@ -423,6 +435,7 @@ class MujocoHandler(BaseSimHandler):
             self.physics.data.xfrc_applied[body_id, 3:6] = 0
 
     def set_dof_targets(self, obj_name: str, actions: list[Action]) -> None:
+        self._actions_cache = actions
         joint_targets = actions[0]["dof_pos_target"]
 
         if self.replay_traj:
@@ -473,6 +486,10 @@ class MujocoHandler(BaseSimHandler):
     @property
     def episode_length_buf(self) -> list[int]:
         return [self._episode_length_buf]
+
+    @property
+    def actions_cache(self) -> list[Action]:
+        return self._actions_cache
 
 
 MujocoEnv: type[EnvWrapper[MujocoHandler]] = GymEnvWrapper(MujocoHandler)

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -257,6 +257,11 @@ class SinglePybulletHandler(BaseSimHandler):
 
         # return None, None, np.zeros(1), np.zeros(1), np.zeros(1)
 
+    def refresh_render(self):
+        """Refresh the render."""
+        # XXX: This implementation is not correct, but just work for compatibility
+        p.stepSimulation()
+
     def launch(self) -> None:
         """Launch the simulation."""
         self._build_pybullet()

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -260,6 +260,7 @@ class SinglePybulletHandler(BaseSimHandler):
     def refresh_render(self):
         """Refresh the render."""
         # XXX: This implementation is not correct, but just work for compatibility
+        # calvin also use this to refresh the render, seems no better way?
         p.stepSimulation()
 
     def launch(self) -> None:

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -231,7 +231,7 @@ class SinglePybulletHandler(BaseSimHandler):
             object, range(action.shape[0]), controlMode=p.POSITION_CONTROL, targetPositions=action
         )
 
-    def set_dof_targets(self, obj_name, target):
+    def set_dof_targets(self, obj_name, actions: list[Action]):
         """Set the target joint positions for the object.
 
         Args:
@@ -239,9 +239,9 @@ class SinglePybulletHandler(BaseSimHandler):
             target: The target joint positions
         """
         # For multi-env version, rewrite this function
-
-        action = target[0]
-        action_arr = np.array([action["dof_pos_target"][name] for name in self.object_joint_order[self.robot.name]])
+        self._actions_cache = actions
+        action = actions[0]
+        action_arr = np.array([action["dof_pos_target"][name] for name in self.object_joint_order[obj_name]])
         self._apply_action(action_arr, self.object_ids[obj_name])
 
     def simulate(self):

--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -317,6 +317,14 @@ class SingleSapienHandler(BaseSimHandler):
         for camera_name, camera_id in self.camera_ids.items():
             camera_id.take_picture()
 
+    def refresh_render(self):
+        """Refresh the render."""
+        self.scene.update_render()
+        if not self.headless:
+            self.viewer.render()
+        for camera_name, camera_id in self.camera_ids.items():
+            camera_id.take_picture()
+
     def launch(self) -> None:
         """Launch the simulation."""
         self._build_sapien()

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -27,7 +27,7 @@ from metasim.cfg.objects import (
 from metasim.cfg.robots import BaseRobotCfg
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.sim.parallel import ParallelSimWrapper
-from metasim.types import EnvState, Obs
+from metasim.types import Action, EnvState, Obs
 from metasim.utils.math import quat_from_euler_np
 
 
@@ -46,6 +46,7 @@ class SingleSapien3Handler(BaseSimHandler):
         log.warning("Sapien3 is still under development, some metasim apis yet don't have sapien3 support")
         super().__init__(scenario)
         self.headless = False  # XXX: no headless anyway
+        self._actions_cache: list[Action] = []
 
     def _build_sapien(self):
         self.engine = sapien_core.Engine()  # Create a physical simulation engine
@@ -321,17 +322,18 @@ class SingleSapien3Handler(BaseSimHandler):
             joint.set_drive_target(action[i])
         # instance.set_drive_target(action)
 
-    def set_dof_targets(self, obj_name, target):
+    def set_dof_targets(self, obj_name, actions: list[Action]):
         """Set the dof targets of the object.
 
         Args:
             obj_name (str): The name of the object
             target (dict): The target values for the object
         """
+        self._actions_cache = actions
         instance = self.object_ids[obj_name]
         if isinstance(instance, sapien_core.physx.PhysxArticulation):
-            action = target[0]
-            action_arr = np.array([action["dof_pos_target"][name] for name in self.object_joint_order[self.robot.name]])
+            action = actions[0]
+            action_arr = np.array([action["dof_pos_target"][name] for name in self.object_joint_order[obj_name]])
             self._apply_action(action_arr, instance)
 
     def simulate(self):
@@ -373,6 +375,17 @@ class SingleSapien3Handler(BaseSimHandler):
                 states[object_type][obj_name]["dof_pos"] = {
                     name: dof_pos[id] for id, name in enumerate(self.object_joint_order[obj_name])
                 }
+            if obj_name == self.robot.name:
+                ## TODO: read from simulator instead of cache
+                if self.actions_cache:
+                    states[object_type][obj_name]["dof_pos_target"] = {
+                        name: self.actions_cache[0]["dof_pos_target"][name]
+                        for name in self.object_joint_order[obj_name]
+                    }
+                else:
+                    states[object_type][obj_name]["dof_pos_target"] = None
+            else:
+                states[object_type][obj_name]["dof_pos_target"] = None
             pose = obj_id.get_pose()
             states[object_type][obj_name].update({
                 "pos": torch.tensor(pose.p),
@@ -421,6 +434,10 @@ class SingleSapien3Handler(BaseSimHandler):
 
             # Reset base position and orientation
             obj_id.set_pose(sapien_core.Pose(p=val["pos"], q=val["rot"]))
+
+    @property
+    def actions_cache(self) -> list[Action]:
+        return self._actions_cache
 
 
 Sapien3Handler = ParallelSimWrapper(SingleSapien3Handler)

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -402,6 +402,14 @@ class SingleSapien3Handler(BaseSimHandler):
 
         return [states]
 
+    def refresh_render(self):
+        """Refresh the render."""
+        self.scene.update_render()
+        if not self.headless:
+            self.viewer.render()
+        for camera_name, camera_id in self.camera_ids.items():
+            camera_id.take_picture()
+
     def get_observation(self) -> Obs:
         """Get observation for compatibility with other simulators."""
         ## TODO: only support single env for now

--- a/metasim/types.py
+++ b/metasim/types.py
@@ -47,14 +47,7 @@ class EnvState(TypedDict):
 
 
 ## Gymnasium types
-class Obs(TypedDict):
-    """Observation of the environment."""
-
-    rgb: torch.Tensor
-    depth: torch.Tensor
-    states: list[EnvState]
-
-
+Obs = List[EnvState]
 Reward = List[List[float]]  # TODO: you may modify this if necessary
 Success = torch.BoolTensor
 TimeOut = torch.BoolTensor

--- a/metasim/utils/save_util/save_util.py
+++ b/metasim/utils/save_util/save_util.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import torch
 
 from .save_util_v1 import is_v1_demo, save_demo_v1
+from .save_util_v2 import is_v2_demo, save_demo_v2
 
 
 def save_demo(save_dir: str, demo: list[dict[str, torch.Tensor]]):
@@ -16,5 +17,7 @@ def save_demo(save_dir: str, demo: list[dict[str, torch.Tensor]]):
     """
     if is_v1_demo(demo):
         save_demo_v1(save_dir, demo)
+    elif is_v2_demo(demo):
+        save_demo_v2(save_dir, demo)
     else:
-        raise ValueError(f"Unknown demo format: {demo}")
+        raise ValueError("Unknown demo format")

--- a/metasim/utils/save_util/save_util_v2.py
+++ b/metasim/utils/save_util/save_util_v2.py
@@ -1,0 +1,139 @@
+"""Sub-module containing utilities for saving data."""
+
+from __future__ import annotations
+
+import json
+import os
+import pickle as pkl
+
+import imageio as iio
+import numpy as np
+import torch
+
+from metasim.types import EnvState
+from metasim.utils.io_util import write_16bit_depth_video
+
+
+def _normalize_depth(depth: np.ndarray) -> np.ndarray:
+    return (depth - depth.min()) / (depth.max() - depth.min())
+
+
+def is_v2_demo(demo: list[EnvState]) -> bool:
+    """Check if the demo is in the v2 format. Demo should be v3 state format."""
+    return "robots" in demo[0]
+
+
+def save_demo_v2(save_dir: str, demo: list[EnvState]):
+    """Save a demo to a directory.
+
+    Args:
+        save_dir: The directory to save the demo.
+        demo: The demo to save.
+    """
+    os.makedirs(save_dir, exist_ok=True)
+
+    # Get the main robot name (assuming first robot in first state)
+    robot_name = next(iter(demo[0]["robots"].keys()))
+    # Get the main camera name (assuming first camera in first state)
+    camera_name = next(iter(demo[0]["cameras"].keys()))
+
+    # Convert and prepare data for saving
+    rgbs = []
+    depths = []
+    jsondata = {
+        "depth_min": [],
+        "depth_max": [],
+        "cam_pos": [],
+        "cam_look_at": [],
+        "cam_intr": [],
+        "cam_extr": [],
+        "joint_qpos_target": [],
+        "joint_qpos": [],
+        "robot_ee_state": [],
+        "robot_ee_state_target": [],
+        "robot_root_state": [],
+        "robot_body_state": [],
+    }
+
+    # Process each timestep
+    for i, state in enumerate(demo):
+        # Extract robot state
+        robot_state = state["robots"][robot_name]
+        camera_state = state["cameras"][camera_name]
+
+        # Extract vision data
+        if "rgb" in camera_state:
+            rgb = camera_state["rgb"].cpu().numpy()
+            rgbs.append(rgb)
+
+        if "depth" in camera_state:
+            depth = camera_state["depth"].cpu().numpy()
+            depths.append(_normalize_depth(depth))
+            jsondata["depth_min"].append(depth.min().item())
+            jsondata["depth_max"].append(depth.max().item())
+
+        # Extract camera data
+        jsondata["cam_pos"].append(camera_state["cam_pos"].tolist() if "cam_pos" in camera_state else [])
+        jsondata["cam_look_at"].append(camera_state["cam_look_at"].tolist() if "cam_look_at" in camera_state else [])
+        jsondata["cam_intr"].append(camera_state["cam_intr"].tolist() if "cam_intr" in camera_state else [])
+        jsondata["cam_extr"].append(camera_state["cam_extr"].tolist() if "cam_extr" in camera_state else [])
+
+        # Extract robot data
+        jsondata["joint_qpos"].append([robot_state["dof_pos"][k] for k in sorted(robot_state["dof_pos"].keys())])
+
+        # For targets, handle them in the same way as the original function
+        if i < len(demo) - 1:
+            next_robot_state = demo[i + 1]["robots"][robot_name]
+            target_dof_pos = [
+                next_robot_state["dof_pos_target"][k] for k in sorted(next_robot_state["dof_pos_target"].keys())
+            ]
+        else:
+            # For the last timestep, use the same target as the current state
+            target_dof_pos = [robot_state["dof_pos_target"][k] for k in sorted(robot_state["dof_pos_target"].keys())]
+
+        jsondata["joint_qpos_target"].append(target_dof_pos)
+
+        # Extract EE state (position, rotation, last joint)
+        # Assuming ee_state is available in the state
+        ee_pos = robot_state["pos"]
+        ee_rot = robot_state["rot"]
+        last_joint_pos = robot_state["dof_pos"][sorted(robot_state["dof_pos"].keys())[-1]]
+        robot_ee_state = torch.cat([ee_pos, ee_rot, torch.tensor([last_joint_pos])]).tolist()
+        jsondata["robot_ee_state"].append(robot_ee_state)
+
+        # Set robot_ee_state_target
+        if i < len(demo) - 1:
+            next_robot_state = demo[i + 1]["robots"][robot_name]
+            next_ee_pos = next_robot_state["pos"]
+            next_ee_rot = next_robot_state["rot"]
+            next_last_joint_pos = next_robot_state["dof_pos"][sorted(next_robot_state["dof_pos"].keys())[-1]]
+            next_robot_ee_state = torch.cat([next_ee_pos, next_ee_rot, torch.tensor([next_last_joint_pos])]).tolist()
+            jsondata["robot_ee_state_target"].append(next_robot_ee_state)
+        else:
+            jsondata["robot_ee_state_target"].append(robot_ee_state)
+
+        # Extract root and body state
+        jsondata["robot_root_state"].append(
+            torch.cat([robot_state["pos"], robot_state["rot"], robot_state["vel"], robot_state["ang_vel"]]).tolist()
+        )
+
+    # Save video files
+    if rgbs:
+        iio.mimsave(os.path.join(save_dir, "rgb.mp4"), rgbs, fps=30, quality=10)
+
+    if depths:
+        write_16bit_depth_video(os.path.join(save_dir, "depth_uint16.mkv"), depths, fps=30)
+        iio.mimsave(
+            os.path.join(save_dir, "depth_uint8.mp4"),
+            [(depth * 255).astype(np.uint8) for depth in depths],
+            fps=30,
+            quality=10,
+        )
+
+    # Save metadata
+    json.dump(jsondata, open(os.path.join(save_dir, "metadata.json"), "w"))
+    pkl.dump(jsondata, open(os.path.join(save_dir, "metadata.pkl"), "wb"))
+
+    # Mark as finished
+    with open(os.path.join(save_dir, "status.txt"), "w+") as f:
+        f.write("success")


### PR DESCRIPTION
1. use states as observation

    -   change replay_demo, collect_demo and random_action to fit with 1
    -   change hybrid sim to fit with 1
    -   change obs type to fit with 1
    -   change dashboard script to fit with 1
    -   change get_started scripts to fit with 1

2. dashboard run_test now has same conda env name convention as dockerfile
3. isaaclab, mujoco, isaacgym, sapien3, pybullet, genesis: get_states also return robots' `dof_pos_target`, temporarily implemented using cache
4. sapien2, sapien3, genesis, pybullet: implement `refresh_render` method
5. get_started example test passed (genesis + 2 is buggy, but seems not my blame)
6. gitignore: ignore *.convex.stl