### PR TITLE
fix joint name extraction error in mujoco.py

### DIFF
--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -274,6 +274,7 @@ class MujocoHandler(BaseSimHandler):
                     self.physics.model.joint(joint_id).name.split("/")[-1]
                     for joint_id in range(self.physics.model.njnt)
                     if self.physics.model.joint(joint_id).name.startswith(self._mujoco_robot_name)
+                    and len(self.physics.model.joint(joint_id).name.split("/")[-1]) > 0
                 ]
                 if self.actions_cache:
                     state[object_type][obj.name]["dof_pos_target"] = {


### PR DESCRIPTION
running command:
`python roboverse_learn/humanoidbench_rl/train_sb3.py --sim mujoco --num_envs 1 --robot=h1 --task humanoidbench:Stand`
error:
```
  File "/home/panwei/RoboVerse/roboverse_learn/humanoidbench_rl/wrapper_sb3.py", line 
147, in step_wait
    _, _, terminated_tensor, truncated_tensor, _ = self.env.step(action_dict)
  File "/home/panwei/RoboVerse/metasim/sim/env_wrapper.py", line 88, in step
    success = self.handler.checker.check(self.handler)
  File "/home/panwei/RoboVerse/metasim/cfg/checkers/checkers.py", line 374, in check
    states = handler.get_states()
  File "/home/panwei/RoboVerse/metasim/sim/mujoco/mujoco.py", line 279, in get_states
    state[object_type][obj.name]["dof_pos_target"] = {
  File "/home/panwei/RoboVerse/metasim/sim/mujoco/mujoco.py", line 280, in <dictcomp>
    joint_name: self.actions_cache[0]["dof_pos_target"][joint_name] for joint_name in 
joint_names
KeyError: ''
```

In my case, the error occurs because when creating scene in MuJoCo, adding `freejoint`(in file `metasim/sim/mujoco/mujoco.py`) introduces an another joint name `h1/` besides the 19 joints defined in `h1.xml` This can be fixed by adding length check to filter out empty strings during joint name extraction.