### PR TITLE
[docs/fix] Add clone project to installation.rst

### DIFF
--- a/docs/source/metasim/get_started/installation.rst
+++ b/docs/source/metasim/get_started/installation.rst
@@ -1,6 +1,13 @@
 Direct Installation
 ===================
 
+First, clone the RoboVerse project:
+
+.. code-block:: bash
+
+    git clone git@github.com:RoboVerseOrg/RoboVerse.git
+    cd RoboVerse
+
 MetaSim uses `uv <https://docs.astral.sh/uv/>`_ to manage dependencies.
 
 To install ``uv``, please refer to the `official guide <https://docs.astral.sh/uv/getting-started/installation/>`_, or run:


### PR DESCRIPTION
I wonder if cloning project is missing from installation in docs. That made `uv pip install -e ".[<simulator>]"` below a little confusing.