### PR TITLE
Tensorize states

### DIFF
--- a/get_started/0_static_scene.py
+++ b/get_started/0_static_scene.py
@@ -142,6 +142,6 @@ init_states = [
 ]
 obs, extras = env.reset(states=init_states)
 os.makedirs("get_started/output", exist_ok=True)
-imageio.imwrite(
-    f"get_started/output/0_static_scene_{args.sim}.png", next(iter(obs[0]["cameras"].values()))["rgb"].cpu().numpy()
-)
+save_path = f"get_started/output/0_static_scene_{args.sim}.png"
+log.info(f"Saving image to {save_path}")
+imageio.imwrite(save_path, next(iter(obs.cameras.values())).rgb[0].cpu().numpy())

--- a/get_started/4_motion_planning.py
+++ b/get_started/4_motion_planning.py
@@ -163,8 +163,7 @@ robot_joint_limits = scenario.robot.joint_limits
 for step in range(200):
     log.debug(f"Step {step}")
     states = env.handler.get_states()
-    robot_states = [next(iter(s["robots"].values())) for s in states]
-    curr_robot_q = torch.tensor([[s["dof_pos"][jn] for jn in robot.actuators.keys()] for s in robot_states]).cuda()
+    curr_robot_q = states.robots[robot.name].joint_pos.cuda()
 
     seed_config = curr_robot_q[:, :curobo_n_dof].unsqueeze(1).tile([1, robot_ik._num_seeds, 1])
     x_target = 0.3 + 0.1 * (step / 100)

--- a/get_started/6_advanced_rendering.py
+++ b/get_started/6_advanced_rendering.py
@@ -145,7 +145,6 @@ init_states = [
 ]
 obs, extras = env.reset(states=init_states)
 os.makedirs("get_started/output", exist_ok=True)
-imageio.imwrite(
-    f"get_started/output/6_advanced_rendering_{args.sim}_{args.render.mode}.png",
-    next(iter(obs[0]["cameras"].values()))["rgb"].cpu().numpy(),
-)
+save_path = f"get_started/output/6_advanced_rendering_{args.sim}_{args.render.mode}.png"
+log.info(f"Saving image to {save_path}")
+imageio.imwrite(save_path, next(iter(obs.cameras.values())).rgb[0].cpu().numpy())

--- a/metasim/cfg/checkers/checkers.py
+++ b/metasim/cfg/checkers/checkers.py
@@ -9,7 +9,7 @@ from loguru import logger as log
 from metasim.cfg.objects import BaseObjCfg
 from metasim.utils.configclass import configclass
 from metasim.utils.math import euler_xyz_from_quat, matrix_from_quat, quat_from_matrix
-from metasim.utils.state import tensor_state_to_env_states
+from metasim.utils.state import state_tensor_to_nested
 from metasim.utils.tensor_util import tensor_to_str
 
 from .base_checker import BaseChecker
@@ -373,7 +373,7 @@ class WalkChecker(BaseChecker):
         from metasim.utils.humanoid_robot_util import robot_position
 
         states = handler.get_states()
-        states = tensor_state_to_env_states(handler, states)
+        states = state_tensor_to_nested(handler, states)
         terminated = []
         for state in states:
             if robot_position(state, handler.robot.name)[2] < 0.2:

--- a/metasim/cfg/checkers/checkers.py
+++ b/metasim/cfg/checkers/checkers.py
@@ -9,6 +9,7 @@ from loguru import logger as log
 from metasim.cfg.objects import BaseObjCfg
 from metasim.utils.configclass import configclass
 from metasim.utils.math import euler_xyz_from_quat, matrix_from_quat, quat_from_matrix
+from metasim.utils.state import tensor_state_to_env_states
 from metasim.utils.tensor_util import tensor_to_str
 
 from .base_checker import BaseChecker
@@ -372,6 +373,7 @@ class WalkChecker(BaseChecker):
         from metasim.utils.humanoid_robot_util import robot_position
 
         states = handler.get_states()
+        states = tensor_state_to_env_states(handler, states)
         terminated = []
         for state in states:
             if robot_position(state, handler.robot.name)[2] < 0.2:

--- a/metasim/cfg/checkers/detectors.py
+++ b/metasim/cfg/checkers/detectors.py
@@ -54,11 +54,13 @@ class RelativeBboxDetector(BaseDetector):
         if env_ids is None:
             env_ids = list(range(handler.num_envs))
 
-        relative_rot_mat = matrix_from_quat(torch.tensor(self.relative_quat, dtype=torch.float32))  # [3, 3]
-        relative_pos = torch.tensor(self.relative_pos, dtype=torch.float32)  # [3]
+        relative_rot_mat = matrix_from_quat(
+            torch.tensor(self.relative_quat, dtype=torch.float32, device=handler.device)
+        )  # [3, 3]
+        relative_pos = torch.tensor(self.relative_pos, dtype=torch.float32, device=handler.device)  # [3]
         base_pos = handler.get_pos(self.base_obj_name, env_ids=env_ids)
         if self.ignore_base_ori:
-            base_quat = torch.zeros((len(env_ids), 4), dtype=torch.float32)
+            base_quat = torch.zeros((len(env_ids), 4), dtype=torch.float32, device=handler.device)
             base_quat[:, 0] = 1.0
         else:
             base_quat = handler.get_rot(self.base_obj_name, env_ids=env_ids)
@@ -67,11 +69,11 @@ class RelativeBboxDetector(BaseDetector):
         checker_rot_mat = torch.matmul(base_rot_mat, relative_rot_mat)  # [n_env, 3, 3]
 
         if not hasattr(self, "checker_pos"):
-            self.checker_pos = torch.zeros((handler.num_envs, 3), dtype=torch.float32)
+            self.checker_pos = torch.zeros((handler.num_envs, 3), dtype=torch.float32, device=handler.device)
         if not hasattr(self, "checker_rot_mat"):
-            self.checker_rot_mat = torch.zeros((handler.num_envs, 3, 3), dtype=torch.float32)
+            self.checker_rot_mat = torch.zeros((handler.num_envs, 3, 3), dtype=torch.float32, device=handler.device)
         if not hasattr(self, "checker_quat"):
-            self.checker_quat = torch.zeros((handler.num_envs, 4), dtype=torch.float32)
+            self.checker_quat = torch.zeros((handler.num_envs, 4), dtype=torch.float32, device=handler.device)
 
         self.checker_pos[env_ids] = checker_pos
         self.checker_rot_mat[env_ids] = checker_rot_mat
@@ -82,8 +84,8 @@ class RelativeBboxDetector(BaseDetector):
             env_ids = list(range(handler.num_envs))
         self._update_checker(handler, env_ids)
 
-        self.checker_lower = torch.tensor(self.checker_lower, dtype=torch.float32)
-        self.checker_upper = torch.tensor(self.checker_upper, dtype=torch.float32)
+        self.checker_lower = torch.tensor(self.checker_lower, dtype=torch.float32, device=handler.device)
+        self.checker_upper = torch.tensor(self.checker_upper, dtype=torch.float32, device=handler.device)
 
         ## Reset debug viewer
         self.reset_debug_viewer(handler, env_ids)

--- a/metasim/data/quick_start/robots/franka/mjcf/panda.xml
+++ b/metasim/data/quick_start/robots/franka/mjcf/panda.xml
@@ -117,7 +117,7 @@
 
   <worldbody>
     <light name="top" pos="0 0 2" mode="trackcom"/>
-    <body name="link0" childclass="panda">
+    <body name="panda_link0" childclass="panda">
       <inertial mass="0.629769" pos="-0.041018 -0.00014 0.049974"
         fullinertia="0.00315 0.00388 0.004285 8.2904e-7 0.00015 8.2299e-6"/>
       <geom mesh="link0_0" material="off_white" class="visual"/>
@@ -132,19 +132,19 @@
       <geom mesh="link0_10" material="off_white" class="visual"/>
       <geom mesh="link0_11" material="white" class="visual"/>
       <geom mesh="link0_c" class="collision"/>
-      <body name="link1" pos="0 0 0.333">
+      <body name="panda_link1" pos="0 0 0.333">
         <inertial mass="4.970684" pos="0.003875 0.002081 -0.04762"
           fullinertia="0.70337 0.70661 0.0091170 -0.00013900 0.0067720 0.019169"/>
         <joint name="panda_joint1"/>
         <geom material="white" mesh="link1" class="visual"/>
         <geom mesh="link1_c" class="collision"/>
-        <body name="link2" quat="1 -1 0 0">
+        <body name="panda_link2" quat="1 -1 0 0">
           <inertial mass="0.646926" pos="-0.003141 -0.02872 0.003495"
             fullinertia="0.0079620 2.8110e-2 2.5995e-2 -3.925e-3 1.0254e-2 7.04e-4"/>
           <joint name="panda_joint2" range="-1.7628 1.7628"/>
           <geom material="white" mesh="link2" class="visual"/>
           <geom mesh="link2_c" class="collision"/>
-          <body name="link3" pos="0 -0.316 0" quat="1 1 0 0">
+          <body name="panda_link3" pos="0 -0.316 0" quat="1 1 0 0">
             <joint name="panda_joint3"/>
             <inertial mass="3.228604" pos="2.7518e-2 3.9252e-2 -6.6502e-2"
               fullinertia="3.7242e-2 3.6155e-2 1.083e-2 -4.761e-3 -1.1396e-2 -1.2805e-2"/>
@@ -153,7 +153,7 @@
             <geom mesh="link3_2" material="white" class="visual"/>
             <geom mesh="link3_3" material="black" class="visual"/>
             <geom mesh="link3_c" class="collision"/>
-            <body name="link4" pos="0.0825 0 0" quat="1 1 0 0">
+            <body name="panda_link4" pos="0.0825 0 0" quat="1 1 0 0">
               <inertial mass="3.587895" pos="-5.317e-2 1.04419e-1 2.7454e-2"
                 fullinertia="2.5853e-2 1.9552e-2 2.8323e-2 7.796e-3 -1.332e-3 8.641e-3"/>
               <joint name="panda_joint4" range="-3.0718 -0.0698"/>
@@ -162,7 +162,7 @@
               <geom mesh="link4_2" material="black" class="visual"/>
               <geom mesh="link4_3" material="white" class="visual"/>
               <geom mesh="link4_c" class="collision"/>
-              <body name="link5" pos="-0.0825 0.384 0" quat="1 -1 0 0">
+              <body name="panda_link5" pos="-0.0825 0.384 0" quat="1 -1 0 0">
                 <inertial mass="1.225946" pos="-1.1953e-2 4.1065e-2 -3.8437e-2"
                   fullinertia="3.5549e-2 2.9474e-2 8.627e-3 -2.117e-3 -4.037e-3 2.29e-4"/>
                 <joint name="panda_joint5"/>
@@ -172,7 +172,7 @@
                 <geom mesh="link5_c0" class="collision"/>
                 <geom mesh="link5_c1" class="collision"/>
                 <geom mesh="link5_c2" class="collision"/>
-                <body name="link6" quat="1 1 0 0">
+                <body name="panda_link6" quat="1 1 0 0">
                   <inertial mass="1.666555" pos="6.0149e-2 -1.4117e-2 -1.0517e-2"
                     fullinertia="1.964e-3 4.354e-3 5.433e-3 1.09e-4 -1.158e-3 3.41e-4"/>
                   <joint name="panda_joint6" range="-0.0175 3.7525"/>
@@ -194,7 +194,7 @@
                   <geom mesh="link6_15" material="black" class="visual"/>
                   <geom mesh="link6_16" material="white" class="visual"/>
                   <geom mesh="link6_c" class="collision"/>
-                  <body name="link7" pos="0.088 0 0" quat="1 1 0 0">
+                  <body name="panda_link7" pos="0.088 0 0" quat="1 1 0 0">
                     <inertial mass="7.35522e-01" pos="1.0517e-2 -4.252e-3 6.1597e-2"
                       fullinertia="1.2516e-2 1.0027e-2 4.815e-3 -4.28e-4 -1.196e-3 -7.41e-4"/>
                     <joint name="panda_joint7"/>
@@ -207,7 +207,7 @@
                     <geom mesh="link7_6" material="black" class="visual"/>
                     <geom mesh="link7_7" material="white" class="visual"/>
                     <geom mesh="link7_c" class="collision"/>
-                    <body name="hand" pos="0 0 0.107" quat="0.9238795 0 0 -0.3826834">
+                    <body name="panda_hand" pos="0 0 0.107" quat="0.9238795 0 0 -0.3826834">
                       <inertial mass="0.73" pos="-0.01 0 0.03" diaginertia="0.001 0.0025 0.0017"/>
                       <geom mesh="hand_0" material="off_white" class="visual"/>
                       <geom mesh="hand_1" material="black" class="visual"/>
@@ -215,7 +215,7 @@
                       <geom mesh="hand_3" material="white" class="visual"/>
                       <geom mesh="hand_4" material="off_white" class="visual"/>
                       <geom mesh="hand_c" class="collision"/>
-                      <body name="left_finger" pos="0 0 0.0584">
+                      <body name="panda_leftfinger" pos="0 0 0.0584">
                         <inertial mass="0.015" pos="0 0 0" diaginertia="2.375e-6 2.375e-6 7.5e-7"/>
                         <joint name="panda_finger_joint1" class="finger"/>
                         <geom mesh="finger_0" material="off_white" class="visual"/>
@@ -227,7 +227,7 @@
                         <geom class="fingertip_pad_collision_4"/>
                         <geom class="fingertip_pad_collision_5"/>
                       </body>
-                      <body name="right_finger" pos="0 0 0.0584" quat="0 0 0 1">
+                      <body name="panda_rightfinger" pos="0 0 0.0584" quat="0 0 0 1">
                         <inertial mass="0.015" pos="0 0 0" diaginertia="2.375e-6 2.375e-6 7.5e-7"/>
                         <joint name="panda_finger_joint2" class="finger"/>
                         <geom mesh="finger_0" material="off_white" class="visual"/>

--- a/metasim/scripts/collect_demo.py
+++ b/metasim/scripts/collect_demo.py
@@ -112,6 +112,7 @@ from metasim.constants import SimType
 from metasim.sim import BaseSimHandler, EnvWrapper
 from metasim.utils.demo_util import get_traj
 from metasim.utils.setup_util import get_robot, get_sim_env_class, get_task
+from metasim.utils.state import tensor_state_to_env_states
 from metasim.utils.tensor_util import tensor_to_cpu
 
 
@@ -371,6 +372,7 @@ def main():
 
     ## Reset before first step
     obs, extras = env.reset(states=[init_states[demo_idx] for demo_idx in demo_idxs])
+    obs = tensor_state_to_env_states(env.handler, obs)
 
     ## Initialize
     for env_id, demo_idx in enumerate(demo_idxs):
@@ -381,6 +383,7 @@ def main():
         pbar.set_description(f"Frame {global_step} Success {tot_success} Giveup {tot_give_up}")
         actions = get_actions(all_actions, env, demo_idxs)
         obs, reward, success, time_out, extras = env.step(actions)
+        obs = tensor_state_to_env_states(env.handler, obs)
         run_out = get_run_out(all_actions, env, demo_idxs)
 
         for env_id in range(env.handler.num_envs):
@@ -415,6 +418,7 @@ def main():
                     ## NextDemo --> CollectingDemo
                     demo_idxs[env_id] = demo_indexer.next_idx
                     obs, _ = env.reset(states=[init_states[demo_idx] for demo_idx in demo_idxs], env_ids=[env_id])
+                    obs = tensor_state_to_env_states(env.handler, obs)
                     collector.create(demo_indexer.next_idx, obs[env_id])
                     demo_indexer.move_on()
                     run_out[env_id] = False
@@ -437,6 +441,7 @@ def main():
                 ## Timeout --> CollectingDemo
                 log.info(f"Demo {demo_idx} failed {failure_count[env_id]} times, retrying...")
                 obs, _ = env.reset(states=[init_states[demo_idx] for demo_idx in demo_idxs], env_ids=[env_id])
+                obs = tensor_state_to_env_states(env.handler, obs)
                 collector.create(demo_idx, obs[env_id])
             else:
                 ## Timeout --> NextDemo
@@ -450,6 +455,7 @@ def main():
                     ## NextDemo --> CollectingDemo
                     demo_idxs[env_id] = demo_indexer.next_idx
                     obs, _ = env.reset(states=[init_states[demo_idx] for demo_idx in demo_idxs], env_ids=[env_id])
+                    obs = tensor_state_to_env_states(env.handler, obs)
                     collector.create(demo_indexer.next_idx, obs[env_id])
                     demo_indexer.move_on()
                 else:

--- a/metasim/scripts/collect_demo.py
+++ b/metasim/scripts/collect_demo.py
@@ -112,7 +112,7 @@ from metasim.constants import SimType
 from metasim.sim import BaseSimHandler, EnvWrapper
 from metasim.utils.demo_util import get_traj
 from metasim.utils.setup_util import get_robot, get_sim_env_class, get_task
-from metasim.utils.state import tensor_state_to_env_states
+from metasim.utils.state import state_tensor_to_nested
 from metasim.utils.tensor_util import tensor_to_cpu
 
 
@@ -372,7 +372,7 @@ def main():
 
     ## Reset before first step
     obs, extras = env.reset(states=[init_states[demo_idx] for demo_idx in demo_idxs])
-    obs = tensor_state_to_env_states(env.handler, obs)
+    obs = state_tensor_to_nested(env.handler, obs)
 
     ## Initialize
     for env_id, demo_idx in enumerate(demo_idxs):
@@ -383,7 +383,7 @@ def main():
         pbar.set_description(f"Frame {global_step} Success {tot_success} Giveup {tot_give_up}")
         actions = get_actions(all_actions, env, demo_idxs)
         obs, reward, success, time_out, extras = env.step(actions)
-        obs = tensor_state_to_env_states(env.handler, obs)
+        obs = state_tensor_to_nested(env.handler, obs)
         run_out = get_run_out(all_actions, env, demo_idxs)
 
         for env_id in range(env.handler.num_envs):
@@ -418,7 +418,7 @@ def main():
                     ## NextDemo --> CollectingDemo
                     demo_idxs[env_id] = demo_indexer.next_idx
                     obs, _ = env.reset(states=[init_states[demo_idx] for demo_idx in demo_idxs], env_ids=[env_id])
-                    obs = tensor_state_to_env_states(env.handler, obs)
+                    obs = state_tensor_to_nested(env.handler, obs)
                     collector.create(demo_indexer.next_idx, obs[env_id])
                     demo_indexer.move_on()
                     run_out[env_id] = False
@@ -441,7 +441,7 @@ def main():
                 ## Timeout --> CollectingDemo
                 log.info(f"Demo {demo_idx} failed {failure_count[env_id]} times, retrying...")
                 obs, _ = env.reset(states=[init_states[demo_idx] for demo_idx in demo_idxs], env_ids=[env_id])
-                obs = tensor_state_to_env_states(env.handler, obs)
+                obs = state_tensor_to_nested(env.handler, obs)
                 collector.create(demo_idx, obs[env_id])
             else:
                 ## Timeout --> NextDemo
@@ -455,7 +455,7 @@ def main():
                     ## NextDemo --> CollectingDemo
                     demo_idxs[env_id] = demo_indexer.next_idx
                     obs, _ = env.reset(states=[init_states[demo_idx] for demo_idx in demo_idxs], env_ids=[env_id])
-                    obs = tensor_state_to_env_states(env.handler, obs)
+                    obs = state_tensor_to_nested(env.handler, obs)
                     collector.create(demo_indexer.next_idx, obs[env_id])
                     demo_indexer.move_on()
                 else:

--- a/metasim/scripts/replay_demo.py
+++ b/metasim/scripts/replay_demo.py
@@ -13,7 +13,6 @@ except ImportError:
 import imageio as iio
 import numpy as np
 import rootutils
-import torch
 import tyro
 from loguru import logger as log
 from numpy.typing import NDArray
@@ -31,10 +30,10 @@ from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg
 from metasim.constants import SimType
 from metasim.sim import HybridSimEnv
-from metasim.types import EnvState
 from metasim.utils import configclass
 from metasim.utils.demo_util import get_traj
 from metasim.utils.setup_util import get_sim_env_class
+from metasim.utils.state import TensorState
 
 
 @configclass
@@ -108,22 +107,12 @@ class ObsSaver:
 
         self.image_idx = 0
 
-    def add(self, states: list[EnvState]):
+    def add(self, state: TensorState):
         """Add the observation to the list."""
         if self.image_dir is None and self.video_path is None:
             return
 
-        rgb_data_list = []
-        for state in states:
-            for camera_name, camera_data in state["cameras"].items():
-                if "rgb" in camera_data:
-                    rgb_data_list.append(camera_data["rgb"])
-                    continue
-
-        if not rgb_data_list:
-            return
-
-        rgb_data = torch.stack(rgb_data_list, dim=0)
+        rgb_data = next(iter(state.cameras.values())).rgb
         image = make_grid(rgb_data.permute(0, 3, 1, 2) / 255, nrow=int(rgb_data.shape[0] ** 0.5))  # (C, H, W)
 
         if self.image_dir is not None:

--- a/metasim/scripts/replay_demo.py
+++ b/metasim/scripts/replay_demo.py
@@ -112,8 +112,12 @@ class ObsSaver:
         if self.image_dir is None and self.video_path is None:
             return
 
-        rgb_data = next(iter(state.cameras.values())).rgb
-        image = make_grid(rgb_data.permute(0, 3, 1, 2) / 255, nrow=int(rgb_data.shape[0] ** 0.5))  # (C, H, W)
+        try:
+            rgb_data = next(iter(state.cameras.values())).rgb
+            image = make_grid(rgb_data.permute(0, 3, 1, 2) / 255, nrow=int(rgb_data.shape[0] ** 0.5))  # (C, H, W)
+        except Exception as e:
+            log.error(f"Error adding observation: {e}")
+            return
 
         if self.image_dir is not None:
             os.makedirs(self.image_dir, exist_ok=True)

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -150,7 +150,7 @@ class BaseSimHandler:
     ## Misc
     ############################################################
     def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
-        """Get the joint names for a specified object in the order of the simulator default joint order.
+        """Get the joint names for a specified object in the order of the simulator default joint order. For same object, different simulator may have different joint order, but joint names are the same.
 
         Args:
             object (BaseObjCfg): The target object.
@@ -161,7 +161,7 @@ class BaseSimHandler:
         raise NotImplementedError
 
     def get_object_joint_reindex(self, obj_name: str) -> list[int]:
-        """Get the reindex of the joint names for a specified object. After reindexing, the joint order is alphabetical.
+        """Get the reindex of the joint names for a specified object. After reindexing, the joint order is alphabetical. For same object, different simulator may have different joint order, thus have different reindex.
 
         Args:
             obj_name (str): The name of the object.
@@ -180,8 +180,19 @@ class BaseSimHandler:
 
         return self._joint_reindex_cache[obj_name]
 
+    def get_object_body_names(self, obj_name: str) -> list[str]:
+        """Get the body names for a specified object in the order of the simulator default body order. For same object, different simulator may have different body order, but body names are the same.
+
+        Args:
+            obj_name (str): The name of the object.
+
+        Returns:
+            list[str]: A list of strings including the body names. For non-articulation objects, return an empty list.
+        """
+        raise NotImplementedError
+
     def get_body_reindex(self, obj_name: str) -> list[int]:
-        """Get the reindex of the body names for a specified object. After reindexing, the body order is alphabetical.
+        """Get the reindex of the body names for a specified object. After reindexing, the body order is alphabetical. For same object, different simulator may have different body order, thus have different reindex.
 
         Args:
             obj_name (str): The name of the object.

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -6,6 +6,7 @@ from loguru import logger as log
 from metasim.cfg.objects import BaseObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, TimeOut
+from metasim.utils.state import tensor_state_to_env_states
 
 
 class BaseSimHandler:
@@ -89,6 +90,7 @@ class BaseSimHandler:
             env_ids = list(range(self.num_envs))
 
         states = self.get_states(env_ids=env_ids)
+        states = tensor_state_to_env_states(self, states)
         return torch.stack([{**env_state["objects"], **env_state["robots"]}[obj_name]["vel"] for env_state in states])
 
     def get_pos(self, obj_name: str, env_ids: list[int] | None = None) -> torch.FloatTensor:
@@ -101,6 +103,7 @@ class BaseSimHandler:
             env_ids = list(range(self.num_envs))
 
         states = self.get_states(env_ids=env_ids)
+        states = tensor_state_to_env_states(self, states)
         return torch.stack([{**env_state["objects"], **env_state["robots"]}[obj_name]["pos"] for env_state in states])
 
     def get_rot(self, obj_name: str, env_ids: list[int] | None = None) -> torch.FloatTensor:
@@ -113,6 +116,7 @@ class BaseSimHandler:
             env_ids = list(range(self.num_envs))
 
         states = self.get_states(env_ids=env_ids)
+        states = tensor_state_to_env_states(self, states)
         return torch.stack([{**env_state["objects"], **env_state["robots"]}[obj_name]["rot"] for env_state in states])
 
     def get_dof_pos(self, obj_name: str, joint_name: str, env_ids: list[int] | None = None) -> torch.FloatTensor:
@@ -125,6 +129,7 @@ class BaseSimHandler:
             env_ids = list(range(self.num_envs))
 
         states = self.get_states(env_ids=env_ids)
+        states = tensor_state_to_env_states(self, states)
         return torch.tensor([
             {**env_state["objects"], **env_state["robots"]}[obj_name]["dof_pos"][joint_name] for env_state in states
         ])

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -160,7 +160,7 @@ class BaseSimHandler:
         """
         raise NotImplementedError
 
-    def get_object_joint_reindex(self, obj_name: str) -> list[int]:
+    def get_joint_reindex(self, obj_name: str) -> list[int]:
         """Get the reindex of the joint names for a specified object. After reindexing, the joint order is alphabetical. For same object, different simulator may have different joint order, thus have different reindex.
 
         Args:

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -180,6 +180,25 @@ class BaseSimHandler:
 
         return self._joint_reindex_cache[obj_name]
 
+    def get_body_reindex(self, obj_name: str) -> list[int]:
+        """Get the reindex of the body names for a specified object. After reindexing, the body order is alphabetical.
+
+        Args:
+            obj_name (str): The name of the object.
+
+        Returns:
+            list[int]: A list of integers including the reindex of the body names.
+        """
+        if not hasattr(self, "_body_reindex_cache"):
+            self._body_reindex_cache = {}
+
+        if obj_name not in self._body_reindex_cache:
+            origin_body_names = self.get_object_body_names(obj_name)
+            sorted_body_names = sorted(origin_body_names)
+            self._body_reindex_cache[obj_name] = [origin_body_names.index(bn) for bn in sorted_body_names]
+
+        return self._body_reindex_cache[obj_name]
+
     @property
     def num_envs(self) -> int:
         return self._num_envs

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -155,6 +155,26 @@ class BaseSimHandler:
         """
         raise NotImplementedError
 
+    def get_object_joint_reindex(self, obj_name: str) -> list[int]:
+        """Get the reindex of the joint names for a specified object. After reindexing, the joint order is alphabetical.
+
+        Args:
+            obj_name (str): The name of the object.
+
+        Returns:
+            list[int]: A list of integers including the reindex of the joint names.
+        """
+        if not hasattr(self, "_joint_reindex_cache"):
+            self._joint_reindex_cache = {}
+
+        if obj_name not in self._joint_reindex_cache:
+            obj_cfg = self.object_dict[obj_name]
+            origin_joint_names = self.get_object_joint_names(obj_cfg)
+            sorted_joint_names = sorted(origin_joint_names)
+            self._joint_reindex_cache[obj_name] = [origin_joint_names.index(jn) for jn in sorted_joint_names]
+
+        return self._joint_reindex_cache[obj_name]
+
     @property
     def num_envs(self) -> int:
         return self._num_envs

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -180,7 +180,7 @@ class BaseSimHandler:
 
         return self._joint_reindex_cache[obj_name]
 
-    def get_object_body_names(self, obj_name: str) -> list[str]:
+    def get_body_names(self, obj_name: str) -> list[str]:
         """Get the body names for a specified object in the order of the simulator default body order. For same object, different simulator may have different body order, but body names are the same.
 
         Args:
@@ -204,7 +204,7 @@ class BaseSimHandler:
             self._body_reindex_cache = {}
 
         if obj_name not in self._body_reindex_cache:
-            origin_body_names = self.get_object_body_names(obj_name)
+            origin_body_names = self.get_body_names(obj_name)
             sorted_body_names = sorted(origin_body_names)
             self._body_reindex_cache[obj_name] = [origin_body_names.index(bn) for bn in sorted_body_names]
 

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -6,7 +6,7 @@ from loguru import logger as log
 from metasim.cfg.objects import BaseObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, TimeOut
-from metasim.utils.state import tensor_state_to_env_states
+from metasim.utils.state import TensorState, tensor_state_to_env_states
 
 
 class BaseSimHandler:
@@ -42,7 +42,7 @@ class BaseSimHandler:
     def step(self, action: list[Action]) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
         raise NotImplementedError
 
-    def reset(self, env_ids: list[int] | None = None) -> tuple[Obs, Extra]:
+    def reset(self, env_ids: list[int] | None = None) -> tuple[TensorState, Extra]:
         """
         Reset the environment.
 

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -6,7 +6,7 @@ from loguru import logger as log
 from metasim.cfg.objects import BaseObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, TimeOut
-from metasim.utils.state import TensorState, tensor_state_to_env_states
+from metasim.utils.state import TensorState, state_tensor_to_nested
 
 
 class BaseSimHandler:
@@ -90,7 +90,7 @@ class BaseSimHandler:
             env_ids = list(range(self.num_envs))
 
         states = self.get_states(env_ids=env_ids)
-        states = tensor_state_to_env_states(self, states)
+        states = state_tensor_to_nested(self, states)
         return torch.stack([{**env_state["objects"], **env_state["robots"]}[obj_name]["vel"] for env_state in states])
 
     def get_pos(self, obj_name: str, env_ids: list[int] | None = None) -> torch.FloatTensor:
@@ -103,7 +103,7 @@ class BaseSimHandler:
             env_ids = list(range(self.num_envs))
 
         states = self.get_states(env_ids=env_ids)
-        states = tensor_state_to_env_states(self, states)
+        states = state_tensor_to_nested(self, states)
         return torch.stack([{**env_state["objects"], **env_state["robots"]}[obj_name]["pos"] for env_state in states])
 
     def get_rot(self, obj_name: str, env_ids: list[int] | None = None) -> torch.FloatTensor:
@@ -116,7 +116,7 @@ class BaseSimHandler:
             env_ids = list(range(self.num_envs))
 
         states = self.get_states(env_ids=env_ids)
-        states = tensor_state_to_env_states(self, states)
+        states = state_tensor_to_nested(self, states)
         return torch.stack([{**env_state["objects"], **env_state["robots"]}[obj_name]["rot"] for env_state in states])
 
     def get_dof_pos(self, obj_name: str, joint_name: str, env_ids: list[int] | None = None) -> torch.FloatTensor:
@@ -129,7 +129,7 @@ class BaseSimHandler:
             env_ids = list(range(self.num_envs))
 
         states = self.get_states(env_ids=env_ids)
-        states = tensor_state_to_env_states(self, states)
+        states = state_tensor_to_nested(self, states)
         return torch.tensor([
             {**env_state["objects"], **env_state["robots"]}[obj_name]["dof_pos"][joint_name] for env_state in states
         ])

--- a/metasim/sim/env_wrapper.py
+++ b/metasim/sim/env_wrapper.py
@@ -99,7 +99,7 @@ def GymEnvWrapper(cls: type[THandler]) -> type[EnvWrapper[THandler]]:
             self._episode_length_buf += 1
             self.handler.set_dof_targets(self.handler.robot.name, actions)
             self.handler.simulate()
-            reward = self._get_reward()
+            reward = None
             success = self.handler.checker.check(self.handler)
             states = self.handler.get_states()
             time_out = self._episode_length_buf >= self.handler.scenario.episode_length

--- a/metasim/sim/env_wrapper.py
+++ b/metasim/sim/env_wrapper.py
@@ -90,6 +90,9 @@ def GymEnvWrapper(cls: type[THandler]) -> type[EnvWrapper[THandler]]:
             self._episode_length_buf[env_ids] = 0
             if states is not None:
                 self.handler.set_states(states, env_ids=env_ids)
+            if self.handler.scenario.sim in ["mujoco", "isaacgym"]:
+                ## HACK
+                self.handler.simulate()
             self.handler.checker.reset(self.handler, env_ids=env_ids)
             self.handler.refresh_render()
             states = self.handler.get_states()

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -109,6 +109,7 @@ class GenesisHandler(BaseSimHandler):
                         ],
                         dim=-1,
                     ),
+                    body_state=None,  # TODO
                     joint_pos=obj_inst.get_dofs_position(envs_idx=env_ids)[:, joint_reindex],
                     joint_vel=obj_inst.get_dofs_velocity(envs_idx=env_ids)[:, joint_reindex],
                 )
@@ -140,6 +141,7 @@ class GenesisHandler(BaseSimHandler):
                     ],
                     dim=-1,
                 ),
+                body_state=None,  # TODO
                 joint_pos=obj_inst.get_dofs_position(envs_idx=env_ids)[:, joint_reindex],
                 joint_vel=obj_inst.get_dofs_velocity(envs_idx=env_ids)[:, joint_reindex],
                 joint_pos_target=None,  # TODO

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -98,7 +98,7 @@ class GenesisHandler(BaseSimHandler):
         for obj in self.objects:
             obj_inst = self.object_inst_dict[obj.name]
             if isinstance(obj, ArticulationObjCfg):
-                joint_reindex = self.get_object_joint_reindex(obj.name)
+                joint_reindex = self.get_joint_reindex(obj.name)
                 state = ObjectState(
                     root_state=torch.cat(
                         [
@@ -130,7 +130,7 @@ class GenesisHandler(BaseSimHandler):
         robot_states = {}
         for obj in [self.robot]:
             obj_inst = self.object_inst_dict[obj.name]
-            joint_reindex = self.get_object_joint_reindex(obj.name)
+            joint_reindex = self.get_joint_reindex(obj.name)
             state = RobotState(
                 root_state=torch.cat(
                     [

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -10,10 +10,10 @@ from loguru import logger as log
 
 rootutils.setup_root(__file__, pythonpath=True)
 from metasim.cfg.objects import ArticulationObjCfg, BaseObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
-from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, GymEnvWrapper
 from metasim.types import Action, EnvState
+from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
 
 
 class GenesisHandler(BaseSimHandler):
@@ -93,49 +93,72 @@ class GenesisHandler(BaseSimHandler):
     def get_states(self, env_ids: list[int] | None = None) -> list[EnvState]:
         if env_ids is None:
             env_ids = list(range(self.num_envs))
-        states = []
 
-        states_concat = {}
-        for obj in self.objects + [self.robot]:
+        object_states = {}
+        for obj in self.objects:
             obj_inst = self.object_inst_dict[obj.name]
-            states_concat[obj.name] = {}
-            states_concat[obj.name]["pos"] = obj_inst.get_pos(envs_idx=env_ids).cpu()
-            states_concat[obj.name]["rot"] = obj_inst.get_quat(envs_idx=env_ids).cpu()
             if isinstance(obj, ArticulationObjCfg):
-                states_concat[obj.name]["dof_pos"] = obj_inst.get_qpos(envs_idx=env_ids).cpu()
-        camera_obs = {}
-        for camera_name, camera_inst in self.camera_inst_dict.items():
-            rgb, _, _, _ = camera_inst.render()
-            rgb = torch.from_numpy(rgb.copy())
-            camera_obs[camera_name] = {"rgb": rgb}
+                joint_reindex = self.get_object_joint_reindex(obj.name)
+                state = ObjectState(
+                    root_state=torch.cat(
+                        [
+                            obj_inst.get_pos(envs_idx=env_ids),
+                            obj_inst.get_quat(envs_idx=env_ids),
+                            obj_inst.get_vel(envs_idx=env_ids),
+                            obj_inst.get_ang(envs_idx=env_ids),
+                        ],
+                        dim=-1,
+                    ),
+                    joint_pos=obj_inst.get_dofs_position(envs_idx=env_ids)[:, joint_reindex],
+                    joint_vel=obj_inst.get_dofs_velocity(envs_idx=env_ids)[:, joint_reindex],
+                )
+            else:
+                state = ObjectState(
+                    root_state=torch.cat(
+                        [
+                            obj_inst.get_pos(envs_idx=env_ids),
+                            obj_inst.get_quat(envs_idx=env_ids),
+                            obj_inst.get_vel(envs_idx=env_ids),
+                            obj_inst.get_ang(envs_idx=env_ids),
+                        ],
+                        dim=-1,
+                    ),
+                )
+            object_states[obj.name] = state
 
-        for env_id in env_ids:
-            env_state = {"objects": {}, "robots": {}, "cameras": camera_obs}
-            for obj in self.objects + [self.robot]:
-                obj_inst = self.object_inst_dict[obj.name]
-                obj_state = {}
-                obj_state["pos"] = states_concat[obj.name]["pos"][env_id]
-                obj_state["rot"] = states_concat[obj.name]["rot"][env_id]
-                if isinstance(obj, ArticulationObjCfg):
-                    obj_state["dof_pos"] = {
-                        jn: states_concat[obj.name]["dof_pos"][env_id][jid]
-                        for jid, jn in enumerate(self.get_object_joint_names(obj))
-                    }
-                if isinstance(obj, BaseRobotCfg):
-                    ## TODO: read from simulator instead of cache
-                    if self.actions_cache:
-                        obj_state["dof_pos_target"] = {
-                            jn: self.actions_cache[env_id]["dof_pos_target"][jn]
-                            for jid, jn in enumerate(self.get_object_joint_names(obj))
-                        }
-                    else:
-                        obj_state["dof_pos_target"] = None
-                if obj.name == self.robot.name:
-                    env_state["robots"][obj.name] = obj_state
-                else:
-                    env_state["objects"][obj.name] = obj_state
-            states.append(env_state)
-        return states
+        robot_states = {}
+        for obj in [self.robot]:
+            obj_inst = self.object_inst_dict[obj.name]
+            joint_reindex = self.get_object_joint_reindex(obj.name)
+            state = RobotState(
+                root_state=torch.cat(
+                    [
+                        obj_inst.get_pos(envs_idx=env_ids),
+                        obj_inst.get_quat(envs_idx=env_ids),
+                        obj_inst.get_vel(envs_idx=env_ids),
+                        obj_inst.get_ang(envs_idx=env_ids),
+                    ],
+                    dim=-1,
+                ),
+                joint_pos=obj_inst.get_dofs_position(envs_idx=env_ids)[:, joint_reindex],
+                joint_vel=obj_inst.get_dofs_velocity(envs_idx=env_ids)[:, joint_reindex],
+                joint_pos_target=None,  # TODO
+                joint_vel_target=None,  # TODO
+                joint_effort_target=None,  # TODO
+            )
+            robot_states[obj.name] = state
+
+        camera_states = {}
+        for camera in self.cameras:
+            camera_inst = self.camera_inst_dict[camera.name]
+            rgb, depth, _, _ = camera_inst.render(depth=True)
+            state = CameraState(
+                rgb=torch.from_numpy(rgb.copy()).unsqueeze(0).repeat_interleave(self.num_envs, dim=0),  # XXX
+                depth=torch.from_numpy(depth.copy()).unsqueeze(0).repeat_interleave(self.num_envs, dim=0),  # XXX
+            )
+            camera_states[camera.name] = state
+
+        return TensorState(objects=object_states, robots=robot_states, cameras=camera_states)
 
     def set_states(self, states: list[EnvState], env_ids: list[int] | None = None) -> None:
         if env_ids is None:

--- a/metasim/sim/hybrid.py
+++ b/metasim/sim/hybrid.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from metasim.sim import BaseSimHandler, EnvWrapper
 from metasim.types import Action, EnvState, Extra, Reward, Success, TimeOut
-from metasim.utils.state import TensorState, tensor_state_to_env_states
+from metasim.utils.state import TensorState, state_tensor_to_nested
 
 
 class HybridSimEnv(EnvWrapper[BaseSimHandler]):
@@ -17,7 +17,7 @@ class HybridSimEnv(EnvWrapper[BaseSimHandler]):
     def step(self, action: list[Action]) -> tuple[TensorState, Reward, Success, TimeOut, Extra]:
         obs, reward, success, time_out, extra = self.sim_env1.step(action)
         states = self.sim_env1.handler.get_states()
-        states_nested = tensor_state_to_env_states(self.sim_env1.handler, obs)
+        states_nested = state_tensor_to_nested(self.sim_env1.handler, obs)
         self.sim_env2.handler.set_states(states_nested)
         self.sim_env2.handler.refresh_render()
         states = self.sim_env2.handler.get_states()

--- a/metasim/sim/hybrid.py
+++ b/metasim/sim/hybrid.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 from metasim.sim import BaseSimHandler, EnvWrapper
-from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, TimeOut
+from metasim.types import Action, EnvState, Extra, Reward, Success, TimeOut
+from metasim.utils.state import TensorState, tensor_state_to_env_states
 
 
 class HybridSimEnv(EnvWrapper[BaseSimHandler]):
@@ -13,10 +14,11 @@ class HybridSimEnv(EnvWrapper[BaseSimHandler]):
         self.sim_env1.reset(states=states)
         return self.sim_env2.reset(states=states)
 
-    def step(self, action: list[Action]) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
+    def step(self, action: list[Action]) -> tuple[TensorState, Reward, Success, TimeOut, Extra]:
         obs, reward, success, time_out, extra = self.sim_env1.step(action)
         states = self.sim_env1.handler.get_states()
-        self.sim_env2.handler.set_states(states)
+        states_nested = tensor_state_to_env_states(self.sim_env1.handler, obs)
+        self.sim_env2.handler.set_states(states_nested)
         self.sim_env2.handler.refresh_render()
         states = self.sim_env2.handler.get_states()
         return states, reward, success, time_out, extra

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -420,6 +420,7 @@ class IsaacgymHandler(BaseSimHandler):
                 joint_reindex = self.get_object_joint_reindex(obj.name)
                 state = ObjectState(
                     root_state=self._root_states.view(self.num_envs, -1, 13)[:, obj_id, :],
+                    body_state=None,  # TODO
                     joint_pos=self._dof_states.view(self.num_envs, -1, 2)[:, joint_reindex, 0],
                     joint_vel=self._dof_states.view(self.num_envs, -1, 2)[:, joint_reindex, 1],
                 )
@@ -430,17 +431,18 @@ class IsaacgymHandler(BaseSimHandler):
             object_states[obj.name] = state
 
         robot_states = {}
-        for obj_id, obj in enumerate([self.robot]):
-            joint_reindex = self.get_object_joint_reindex(obj.name)
+        for obj_id, robot in enumerate([self.robot]):
+            joint_reindex = self.get_object_joint_reindex(robot.name)
             state = RobotState(
                 root_state=self._root_states.view(self.num_envs, -1, 13)[:, obj_id, :],
+                body_state=None,  # TODO
                 joint_pos=self._dof_states.view(self.num_envs, -1, 2)[:, joint_reindex, 0],
                 joint_vel=self._dof_states.view(self.num_envs, -1, 2)[:, joint_reindex, 1],
                 joint_pos_target=None,  # TODO
                 joint_vel_target=None,  # TODO
                 joint_effort_target=None,  # TODO
             )
-            robot_states[obj.name] = state
+            robot_states[robot.name] = state
 
         camera_states = {}
         for cam_id, cam in enumerate(self.cameras):

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -417,7 +417,7 @@ class IsaacgymHandler(BaseSimHandler):
         object_states = {}
         for obj_id, obj in enumerate(self.objects):
             if isinstance(obj, ArticulationObjCfg):
-                joint_reindex = self.get_object_joint_reindex(obj.name)
+                joint_reindex = self.get_joint_reindex(obj.name)
                 body_ids_reindex = [
                     self._body_info[obj.name]["global_indices"][bn] for bn in sorted(self.get_body_names(obj.name))
                 ]
@@ -435,7 +435,7 @@ class IsaacgymHandler(BaseSimHandler):
 
         robot_states = {}
         for obj_id, robot in enumerate([self.robot]):
-            joint_reindex = self.get_object_joint_reindex(robot.name)
+            joint_reindex = self.get_joint_reindex(robot.name)
             body_ids_reindex = [
                 self._body_info[robot.name]["global_indices"][bn] for bn in sorted(self.get_body_names(robot.name))
             ]

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -12,6 +12,7 @@ from metasim.cfg.robots.base_robot_cfg import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.types import Action, EnvState
+from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
 
 
 class IsaacgymHandler(BaseSimHandler):
@@ -413,94 +414,43 @@ class IsaacgymHandler(BaseSimHandler):
         if env_ids is None:
             env_ids = list(range(self.num_envs))
 
-        states = []
-        for env_id in env_ids:
-            env_state = {"objects": {}, "robots": {}, "cameras": {}}
-            for obj_id, obj in enumerate(self.objects + [self._robot]):
-                obj_state = {}
-                object_type = "robots" if obj.name in self._robot_names else "objects"
+        object_states = {}
+        for obj_id, obj in enumerate(self.objects):
+            if isinstance(obj, ArticulationObjCfg):
+                joint_reindex = self.get_object_joint_reindex(obj.name)
+                state = ObjectState(
+                    root_state=self._root_states.view(self.num_envs, -1, 13)[:, obj_id, :],
+                    joint_pos=self._dof_states.view(self.num_envs, -1, 2)[:, joint_reindex, 0],
+                    joint_vel=self._dof_states.view(self.num_envs, -1, 2)[:, joint_reindex, 1],
+                )
+            else:
+                state = ObjectState(
+                    root_state=self._root_states.view(self.num_envs, -1, 13)[:, obj_id, :],
+                )
+            object_states[obj.name] = state
 
-                ## Basic states -- for both robot and object
-                obj_state["pos"] = self._root_states.view(self.num_envs, -1, 13)[env_id, obj_id, :3].cpu()
-                obj_state["rot"] = self._root_states.view(self.num_envs, -1, 13)[env_id, obj_id, 3:7].cpu()
-                obj_state["vel"] = self._root_states.view(self.num_envs, -1, 13)[env_id, obj_id, 7:10].cpu()
-                obj_state["ang_vel"] = self._root_states.view(self.num_envs, -1, 13)[env_id, obj_id, 10:].cpu()
+        robot_states = {}
+        for obj_id, obj in enumerate([self.robot]):
+            joint_reindex = self.get_object_joint_reindex(obj.name)
+            state = RobotState(
+                root_state=self._root_states.view(self.num_envs, -1, 13)[:, obj_id, :],
+                joint_pos=self._dof_states.view(self.num_envs, -1, 2)[:, joint_reindex, 0],
+                joint_vel=self._dof_states.view(self.num_envs, -1, 2)[:, joint_reindex, 1],
+                joint_pos_target=None,  # TODO
+                joint_vel_target=None,  # TODO
+                joint_effort_target=None,  # TODO
+            )
+            robot_states[obj.name] = state
 
-                ## Joint states -- for robot and articulated object
-                if isinstance(obj, ArticulationObjCfg):
-                    obj_state["dof_pos"] = {
-                        joint_name: self._dof_states.view(self.num_envs, -1, 2)[env_id, global_idx, 0].item()
-                        for joint_name, global_idx in (self._joint_info[obj.name]["global_indices"]).items()
-                    }
-                    obj_state["dof_vel"] = {
-                        joint_name: self._dof_states.view(self.num_envs, -1, 2)[env_id, global_idx, 1].item()
-                        for joint_name, global_idx in (self._joint_info[obj.name]["global_indices"]).items()
-                    }
+        camera_states = {}
+        for cam_id, cam in enumerate(self.cameras):
+            state = CameraState(
+                rgb=torch.stack([self._rgb_tensors[env_id][cam_id][..., :3] for env_id in env_ids]),
+                depth=torch.stack([self._depth_tensors[env_id][cam_id] for env_id in env_ids]),
+            )
+            camera_states[cam.name] = state
 
-                ## Actions -- for robot
-                ## TODO: read from simulator instead of cache
-                if isinstance(obj, BaseRobotCfg):
-                    if self.actions_cache:
-                        obj_state["dof_pos_target"] = {
-                            joint_name: self.actions_cache[env_id]["dof_pos_target"][joint_name]
-                            for joint_name in self._joint_info[obj.name]["names"]
-                        }
-                    else:
-                        obj_state["dof_pos_target"] = None
-
-                ## Actuator states -- for robot
-                ## XXX: Could non-robot objects have actuators?
-                if isinstance(obj, BaseRobotCfg):
-                    obj_state["dof_pos_target"] = {
-                        joint_name: None  # TODO
-                        for i, joint_name in enumerate(self._joint_info[obj.name]["names"])
-                    }
-                    obj_state["dof_vel_target"] = {
-                        joint_name: None  # TODO
-                        for i, joint_name in enumerate(self._joint_info[obj.name]["names"])
-                    }
-                    obj_state["dof_torque"] = {
-                        joint_name: None  # TODO
-                        for i, joint_name in enumerate(self._joint_info[obj.name]["names"])
-                    }
-                env_state[object_type][obj.name] = obj_state
-
-                ## Body states -- for both robot and object
-                env_state[object_type][obj.name]["body"] = {}
-                for i, body_name in enumerate(self._body_info[obj.name]["name"]):
-                    body_state = {
-                        "pos": self._rigid_body_states[
-                            self._body_info[obj.name]["global_indices"][body_name], :3
-                        ].cpu(),
-                        "rot": self._rigid_body_states[
-                            self._body_info[obj.name]["global_indices"][body_name], 3:7
-                        ].cpu(),
-                        "vel": self._rigid_body_states[
-                            self._body_info[obj.name]["global_indices"][body_name], 7:10
-                        ].cpu(),
-                        "ang_vel": self._rigid_body_states[
-                            self._body_info[obj.name]["global_indices"][body_name], 10:
-                        ].cpu(),
-                    }
-                    env_state[object_type][obj.name]["body"][body_name] = body_state
-
-            if len(self.cameras) > 0:
-                self.gym.start_access_image_tensors(self.sim)
-                for i_cam, cam in enumerate(self._cameras):
-                    cam_state = {}
-                    cam_state[cam.name] = {
-                        "rgb": self._rgb_tensors[env_id][i_cam][..., :3],
-                        "depth": self._depth_tensors[env_id][i_cam],
-                        "pos": torch.tensor(cam.pos, device=self.device),
-                        "look_at": torch.tensor(cam.look_at, device=self.device),
-                        "intrinsic": torch.zeros((3, 3), device=self.device),  # TODO: get intrinsic matrix
-                        "extrinsic": torch.zeros((4, 4), device=self.device),  # TODO: get extrinsic matrix
-                    }
-                env_state["cameras"] = cam_state
-                self.gym.end_access_image_tensors(self.sim)
-
-            states.append(env_state)
-        return states
+        return TensorState(objects=object_states, robots=robot_states, cameras=camera_states)
 
     @property
     def episode_length_buf(self) -> list[int]:
@@ -724,27 +674,11 @@ class IsaacgymHandler(BaseSimHandler):
         pass
 
     ############################################################
-    ## Set object states per step
-    ############################################################
-    def _set_object_joint_pos(
-        self,
-        object: BaseObjCfg,
-        joint_pos: list[float],
-    ) -> None:
-        assert len(joint_pos) == self.env.scene.articulations[object.name].num_joints
-
-        pos = torch.tensor(joint_pos, device=self.env.device)
-        vel = torch.zeros_like(pos)
-        self.env.scene.articulations[object.name].write_joint_state_to_sim(
-            pos, vel, env_ids=torch.tensor([0], device=self.env.device)
-        )
-
-    ############################################################
     ## Utils
     ############################################################
-    def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
-        if isinstance(object, ArticulationObjCfg):
-            return self.env.scene.articulations[object.name].joint_names
+    def get_object_joint_names(self, obj: BaseObjCfg) -> list[str]:
+        if isinstance(obj, ArticulationObjCfg):
+            return list(self._joint_info[obj.name]["global_indices"].keys())
         else:
             return []
 

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -419,8 +419,7 @@ class IsaacgymHandler(BaseSimHandler):
             if isinstance(obj, ArticulationObjCfg):
                 joint_reindex = self.get_object_joint_reindex(obj.name)
                 body_ids_reindex = [
-                    self._body_info[obj.name]["global_indices"][bn]
-                    for bn in sorted(self.get_object_body_names(obj.name))
+                    self._body_info[obj.name]["global_indices"][bn] for bn in sorted(self.get_body_names(obj.name))
                 ]
                 state = ObjectState(
                     root_state=self._root_states.view(self.num_envs, -1, 13)[:, obj_id, :],
@@ -438,8 +437,7 @@ class IsaacgymHandler(BaseSimHandler):
         for obj_id, robot in enumerate([self.robot]):
             joint_reindex = self.get_object_joint_reindex(robot.name)
             body_ids_reindex = [
-                self._body_info[robot.name]["global_indices"][bn]
-                for bn in sorted(self.get_object_body_names(robot.name))
+                self._body_info[robot.name]["global_indices"][bn] for bn in sorted(self.get_body_names(robot.name))
             ]
             state = RobotState(
                 root_state=self._root_states.view(self.num_envs, -1, 13)[:, obj_id, :],
@@ -692,7 +690,7 @@ class IsaacgymHandler(BaseSimHandler):
         else:
             return []
 
-    def get_object_body_names(self, obj_name: str) -> list[str]:
+    def get_body_names(self, obj_name: str) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             return self._body_info[obj_name]["name"]
         else:

--- a/metasim/sim/isaaclab/env_overwriter.py
+++ b/metasim/sim/isaaclab/env_overwriter.py
@@ -382,12 +382,12 @@ class IsaaclabEnvOverwriter:
             assert torch.allclose(cam_intr0, cam_intr)
 
             ## Robot State
-            joint_qpos_target = env.actions.cpu()
-            joint_qpos = env.robot.data.joint_pos.cpu()
-            robot_root_state = env.robot.data.root_state_w.cpu()
-            robot_body_state = env.robot.data.body_link_state_w.cpu()
-            robot_root_state[..., 0:3] -= env.scene.env_origins.cpu()
-            robot_body_state[..., 0:3] -= env.scene.env_origins.cpu().unsqueeze(1)
+            joint_qpos_target = env.actions
+            joint_qpos = env.robot.data.joint_pos
+            robot_root_state = env.robot.data.root_state_w
+            robot_body_state = env.robot.data.body_link_state_w
+            robot_root_state[..., 0:3] -= env.scene.env_origins
+            robot_body_state[..., 0:3] -= env.scene.env_origins.unsqueeze(1)
             if self.robot.ee_body_name is not None:
                 ee_pos, ee_quat = get_pose(env, self.robot.name, self.robot.ee_body_name)
                 robot_ee_state = torch.cat([ee_pos, ee_quat, joint_qpos[:, -1:]], dim=-1)
@@ -411,11 +411,6 @@ class IsaaclabEnvOverwriter:
                 "robot_root_state": robot_root_state,
                 "robot_body_state": robot_body_state,
             }
-
-            for k, v in data_dict.items():
-                if isinstance(v, torch.Tensor):
-                    data_dict[k] = v.cpu()
-            torch.cuda.empty_cache()
 
             return data_dict
 

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -292,8 +292,10 @@ class IsaaclabHandler(BaseSimHandler):
             if isinstance(obj, ArticulationObjCfg):
                 obj_inst = self.env.scene.articulations[obj.name]
                 joint_reindex = self.get_object_joint_reindex(obj.name)
+                body_reindex = self.get_body_reindex(obj.name)
                 state = ObjectState(
                     root_state=obj_inst.data.root_state_w,
+                    body_state=obj_inst.data.body_state_w[:, body_reindex],
                     joint_pos=obj_inst.data.joint_pos[:, joint_reindex],
                     joint_vel=obj_inst.data.joint_vel[:, joint_reindex],
                 )
@@ -309,8 +311,10 @@ class IsaaclabHandler(BaseSimHandler):
             ## TODO: dof_pos_target, dof_vel_target, dof_torque
             obj_inst = self.env.scene.articulations[obj.name]
             joint_reindex = self.get_object_joint_reindex(obj.name)
+            body_reindex = self.get_body_reindex(obj.name)
             state = RobotState(
                 root_state=obj_inst.data.root_state_w,
+                body_state=obj_inst.data.body_state_w[:, body_reindex],
                 joint_pos=obj_inst.data.joint_pos[:, joint_reindex],
                 joint_vel=obj_inst.data.joint_vel[:, joint_reindex],
                 joint_pos_target=obj_inst.data.joint_pos_target[:, joint_reindex],
@@ -361,6 +365,12 @@ class IsaaclabHandler(BaseSimHandler):
     def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
         if isinstance(object, ArticulationObjCfg):
             return self.env.scene.articulations[object.name].joint_names
+        else:
+            return []
+
+    def get_object_body_names(self, obj_name: str) -> list[str]:
+        if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
+            return self.env.scene.articulations[obj_name].body_names
         else:
             return []
 

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -291,7 +291,7 @@ class IsaaclabHandler(BaseSimHandler):
         for obj in self.objects:
             if isinstance(obj, ArticulationObjCfg):
                 obj_inst = self.env.scene.articulations[obj.name]
-                joint_reindex = self.get_object_joint_reindex(obj.name)
+                joint_reindex = self.get_joint_reindex(obj.name)
                 body_reindex = self.get_body_reindex(obj.name)
                 state = ObjectState(
                     root_state=obj_inst.data.root_state_w,
@@ -310,7 +310,7 @@ class IsaaclabHandler(BaseSimHandler):
         for obj in [self.robot]:
             ## TODO: dof_pos_target, dof_vel_target, dof_torque
             obj_inst = self.env.scene.articulations[obj.name]
-            joint_reindex = self.get_object_joint_reindex(obj.name)
+            joint_reindex = self.get_joint_reindex(obj.name)
             body_reindex = self.get_body_reindex(obj.name)
             state = RobotState(
                 root_state=obj_inst.data.root_state_w,

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -287,16 +287,6 @@ class IsaaclabHandler(BaseSimHandler):
         if env_ids is None:
             env_ids = list(range(self.num_envs))
 
-        ## Preprocess camera data
-        rgb_datas = []
-        depth_datas = []
-        for camera in self.cameras:
-            camera_inst = self.env.scene.sensors[camera.name]
-            rgb_data = camera_inst.data.output.get("rgb", None)
-            depth_data = camera_inst.data.output.get("depth", None)
-            rgb_datas.append(rgb_data)
-            depth_datas.append(depth_data)
-
         object_states = {}
         for obj in self.objects:
             if isinstance(obj, ArticulationObjCfg):

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -301,10 +301,11 @@ class IsaaclabHandler(BaseSimHandler):
         for obj in self.objects:
             if isinstance(obj, ArticulationObjCfg):
                 obj_inst = self.env.scene.articulations[obj.name]
+                joint_reindex = self.get_object_joint_reindex(obj.name)
                 state = ObjectState(
                     root_state=obj_inst.data.root_state_w,
-                    joint_pos=obj_inst.data.joint_pos,
-                    joint_vel=obj_inst.data.joint_vel,
+                    joint_pos=obj_inst.data.joint_pos[:, joint_reindex],
+                    joint_vel=obj_inst.data.joint_vel[:, joint_reindex],
                 )
             else:
                 obj_inst = self.env.scene.rigid_objects[obj.name]
@@ -317,13 +318,14 @@ class IsaaclabHandler(BaseSimHandler):
         for obj in [self.robot]:
             ## TODO: dof_pos_target, dof_vel_target, dof_torque
             obj_inst = self.env.scene.articulations[obj.name]
+            joint_reindex = self.get_object_joint_reindex(obj.name)
             state = RobotState(
                 root_state=obj_inst.data.root_state_w,
-                joint_pos=obj_inst.data.joint_pos,
-                joint_vel=obj_inst.data.joint_vel,
-                joint_pos_target=obj_inst.data.joint_pos_target,
-                joint_vel_target=obj_inst.data.joint_vel_target,
-                joint_effort_target=obj_inst.data.joint_effort_target,
+                joint_pos=obj_inst.data.joint_pos[:, joint_reindex],
+                joint_vel=obj_inst.data.joint_vel[:, joint_reindex],
+                joint_pos_target=obj_inst.data.joint_pos_target[:, joint_reindex],
+                joint_vel_target=obj_inst.data.joint_vel_target[:, joint_reindex],
+                joint_effort_target=obj_inst.data.joint_effort_target[:, joint_reindex],
             )
             robot_states[obj.name] = state
 

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -368,7 +368,7 @@ class IsaaclabHandler(BaseSimHandler):
         else:
             return []
 
-    def get_object_body_names(self, obj_name: str) -> list[str]:
+    def get_body_names(self, obj_name: str) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             return self.env.scene.articulations[obj_name].body_names
         else:

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -7,13 +7,13 @@ import torch
 from loguru import logger as log
 
 from metasim.cfg.objects import ArticulationObjCfg, BaseObjCfg, RigidObjCfg
-from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, EnvWrapper, IdentityEnvWrapper
 from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, TimeOut
+from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
 
 from .env_overwriter import IsaaclabEnvOverwriter
-from .isaaclab_helper import get_pose, joint_is_implicit_actuator
+from .isaaclab_helper import get_pose
 
 try:
     from omni.isaac.lab.app import AppLauncher
@@ -283,7 +283,7 @@ class IsaaclabHandler(BaseSimHandler):
     ############################################################
     ## Get states
     ############################################################
-    def get_states(self, env_ids: list[int] | None = None) -> list[EnvState]:
+    def get_states(self, env_ids: list[int] | None = None) -> TensorState:
         if env_ids is None:
             env_ids = list(range(self.num_envs))
 
@@ -297,84 +297,44 @@ class IsaaclabHandler(BaseSimHandler):
             rgb_datas.append(rgb_data)
             depth_datas.append(depth_data)
 
-        states = []
-        for env_id in env_ids:
-            env_state = {"objects": {}, "robots": {}, "cameras": {}}
+        object_states = {}
+        for obj in self.objects:
+            if isinstance(obj, ArticulationObjCfg):
+                obj_inst = self.env.scene.articulations[obj.name]
+                state = ObjectState(
+                    root_state=obj_inst.data.root_state_w,
+                    joint_pos=obj_inst.data.joint_pos,
+                    joint_vel=obj_inst.data.joint_vel,
+                )
+            else:
+                obj_inst = self.env.scene.rigid_objects[obj.name]
+                state = ObjectState(
+                    root_state=obj_inst.data.root_state_w,
+                )
+            object_states[obj.name] = state
 
-            for obj in self.objects + [self.robot]:
-                object_type = "robots" if obj is self.robot else "objects"
-                if isinstance(obj, ArticulationObjCfg):
-                    obj_inst = self.env.scene.articulations[obj.name]
-                else:
-                    obj_inst = self.env.scene.rigid_objects[obj.name]
-                obj_state = {}
+        robot_states = {}
+        for obj in [self.robot]:
+            ## TODO: dof_pos_target, dof_vel_target, dof_torque
+            obj_inst = self.env.scene.articulations[obj.name]
+            state = RobotState(
+                root_state=obj_inst.data.root_state_w,
+                joint_pos=obj_inst.data.joint_pos,
+                joint_vel=obj_inst.data.joint_vel,
+                joint_pos_target=obj_inst.data.joint_pos_target,
+                joint_vel_target=obj_inst.data.joint_vel_target,
+                joint_effort_target=obj_inst.data.joint_effort_target,
+            )
+            robot_states[obj.name] = state
 
-                ## Basic states
-                obj_state["pos"] = obj_inst.data.root_pos_w[env_id].cpu() - self.env.scene.env_origins[env_id].cpu()
-                obj_state["rot"] = obj_inst.data.root_quat_w[env_id].cpu()
-                obj_state["vel"] = obj_inst.data.root_lin_vel_w[env_id].cpu()
-                obj_state["ang_vel"] = obj_inst.data.root_ang_vel_w[env_id].cpu()
+        camera_states = {}
+        for camera in self.cameras:
+            camera_inst = self.env.scene.sensors[camera.name]
+            rgb_data = camera_inst.data.output.get("rgb", None)
+            depth_data = camera_inst.data.output.get("depth", None)
+            camera_states[camera.name] = CameraState(rgb=rgb_data, depth=depth_data)
 
-                ## Joint states
-                if isinstance(obj, ArticulationObjCfg):
-                    obj_state["dof_pos"] = {
-                        joint_name: obj_inst.data.joint_pos[env_id][i].item()
-                        for i, joint_name in enumerate(obj_inst.joint_names)
-                    }
-                    obj_state["dof_vel"] = {
-                        joint_name: obj_inst.data.joint_vel[env_id][i].item()
-                        for i, joint_name in enumerate(obj_inst.joint_names)
-                    }
-
-                ## Actuator states
-                ## XXX: Could non-robot objects have actuators?
-                if isinstance(obj, BaseRobotCfg):
-                    obj_state["dof_pos_target"] = {
-                        joint_name: obj_inst.data.joint_pos_target[env_id][i].item()
-                        for i, joint_name in enumerate(obj_inst.joint_names)
-                    }
-                    obj_state["dof_vel_target"] = {
-                        joint_name: obj_inst.data.joint_vel_target[env_id][i].item()
-                        for i, joint_name in enumerate(obj_inst.joint_names)
-                    }
-                    obj_state["dof_torque"] = {
-                        joint_name: (
-                            obj_inst.data.joint_effort_target[env_id][i].item()
-                            if joint_is_implicit_actuator(joint_name, obj_inst)
-                            else obj_inst.data.applied_torque[env_id][i].item()
-                        )
-                        for i, joint_name in enumerate(obj_inst.joint_names)
-                    }
-                env_state[obj.name] = obj_state
-                env_state[object_type][obj.name] = obj_state
-
-                ## Body states
-                env_state[object_type][obj.name]["body"] = {}
-                coms = obj_inst.root_physx_view.get_coms()
-                coms = coms.reshape((self.env.num_envs, obj_inst.num_bodies, 7))
-                com_positions = coms[:, :, :3]  # (num_envs, num_bodies, 3)
-                for i, body_name in enumerate(obj_inst.body_names):
-                    body_state = {}
-                    body_state["pos"] = (
-                        obj_inst.data.body_link_pos_w[env_id, i].cpu() - self.env.scene.env_origins[env_id].cpu()
-                    )
-                    body_state["rot"] = obj_inst.data.body_link_quat_w[env_id, i].cpu()
-                    body_state["vel"] = obj_inst.data.body_link_vel_w[env_id, i].cpu()
-                    body_state["ang_vel"] = obj_inst.data.body_link_ang_vel_w[env_id, i].cpu()
-                    body_state["com"] = com_positions[env_id, i].cpu()
-                    env_state[object_type][obj.name]["body"][body_name] = body_state
-
-            ## Cameras
-            env_state["cameras"] = {
-                camera.name: {
-                    "rgb": rgb_datas[i][env_id],
-                    "depth": depth_datas[i][env_id],
-                }
-                for i, camera in enumerate(self.cameras)
-            }
-
-            states.append(env_state)
-        return states
+        return TensorState(objects=object_states, robots=robot_states, cameras=camera_states)
 
     def get_pos(self, obj_name: str, env_ids: list[int] | None = None) -> torch.FloatTensor:
         if env_ids is None:

--- a/metasim/sim/isaaclab/isaaclab_helper.py
+++ b/metasim/sim/isaaclab/isaaclab_helper.py
@@ -216,8 +216,8 @@ def get_pose(
         raise ValueError(f"Object {obj_name} not found")
 
     if obj_subpath is None:
-        pos = obj_inst.data.root_pos_w.cpu()[env_ids] - env.scene.env_origins.cpu()[env_ids]
-        rot = obj_inst.data.root_quat_w.cpu()[env_ids]
+        pos = obj_inst.data.root_pos_w[env_ids] - env.scene.env_origins[env_ids]
+        rot = obj_inst.data.root_quat_w[env_ids]
     else:
         ## TODO: Following code has bug with IsaacLab2.0 (IsaacSim 4.5)
         if ISAACLAB_VERSION == 1:
@@ -228,12 +228,10 @@ def get_pose(
             )
             pos, rot = view.get_world_poses(indices=env_ids)
             pos = pos - env.scene.env_origins[env_ids]
-            pos = pos.cpu()
-            rot = rot.cpu()
         else:
             log.warning("IsaacLab2.0 (IsaacSim 4.5) does not support creating RigidPrimView, so we return zeros.")
-            pos = torch.zeros((len(env_ids), 3))
-            rot = torch.zeros((len(env_ids), 4))
+            pos = torch.zeros((len(env_ids), 3), device=env.device)
+            rot = torch.zeros((len(env_ids), 4), device=env.device)
 
     assert pos.shape == (len(env_ids), 3)
     assert rot.shape == (len(env_ids), 4)

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -17,12 +17,8 @@ from metasim.cfg.objects import (
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import TaskType
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
-<<<<<<< HEAD
 from metasim.types import Action
-=======
-from metasim.types import Action, Obs
 from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
->>>>>>> d832f32 (mujoco replay close_box/stack_cube successful)
 
 
 class MujocoHandler(BaseSimHandler):

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -212,6 +212,12 @@ class MujocoHandler(BaseSimHandler):
             if isinstance(obj, ArticulationObjCfg):
                 joint_names = sorted(self.get_object_joint_names(obj))
                 body_reindex = self.get_body_reindex(obj.name)
+                body_ids_origin = [
+                    bi
+                    for bi in range(self.physics.model.nbody)
+                    if self.physics.model.body(bi).name.split("/")[0] == model_name
+                ]
+                body_ids_reindex = [body_ids_origin[i] for i in body_reindex]
                 state = ObjectState(
                     root_state=torch.concat([
                         torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
@@ -226,7 +232,7 @@ class MujocoHandler(BaseSimHandler):
                                 self.physics.data.cvel[body_id],  # (6,)
                             ])
                         ).float()
-                        for body_id in body_reindex
+                        for body_id in body_ids_reindex
                     ]).unsqueeze(0),
                     joint_pos=torch.tensor([
                         self.physics.data.joint(f"{model_name}/{jn}").qpos.item() for jn in joint_names
@@ -251,6 +257,12 @@ class MujocoHandler(BaseSimHandler):
             obj_body_id = self.physics.model.body(f"{model_name}/").id
             joint_names = sorted(self.get_object_joint_names(robot))
             body_reindex = self.get_body_reindex(robot.name)
+            body_ids_origin = [
+                bi
+                for bi in range(self.physics.model.nbody)
+                if self.physics.model.body(bi).name.split("/")[0] == model_name
+            ]
+            body_ids_reindex = [body_ids_origin[i] for i in body_reindex]
             state = RobotState(
                 root_state=torch.concat([
                     torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
@@ -265,7 +277,7 @@ class MujocoHandler(BaseSimHandler):
                             self.physics.data.cvel[body_id],  # (6,)
                         ])
                     ).float()
-                    for body_id in body_reindex
+                    for body_id in body_ids_reindex
                 ]).unsqueeze(0),
                 joint_pos=torch.tensor([
                     self.physics.data.joint(f"{model_name}/{jn}").qpos.item() for jn in joint_names

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -442,7 +442,7 @@ class MujocoHandler(BaseSimHandler):
         sorted_actuator_names = sorted(origin_actuator_names)
         return [origin_actuator_names.index(name) for name in sorted_actuator_names]
 
-    def get_object_body_names(self, obj_name: str) -> list[str]:
+    def get_body_names(self, obj_name: str) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             names = [self.physics.model.body(i).name for i in range(self.physics.model.nbody)]
             names = [name.split("/")[-1] for name in names if name.split("/")[0] == obj_name]

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -7,11 +7,22 @@ import torch
 from dm_control import mjcf
 from loguru import logger as log
 
-from metasim.cfg.objects import PrimitiveCubeCfg, PrimitiveCylinderCfg, PrimitiveSphereCfg
+from metasim.cfg.objects import (
+    ArticulationObjCfg,
+    BaseObjCfg,
+    PrimitiveCubeCfg,
+    PrimitiveCylinderCfg,
+    PrimitiveSphereCfg,
+)
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import TaskType
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
+<<<<<<< HEAD
 from metasim.types import Action
+=======
+from metasim.types import Action, Obs
+from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
+>>>>>>> d832f32 (mujoco replay close_box/stack_cube successful)
 
 
 class MujocoHandler(BaseSimHandler):
@@ -175,67 +186,6 @@ class MujocoHandler(BaseSimHandler):
         self._mujoco_robot_name = robot_xml.full_identifier
         return mjcf_model
 
-    def _get_root_state(self, obj, obj_name):
-        """Get root position, rotation, velocity for an object or robot."""
-        if obj == self._robot:
-            if not self._robot.fix_base_link:
-                root_joint = self.physics.data.joint(self._mujoco_robot_name)
-                return {
-                    "pos": torch.tensor(root_joint.qpos[:3], dtype=torch.float32),
-                    "rot": torch.tensor(root_joint.qpos[3:7], dtype=torch.float32),
-                    "vel": torch.tensor(root_joint.qvel[:3], dtype=torch.float32),
-                    "ang_vel": torch.tensor(root_joint.qvel[3:6], dtype=torch.float32),
-                }
-            else:
-                root_body_id = self.physics.model.body(self._mujoco_robot_name).id
-                return {
-                    "pos": torch.tensor(self.physics.data.xpos[root_body_id], dtype=torch.float32),
-                    "rot": torch.tensor(self.physics.data.xquat[root_body_id], dtype=torch.float32),
-                    "vel": torch.tensor(self.physics.data.cvel[root_body_id][:3], dtype=torch.float32),
-                    "ang_vel": torch.tensor(self.physics.data.cvel[root_body_id][3:6], dtype=torch.float32),
-                }
-        else:
-            model_name = self.mj_objects[obj_name].model + "/"
-            try:
-                obj_joint = self.physics.data.joint(model_name)
-                return {
-                    "pos": torch.tensor(obj_joint.qpos[:3], dtype=torch.float32),
-                    "rot": torch.tensor(obj_joint.qpos[3:7], dtype=torch.float32),
-                    "vel": torch.tensor(obj_joint.qvel[:3], dtype=torch.float32),
-                    "ang_vel": torch.tensor(obj_joint.qvel[3:6], dtype=torch.float32),
-                }
-            except KeyError:
-                obj_body_id = self.physics.model.body(model_name).id
-                return {
-                    "pos": torch.tensor(self.physics.data.xpos[obj_body_id], dtype=torch.float32),
-                    "rot": torch.tensor(self.physics.data.xquat[obj_body_id], dtype=torch.float32),
-                    "vel": torch.tensor(self.physics.data.cvel[obj_body_id][:3], dtype=torch.float32),
-                    "ang_vel": torch.tensor(self.physics.data.cvel[obj_body_id][3:6], dtype=torch.float32),
-                }
-
-    def _get_joint_states(self, obj_name):
-        """Get joint positions and velocities."""
-        joint_states = {"dof_pos": {}, "dof_vel": {}}
-
-        for joint_id in range(self.physics.model.njnt):
-            joint_name = self.physics.model.joint(joint_id).name
-            if joint_name.startswith(f"{obj_name}/") or (
-                obj_name == self._robot.name and joint_name.startswith(self._mujoco_robot_name)
-            ):
-                clean_joint_name = joint_name.split("/")[-1]
-                if clean_joint_name == "":
-                    continue
-                joint = self.physics.data.joint(joint_name)
-
-                if len(joint.qpos.shape) == 0 or joint.qpos.shape == (1,):
-                    joint_states["dof_pos"][clean_joint_name] = joint.qpos.item()
-                    joint_states["dof_vel"][clean_joint_name] = joint.qvel.item()
-                else:  # free joint
-                    joint_states["dof_pos"][clean_joint_name] = torch.tensor(joint.qpos.copy(), dtype=torch.float32)
-                    joint_states["dof_vel"][clean_joint_name] = torch.tensor(joint.qvel.copy(), dtype=torch.float32)
-
-        return joint_states
-
     def _get_actuator_states(self, obj_name):
         """Get actuator states (targets and forces)."""
         actuator_states = {
@@ -258,114 +208,73 @@ class MujocoHandler(BaseSimHandler):
         return actuator_states
 
     def get_states(self, env_ids: list[int] | None = None) -> list[dict]:
-        state = {"objects": {}, "robots": {}, "cameras": {}}
-
-        ## Root states -- for both robot and object
-        for obj in self.objects + [self._robot]:
-            object_type = "robots" if obj == self._robot else "objects"
-            state[object_type][obj.name] = {}
-            state[object_type][obj.name].update(self._get_root_state(obj, obj.name))
-            state[object_type][obj.name].update(self._get_joint_states(obj.name))
-            ## Actuator states -- for robot
-            if obj == self._robot:
-                ## TODO: read from simulator instead of cache
-                state[object_type][obj.name].update(self._get_actuator_states(obj.name))
-                joint_names = [
-                    self.physics.model.joint(joint_id).name.split("/")[-1]
-                    for joint_id in range(self.physics.model.njnt)
-                    if self.physics.model.joint(joint_id).name.startswith(self._mujoco_robot_name)
-                    and len(self.physics.model.joint(joint_id).name.split("/")[-1]) > 0
-                ]
-                if self.actions_cache:
-                    state[object_type][obj.name]["dof_pos_target"] = {
-                        joint_name: self.actions_cache[0]["dof_pos_target"][joint_name] for joint_name in joint_names
-                    }
-                else:
-                    state[object_type][obj.name]["dof_pos_target"] = None
-
-        ## Body states -- for both robot and object
-        object_names = [obj.name for obj in self.objects]
-        robot_names = [self._robot.name]
+        object_states = {}
         for obj in self.objects:
-            state["objects"][obj.name]["body"] = {}
-        for obj in [self._robot]:
-            state["robots"][obj.name]["body"] = {}
-        for body_id in range(self.physics.model.nbody):
-            body = self.physics.model.body(body_id)
-            body_full_name = body.name  # e.g. h1/left_shoulder_pitch_link
-            robot_name_body_belong = body_full_name.split("/")[0]  # e.g. h1
-            body_base_name = body_full_name.split("/")[-1]  # e.g. left_shoulder_pitch_link
-            if robot_name_body_belong in robot_names:
-                state["robots"][robot_name_body_belong]["body"][body_base_name] = {
-                    # Position and orientation in world frame
-                    "pos": torch.tensor(
-                        self.physics.data.xpos[body_id], dtype=torch.float32
-                    ),  # Position in world frame (x,y,z)
-                    "rot": torch.tensor(
-                        self.physics.data.xquat[body_id], dtype=torch.float32
-                    ),  # Orientation in world frame (quaternion)
-                    # Linear and angular velocity in world frame
-                    "vel": torch.tensor(
-                        self.physics.data.cvel[body_id][:3], dtype=torch.float32
-                    ),  # Linear velocity in world frame (x,y,z)
-                    "ang_vel": torch.tensor(
-                        self.physics.data.cvel[body_id][3:6], dtype=torch.float32
-                    ),  # Angular velocity in world frame (x,y,z)
-                    # Contact forces and torques in local frame
-                    "contact_force": torch.tensor(
-                        self.physics.data.cfrc_ext[body_id][:3], dtype=torch.float32
-                    ),  # Contact force in local frame (x,y,z)
-                    "contact_torque": torch.tensor(
-                        self.physics.data.cfrc_ext[body_id][3:6], dtype=torch.float32
-                    ),  # Contact torque in local frame (x,y,z)
-                }
-            elif robot_name_body_belong in object_names:
-                state["objects"][robot_name_body_belong]["body"][body_base_name] = {
-                    # Position and orientation in world frame
-                    "pos": torch.tensor(
-                        self.physics.data.xpos[body_id], dtype=torch.float32
-                    ),  # Position in world frame (x,y,z)
-                    "rot": torch.tensor(
-                        self.physics.data.xquat[body_id], dtype=torch.float32
-                    ),  # Orientation in world frame (quaternion)
-                    # Linear and angular velocity in world frame
-                    "vel": torch.tensor(
-                        self.physics.data.cvel[body_id][:3], dtype=torch.float32
-                    ),  # Linear velocity in world frame (x,y,z)
-                    "ang_vel": torch.tensor(
-                        self.physics.data.cvel[body_id][3:6], dtype=torch.float32
-                    ),  # Angular velocity in world frame (x,y,z)
-                    # Contact forces and torques in local frame
-                    "contact_force": torch.tensor(
-                        self.physics.data.cfrc_ext[body_id][:3], dtype=torch.float32
-                    ),  # Contact force in local frame (x,y,z)
-                    "contact_torque": torch.tensor(
-                        self.physics.data.cfrc_ext[body_id][3:6], dtype=torch.float32
-                    ),  # Contact torque in local frame (x,y,z)
-                }
+            model_name = self.mj_objects[obj.name].model
 
+            obj_body_id = self.physics.model.body(f"{model_name}/").id
+            if isinstance(obj, ArticulationObjCfg):
+                joint_names = sorted(self.get_object_joint_names(obj))
+                state = ObjectState(
+                    root_state=torch.concat([
+                        torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
+                        torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
+                        torch.from_numpy(self.physics.data.cvel[obj_body_id]).float(),  # (6,)
+                    ]).unsqueeze(0),
+                    joint_pos=torch.tensor([
+                        self.physics.data.joint(f"{model_name}/{jn}").qpos.item() for jn in joint_names
+                    ]).unsqueeze(0),
+                    joint_vel=torch.tensor([
+                        self.physics.data.joint(f"{model_name}/{jn}").qvel.item() for jn in joint_names
+                    ]).unsqueeze(0),
+                )
+            else:
+                state = ObjectState(
+                    root_state=torch.concat([
+                        torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
+                        torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
+                        torch.from_numpy(self.physics.data.cvel[obj_body_id]).float(),  # (6,)
+                    ]).unsqueeze(0),
+                )
+            object_states[obj.name] = state
+
+        robot_states = {}
+        for robot in [self.robot]:
+            assert self.mj_objects[robot.name].model == robot.name
+            model_name = self.mj_objects[robot.name].model
+            obj_body_id = self.physics.model.body(f"{model_name}/").id
+            joint_names = sorted(self.get_object_joint_names(robot))
+            state = RobotState(
+                root_state=torch.concat([
+                    torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
+                    torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
+                    torch.from_numpy(self.physics.data.cvel[obj_body_id]).float(),  # (6,)
+                ]).unsqueeze(0),
+                joint_pos=torch.tensor([
+                    self.physics.data.joint(f"{model_name}/{jn}").qpos.item() for jn in joint_names
+                ]).unsqueeze(0),
+                joint_vel=torch.tensor([
+                    self.physics.data.joint(f"{model_name}/{jn}").qvel.item() for jn in joint_names
+                ]).unsqueeze(0),
+                joint_pos_target=None,  # TODO
+                joint_vel_target=None,  # TODO
+                joint_effort_target=None,  # TODO
+            )
+
+        camera_states = {}
         for camera in self.cameras:
             camera_id = f"{camera.name}_custom"  # XXX: hard code camera id for now
-            state["cameras"][camera.name] = {}
-
+            camera_states[camera.name] = {}
             if "rgb" in camera.data_types:
-                rgb_img = self.physics.render(
-                    width=camera.width,
-                    height=camera.height,
-                    camera_id=camera_id,
-                    depth=False,
-                )
-                state["cameras"][camera.name].update({"rgb": torch.from_numpy(rgb_img.copy())})
+                rgb = self.physics.render(width=camera.width, height=camera.height, camera_id=camera_id, depth=False)
+                rgb = torch.from_numpy(rgb.copy()).unsqueeze(0)
             if "depth" in camera.data_types:
-                depth_img = self.physics.render(
-                    width=camera.width,
-                    height=camera.height,
-                    camera_id=camera_id,
-                    depth=True,
-                )
-                state["cameras"][camera.name].update({"depth": torch.from_numpy(depth_img.copy())})
+                depth = self.physics.render(width=camera.width, height=camera.height, camera_id=camera_id, depth=True)
+                depth = torch.from_numpy(depth.copy()).unsqueeze(0)
+            state = CameraState(rgb=rgb, depth=depth)
+            camera_states[camera.name] = state
 
-        return [state]
+        return TensorState(objects=object_states, robots=robot_states, cameras=camera_states)
 
     def _set_root_state(self, obj_name, obj_state, zero_vel=False):
         """Set root position and rotation."""
@@ -465,6 +374,30 @@ class MujocoHandler(BaseSimHandler):
     def close(self):
         if self.viewer is not None:
             self.viewer.close()
+
+    ############################################################
+    ## Utils
+    ############################################################
+    def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
+        """Get the joint names for a specified object in the order of the simulator default joint order.
+
+        Args:
+            object (BaseObjCfg): The target object.
+
+        Returns:
+            list[str]: A list of strings including the joint names. For non-articulation objects, return an empty list.
+        """
+        if isinstance(object, ArticulationObjCfg):
+            joint_names = [
+                self.physics.model.joint(joint_id).name
+                for joint_id in range(self.physics.model.njnt)
+                if self.physics.model.joint(joint_id).name.startswith(object.name + "/")
+            ]
+            joint_names = [name.split("/")[-1] for name in joint_names]
+            joint_names = [name for name in joint_names if name != ""]
+            return joint_names
+        else:
+            return []
 
     ############################################################
     ## Misc

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -237,7 +237,6 @@ class MujocoHandler(BaseSimHandler):
 
         robot_states = {}
         for robot in [self.robot]:
-            assert self.mj_objects[robot.name].model == robot.name
             model_name = self.mj_objects[robot.name].model
             obj_body_id = self.physics.model.body(f"{model_name}/").id
             joint_names = sorted(self.get_object_joint_names(robot))

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -221,6 +221,7 @@ class MujocoHandler(BaseSimHandler):
                         torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
                         torch.from_numpy(self.physics.data.cvel[obj_body_id]).float(),  # (6,)
                     ]).unsqueeze(0),
+                    body_state=None,  # TODO
                     joint_pos=torch.tensor([
                         self.physics.data.joint(f"{model_name}/{jn}").qpos.item() for jn in joint_names
                     ]).unsqueeze(0),
@@ -250,6 +251,7 @@ class MujocoHandler(BaseSimHandler):
                     torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
                     torch.from_numpy(self.physics.data.cvel[obj_body_id]).float(),  # (6,)
                 ]).unsqueeze(0),
+                body_state=None,  # TODO
                 joint_pos=torch.tensor([
                     self.physics.data.joint(f"{model_name}/{jn}").qpos.item() for jn in joint_names
                 ]).unsqueeze(0),
@@ -260,6 +262,7 @@ class MujocoHandler(BaseSimHandler):
                 joint_vel_target=None,  # TODO
                 joint_effort_target=None,  # TODO
             )
+            robot_states[robot.name] = state
 
         camera_states = {}
         for camera in self.cameras:

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -411,14 +411,6 @@ class MujocoHandler(BaseSimHandler):
     ## Utils
     ############################################################
     def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
-        """Get the joint names for a specified object in the order of the simulator default joint order.
-
-        Args:
-            object (BaseObjCfg): The target object.
-
-        Returns:
-            list[str]: A list of strings including the joint names. For non-articulation objects, return an empty list.
-        """
         if isinstance(object, ArticulationObjCfg):
             joint_names = [
                 self.physics.model.joint(joint_id).name

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -321,7 +321,7 @@ class SinglePybulletHandler(BaseSimHandler):
             ang_vel = torch.zeros_like(pos)  # TODO
             root_state = torch.cat([pos, rot, lin_vel, ang_vel]).unsqueeze(0)
             if isinstance(obj, ArticulationObjCfg):
-                joint_reindex = self.get_object_joint_reindex(obj.name)
+                joint_reindex = self.get_joint_reindex(obj.name)
                 state = ObjectState(
                     root_state=root_state,
                     body_state=None,  # TODO
@@ -334,7 +334,7 @@ class SinglePybulletHandler(BaseSimHandler):
 
         robot_states = {}
         for robot in [self.robot]:
-            joint_reindex = self.get_object_joint_reindex(robot.name)
+            joint_reindex = self.get_joint_reindex(robot.name)
             obj_id = self.object_ids[robot.name]
             pos, rot = p.getBasePositionAndOrientation(obj_id)
             pos = torch.tensor(pos, dtype=torch.float32)

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -324,6 +324,7 @@ class SinglePybulletHandler(BaseSimHandler):
                 joint_reindex = self.get_object_joint_reindex(obj.name)
                 state = ObjectState(
                     root_state=root_state,
+                    body_state=None,  # TODO
                     joint_pos=torch.tensor([p.getJointState(obj_id, i)[0] for i in joint_reindex]).unsqueeze(0),
                     joint_vel=torch.tensor([p.getJointState(obj_id, i)[1] for i in joint_reindex]).unsqueeze(0),
                 )
@@ -343,6 +344,7 @@ class SinglePybulletHandler(BaseSimHandler):
             root_state = torch.cat([pos, rot, lin_vel, ang_vel]).unsqueeze(0)
             state = RobotState(
                 root_state=root_state,
+                body_state=None,  # TODO
                 joint_pos=torch.tensor([p.getJointState(obj_id, i)[0] for i in joint_reindex]).unsqueeze(0),
                 joint_vel=torch.tensor([p.getJointState(obj_id, i)[1] for i in joint_reindex]).unsqueeze(0),
                 joint_pos_target=None,  # TODO

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -14,13 +14,13 @@ import pybullet as p
 import pybullet_data
 import torch
 
-from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
+from metasim.cfg.objects import ArticulationObjCfg, BaseObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
-from metasim.sim.parallel import ParallelSimWrapper
 from metasim.types import Action, EnvState
 from metasim.utils.math import convert_quat
+from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
 
 
 class SinglePybulletHandler(BaseSimHandler):
@@ -311,33 +311,47 @@ class SinglePybulletHandler(BaseSimHandler):
         """
         # For multi-env version, rewrite this function
 
-        states = {"objects": {}, "robots": {}, "cameras": {}}
-        for name, obj_id in self.object_ids.items():
-            object_type = "robots" if name == self.robot.name else "objects"
+        object_states = {}
+        for obj in self.objects:
+            obj_id = self.object_ids[obj.name]
             pos, rot = p.getBasePositionAndOrientation(obj_id)
             pos = torch.tensor(pos, dtype=torch.float32)
             rot = torch.tensor(rot, dtype=torch.float32)
-            states[object_type][name] = {"pos": pos, "rot": rot}
-            if isinstance(self.object_dict[name], ArticulationObjCfg):
-                states[object_type][name]["dof_pos"] = {}
-                states[object_type][name]["dof_vel"] = {}
-                joint_names = self.object_joint_order[name]
-                for i, joint_name in enumerate(joint_names):
-                    joint_state = p.getJointState(obj_id, i)
-                    states[object_type][name]["dof_pos"][joint_name] = joint_state[0]
-                    states[object_type][name]["dof_vel"][joint_name] = joint_state[1]
+            lin_vel = torch.zeros_like(pos)  # TODO
+            ang_vel = torch.zeros_like(pos)  # TODO
+            root_state = torch.cat([pos, rot, lin_vel, ang_vel]).unsqueeze(0)
+            if isinstance(obj, ArticulationObjCfg):
+                joint_reindex = self.get_object_joint_reindex(obj.name)
+                state = ObjectState(
+                    root_state=root_state,
+                    joint_pos=torch.tensor([p.getJointState(obj_id, i)[0] for i in joint_reindex]).unsqueeze(0),
+                    joint_vel=torch.tensor([p.getJointState(obj_id, i)[1] for i in joint_reindex]).unsqueeze(0),
+                )
+            else:
+                state = ObjectState(root_state=root_state)
+            object_states[obj.name] = state
 
-            ## Actions -- for robot
-            ## TODO: read from simulator instead of cache
-            if isinstance(self.object_dict[name], BaseRobotCfg):
-                joint_names = self.object_joint_order[name]
-                if self.actions_cache:
-                    states[object_type][name]["dof_pos_target"] = {
-                        joint_name: self.actions_cache[0]["dof_pos_target"][joint_name] for joint_name in joint_names
-                    }
-                else:
-                    states[object_type][name]["dof_pos_target"] = None
+        robot_states = {}
+        for robot in [self.robot]:
+            joint_reindex = self.get_object_joint_reindex(robot.name)
+            obj_id = self.object_ids[robot.name]
+            pos, rot = p.getBasePositionAndOrientation(obj_id)
+            pos = torch.tensor(pos, dtype=torch.float32)
+            rot = torch.tensor(rot, dtype=torch.float32)
+            lin_vel = torch.zeros_like(pos)  # TODO
+            ang_vel = torch.zeros_like(pos)  # TODO
+            root_state = torch.cat([pos, rot, lin_vel, ang_vel]).unsqueeze(0)
+            state = RobotState(
+                root_state=root_state,
+                joint_pos=torch.tensor([p.getJointState(obj_id, i)[0] for i in joint_reindex]).unsqueeze(0),
+                joint_vel=torch.tensor([p.getJointState(obj_id, i)[1] for i in joint_reindex]).unsqueeze(0),
+                joint_pos_target=None,  # TODO
+                joint_vel_target=None,  # TODO
+                joint_effort_target=None,  # TODO
+            )
+            robot_states[robot.name] = state
 
+        camera_states = {}
         for camera in self.cameras:
             width, height, view_matrix, projection_matrix = self.camera_ids[camera.name]
             img_arr = p.getCameraImage(
@@ -350,17 +364,22 @@ class SinglePybulletHandler(BaseSimHandler):
             rgb_img = np.reshape(img_arr[2], (height, width, 4))
             depth_img = np.reshape(img_arr[3], (height, width))
             segmentation_mask = np.reshape(img_arr[4], (height, width))
-            states["cameras"][camera.name] = {
-                "rgb": torch.from_numpy(rgb_img[:, :, :3]),
-            }
+            state = CameraState(
+                rgb=torch.from_numpy(rgb_img[:, :, :3]).unsqueeze(0),
+                depth=torch.from_numpy(depth_img).unsqueeze(0),
+            )
+            camera_states[camera.name] = state
 
-        return [states]
+        return TensorState(objects=object_states, robots=robot_states, cameras=camera_states)
 
     ############################################################
     ## Utils
     ############################################################
-    def get_object_joint_names(self, object):
-        return self.object_joint_order[object.name]
+    def get_object_joint_names(self, obj: BaseObjCfg) -> list[str]:
+        if isinstance(obj, ArticulationObjCfg):
+            return self.object_joint_order[obj.name]
+        else:
+            return []
 
     @property
     def actions_cache(self) -> list[Action]:
@@ -371,6 +390,6 @@ class SinglePybulletHandler(BaseSimHandler):
         return torch.device("cpu")
 
 
-PybulletHandler = ParallelSimWrapper(SinglePybulletHandler)
+PybulletHandler = SinglePybulletHandler  # TODO: support parallel
 
 PybulletEnv: type[EnvWrapper[PybulletHandler]] = GymEnvWrapper(PybulletHandler)  # type: ignore

--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -361,6 +361,7 @@ class SingleSapienHandler(BaseSimHandler):
                 joint_reindex = self.get_object_joint_reindex(obj.name)
                 state = ObjectState(
                     root_state=root_state,
+                    body_state=None,  # TODO
                     joint_pos=torch.tensor(obj_inst.get_qpos()[joint_reindex]).unsqueeze(0),
                     joint_vel=torch.tensor(obj_inst.get_qvel()[joint_reindex]).unsqueeze(0),
                 )
@@ -381,6 +382,7 @@ class SingleSapienHandler(BaseSimHandler):
             joint_reindex = self.get_object_joint_reindex(robot.name)
             state = RobotState(
                 root_state=root_state,
+                body_state=None,  # TODO
                 joint_pos=torch.tensor(robot_inst.get_qpos()[joint_reindex]).unsqueeze(0),
                 joint_vel=torch.tensor(robot_inst.get_qvel()[joint_reindex]).unsqueeze(0),
                 joint_pos_target=None,  # TODO

--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -18,6 +18,7 @@ from sapien.utils import Viewer
 
 from metasim.cfg.objects import (
     ArticulationObjCfg,
+    BaseObjCfg,
     NonConvexRigidObjCfg,
     PrimitiveCubeCfg,
     PrimitiveSphereCfg,
@@ -28,6 +29,7 @@ from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.sim.parallel import ParallelSimWrapper
 from metasim.types import EnvState
 from metasim.utils.math import quat_from_euler_np
+from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
 
 
 class SingleSapienHandler(BaseSimHandler):
@@ -344,34 +346,61 @@ class SingleSapienHandler(BaseSimHandler):
         Returns:
             dict: A dictionary containing the states of the environment
         """
-        states = {"objects": {}, "robots": {}, "cameras": {}}
-        for obj_name, obj_id in self.object_ids.items():
-            object_type = "robots" if obj_name == self.robot.name else "objects"
-            states[object_type][obj_name] = {}
-            if isinstance(obj_id, sapien_core.Articulation):
-                dof_pos = obj_id.get_qpos()
-                dof_vel = obj_id.get_qvel()
-                states[object_type][obj_name]["dof_pos"] = {
-                    name: dof_pos[id] for id, name in enumerate(self.object_joint_order[obj_name])
-                }
-                states[object_type][obj_name]["dof_vel"] = {
-                    name: dof_vel[id] for id, name in enumerate(self.object_joint_order[obj_name])
-                }
-            pose = obj_id.get_pose()
-            states[object_type][obj_name].update({
-                "pos": torch.tensor(pose.p, dtype=torch.float32),
-                "rot": torch.tensor(pose.q, dtype=torch.float32),
-            })
 
-        states["cameras"] = {}
+        object_states = {}
+        for obj in self.objects:
+            obj_inst = self.object_ids[obj.name]
+            pose = obj_inst.get_pose()
+            pos = torch.tensor(pose.p)
+            rot = torch.tensor(pose.q)
+            vel = torch.zeros_like(pos)  # TODO
+            ang_vel = torch.zeros_like(pos)  # TODO
+            root_state = torch.cat([pos, rot, vel, ang_vel], dim=-1).unsqueeze(0)
+            if isinstance(obj, ArticulationObjCfg):
+                assert isinstance(obj_inst, sapien_core.Articulation)
+                joint_reindex = self.get_object_joint_reindex(obj.name)
+                state = ObjectState(
+                    root_state=root_state,
+                    joint_pos=torch.tensor(obj_inst.get_qpos()[joint_reindex]).unsqueeze(0),
+                    joint_vel=torch.tensor(obj_inst.get_qvel()[joint_reindex]).unsqueeze(0),
+                )
+            else:
+                state = ObjectState(root_state=root_state)
+            object_states[obj.name] = state
 
-        for camera_name, camera_id in self.camera_ids.items():
-            color_img = camera_id.get_float_texture("Color")[..., :3]
-            color_img = (color_img * 255).clip(0, 255).astype("uint8")
-            depth_img = -camera_id.get_float_texture("Position")[..., 2]
-            states["cameras"][camera_name] = {"rgb": torch.from_numpy(color_img)}
+        robot_states = {}
+        for robot in [self.robot]:
+            robot_inst = self.object_ids[robot.name]
+            assert isinstance(robot_inst, sapien_core.Articulation)
+            pose = robot_inst.get_pose()
+            pos = torch.tensor(pose.p)
+            rot = torch.tensor(pose.q)
+            vel = torch.zeros_like(pos)  # TODO
+            ang_vel = torch.zeros_like(pos)  # TODO
+            root_state = torch.cat([pos, rot, vel, ang_vel], dim=-1).unsqueeze(0)
+            joint_reindex = self.get_object_joint_reindex(robot.name)
+            state = RobotState(
+                root_state=root_state,
+                joint_pos=torch.tensor(robot_inst.get_qpos()[joint_reindex]).unsqueeze(0),
+                joint_vel=torch.tensor(robot_inst.get_qvel()[joint_reindex]).unsqueeze(0),
+                joint_pos_target=None,  # TODO
+                joint_vel_target=None,  # TODO
+                joint_effort_target=None,  # TODO
+            )
+            robot_states[robot.name] = state
 
-        return [states]
+        camera_states = {}
+        for camera in self.cameras:
+            cam_inst = self.camera_ids[camera.name]
+            rgb = cam_inst.get_float_texture("Color")[..., :3]
+            rgb = (rgb * 255).clip(0, 255).astype("uint8")
+            rgb = torch.from_numpy(rgb.copy())
+            depth = -cam_inst.get_float_texture("Position")[..., 2]
+            depth = torch.from_numpy(depth.copy())
+            state = CameraState(rgb=rgb.unsqueeze(0), depth=depth.unsqueeze(0))
+            camera_states[camera.name] = state
+
+        return TensorState(objects=object_states, robots=robot_states, cameras=camera_states)
 
     def set_states(self, states, env_ids=None):
         """Set the states of the environment.
@@ -403,6 +432,12 @@ class SingleSapienHandler(BaseSimHandler):
     @property
     def device(self) -> torch.device:
         return torch.device("cpu")
+
+    def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
+        if isinstance(object, ArticulationObjCfg):
+            return self.object_joint_order[object.name]
+        else:
+            return []
 
 
 SapienHandler = ParallelSimWrapper(SingleSapienHandler)

--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -358,7 +358,7 @@ class SingleSapienHandler(BaseSimHandler):
             root_state = torch.cat([pos, rot, vel, ang_vel], dim=-1).unsqueeze(0)
             if isinstance(obj, ArticulationObjCfg):
                 assert isinstance(obj_inst, sapien_core.Articulation)
-                joint_reindex = self.get_object_joint_reindex(obj.name)
+                joint_reindex = self.get_joint_reindex(obj.name)
                 state = ObjectState(
                     root_state=root_state,
                     body_state=None,  # TODO
@@ -379,7 +379,7 @@ class SingleSapienHandler(BaseSimHandler):
             vel = torch.zeros_like(pos)  # TODO
             ang_vel = torch.zeros_like(pos)  # TODO
             root_state = torch.cat([pos, rot, vel, ang_vel], dim=-1).unsqueeze(0)
-            joint_reindex = self.get_object_joint_reindex(robot.name)
+            joint_reindex = self.get_joint_reindex(robot.name)
             state = RobotState(
                 root_state=root_state,
                 body_state=None,  # TODO

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -19,6 +19,7 @@ from sapien.utils import Viewer
 
 from metasim.cfg.objects import (
     ArticulationObjCfg,
+    BaseObjCfg,
     NonConvexRigidObjCfg,
     PrimitiveCubeCfg,
     PrimitiveSphereCfg,
@@ -29,6 +30,7 @@ from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.sim.parallel import ParallelSimWrapper
 from metasim.types import Action, EnvState
 from metasim.utils.math import quat_from_euler_np
+from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
 
 
 class SingleSapien3Handler(BaseSimHandler):
@@ -365,42 +367,61 @@ class SingleSapien3Handler(BaseSimHandler):
         Returns:
             dict: A dictionary containing the states of the environment
         """
-        states = {"objects": {}, "robots": {}, "cameras": {}}
-        for obj_name, obj_id in self.object_ids.items():
-            object_type = "robots" if obj_name == self.robot.name else "objects"
-            states[object_type][obj_name] = {}
-            if isinstance(obj_id, sapien_core.physx.PhysxArticulation):
-                dof_pos = obj_id.get_qpos()
-                dof_vel = obj_id.get_qvel()
-                states[object_type][obj_name]["dof_pos"] = {
-                    name: dof_pos[id] for id, name in enumerate(self.object_joint_order[obj_name])
-                }
-            if obj_name == self.robot.name:
-                ## TODO: read from simulator instead of cache
-                if self.actions_cache:
-                    states[object_type][obj_name]["dof_pos_target"] = {
-                        name: self.actions_cache[0]["dof_pos_target"][name]
-                        for name in self.object_joint_order[obj_name]
-                    }
-                else:
-                    states[object_type][obj_name]["dof_pos_target"] = None
+
+        object_states = {}
+        for obj in self.objects:
+            obj_inst = self.object_ids[obj.name]
+            pose = obj_inst.get_pose()
+            pos = torch.tensor(pose.p)
+            rot = torch.tensor(pose.q)
+            vel = torch.zeros_like(pos)  # TODO
+            ang_vel = torch.zeros_like(pos)  # TODO
+            root_state = torch.cat([pos, rot, vel, ang_vel], dim=-1).unsqueeze(0)
+            if isinstance(obj, ArticulationObjCfg):
+                assert isinstance(obj_inst, sapien_core.physx.PhysxArticulation)
+                joint_reindex = self.get_object_joint_reindex(obj.name)
+                state = ObjectState(
+                    root_state=root_state,
+                    joint_pos=torch.tensor(obj_inst.get_qpos()[joint_reindex]).unsqueeze(0),
+                    joint_vel=torch.tensor(obj_inst.get_qvel()[joint_reindex]).unsqueeze(0),
+                )
             else:
-                states[object_type][obj_name]["dof_pos_target"] = None
-            pose = obj_id.get_pose()
-            states[object_type][obj_name].update({
-                "pos": torch.tensor(pose.p),
-                "rot": torch.tensor(pose.q),
-            })
+                state = ObjectState(root_state=root_state)
+            object_states[obj.name] = state
 
-        states["cameras"] = {}
+        robot_states = {}
+        for robot in [self.robot]:
+            robot_inst = self.object_ids[robot.name]
+            assert isinstance(robot_inst, sapien_core.physx.PhysxArticulation)
+            pose = robot_inst.get_pose()
+            pos = torch.tensor(pose.p)
+            rot = torch.tensor(pose.q)
+            vel = torch.zeros_like(pos)  # TODO
+            ang_vel = torch.zeros_like(pos)  # TODO
+            root_state = torch.cat([pos, rot, vel, ang_vel], dim=-1).unsqueeze(0)
+            joint_reindex = self.get_object_joint_reindex(robot.name)
+            state = RobotState(
+                root_state=root_state,
+                joint_pos=torch.tensor(robot_inst.get_qpos()[joint_reindex]).unsqueeze(0),
+                joint_vel=torch.tensor(robot_inst.get_qvel()[joint_reindex]).unsqueeze(0),
+                joint_pos_target=None,  # TODO
+                joint_vel_target=None,  # TODO
+                joint_effort_target=None,  # TODO
+            )
+            robot_states[robot.name] = state
 
-        for camera_name, camera_id in self.camera_ids.items():
-            color_img = camera_id.get_picture("Color")[..., :3]
-            color_img = (color_img * 255).clip(0, 255).astype("uint8")
-            depth_img = -camera_id.get_picture("Position")[..., 2]
-            states["cameras"][camera_name] = {"rgb": torch.from_numpy(color_img)}
+        camera_states = {}
+        for camera in self.cameras:
+            cam_inst = self.camera_ids[camera.name]
+            rgb = cam_inst.get_picture("Color")[..., :3]
+            rgb = (rgb * 255).clip(0, 255).astype("uint8")
+            rgb = torch.from_numpy(rgb.copy())
+            depth = -cam_inst.get_picture("Position")[..., 2]
+            depth = torch.from_numpy(depth.copy())
+            state = CameraState(rgb=rgb.unsqueeze(0), depth=depth.unsqueeze(0))
+            camera_states[camera.name] = state
 
-        return [states]
+        return TensorState(objects=object_states, robots=robot_states, cameras=camera_states)
 
     def refresh_render(self):
         """Refresh the render."""
@@ -442,6 +463,12 @@ class SingleSapien3Handler(BaseSimHandler):
     @property
     def device(self) -> torch.device:
         return torch.device("cpu")
+
+    def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
+        if isinstance(object, ArticulationObjCfg):
+            return self.object_joint_order[object.name]
+        else:
+            return []
 
 
 Sapien3Handler = ParallelSimWrapper(SingleSapien3Handler)

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -379,7 +379,7 @@ class SingleSapien3Handler(BaseSimHandler):
             root_state = torch.cat([pos, rot, vel, ang_vel], dim=-1).unsqueeze(0)
             if isinstance(obj, ArticulationObjCfg):
                 assert isinstance(obj_inst, sapien_core.physx.PhysxArticulation)
-                joint_reindex = self.get_object_joint_reindex(obj.name)
+                joint_reindex = self.get_joint_reindex(obj.name)
                 state = ObjectState(
                     root_state=root_state,
                     body_state=None,  # TODO
@@ -400,7 +400,7 @@ class SingleSapien3Handler(BaseSimHandler):
             vel = torch.zeros_like(pos)  # TODO
             ang_vel = torch.zeros_like(pos)  # TODO
             root_state = torch.cat([pos, rot, vel, ang_vel], dim=-1).unsqueeze(0)
-            joint_reindex = self.get_object_joint_reindex(robot.name)
+            joint_reindex = self.get_joint_reindex(robot.name)
             state = RobotState(
                 root_state=root_state,
                 body_state=None,  # TODO

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -382,6 +382,7 @@ class SingleSapien3Handler(BaseSimHandler):
                 joint_reindex = self.get_object_joint_reindex(obj.name)
                 state = ObjectState(
                     root_state=root_state,
+                    body_state=None,  # TODO
                     joint_pos=torch.tensor(obj_inst.get_qpos()[joint_reindex]).unsqueeze(0),
                     joint_vel=torch.tensor(obj_inst.get_qvel()[joint_reindex]).unsqueeze(0),
                 )
@@ -402,6 +403,7 @@ class SingleSapien3Handler(BaseSimHandler):
             joint_reindex = self.get_object_joint_reindex(robot.name)
             state = RobotState(
                 root_state=root_state,
+                body_state=None,  # TODO
                 joint_pos=torch.tensor(robot_inst.get_qpos()[joint_reindex]).unsqueeze(0),
                 joint_vel=torch.tensor(robot_inst.get_qvel()[joint_reindex]).unsqueeze(0),
                 joint_pos_target=None,  # TODO

--- a/metasim/utils/humanoid_robot_util.py
+++ b/metasim/utils/humanoid_robot_util.py
@@ -60,7 +60,11 @@ def torso_vertical_orientation(envstate, robot_name: str):
 
 def actuator_forces(envstate, robot_name: str):
     """Returns a copy of the forces applied by the actuators."""
-    return torch.tensor([(x if x is not None else 0) for x in envstate["robots"][robot_name]["dof_torque"].values()])
+    return (
+        torch.tensor([x for x in envstate["robots"][robot_name]["dof_torque"].values()])
+        if envstate["robots"][robot_name].get("dof_torque", None) is not None
+        else torch.zeros(len(envstate["robots"][robot_name]["dof_pos"]))
+    )
 
 
 def left_hand_position(envstate, robot_name: str):

--- a/metasim/utils/save_util/save_util_v2.py
+++ b/metasim/utils/save_util/save_util_v2.py
@@ -98,7 +98,7 @@ def save_demo_v2(save_dir: str, demo: list[EnvState]):
         ee_pos = robot_state["pos"]
         ee_rot = robot_state["rot"]
         last_joint_pos = robot_state["dof_pos"][sorted(robot_state["dof_pos"].keys())[-1]]
-        robot_ee_state = torch.cat([ee_pos, ee_rot, torch.tensor([last_joint_pos])]).tolist()
+        robot_ee_state = torch.cat([ee_pos, ee_rot, torch.tensor([last_joint_pos], device=ee_pos.device)]).tolist()
         jsondata["robot_ee_state"].append(robot_ee_state)
 
         # Set robot_ee_state_target

--- a/metasim/utils/save_util/save_util_v2.py
+++ b/metasim/utils/save_util/save_util_v2.py
@@ -82,14 +82,20 @@ def save_demo_v2(save_dir: str, demo: list[EnvState]):
         jsondata["joint_qpos"].append([robot_state["dof_pos"][k] for k in sorted(robot_state["dof_pos"].keys())])
 
         # For targets, handle them in the same way as the original function
-        if i < len(demo) - 1:
-            next_robot_state = demo[i + 1]["robots"][robot_name]
-            target_dof_pos = [
-                next_robot_state["dof_pos_target"][k] for k in sorted(next_robot_state["dof_pos_target"].keys())
-            ]
+        ## XXX
+        if next(iter(demo[0]["robots"].values())).get("dof_pos_target", None) is not None:
+            if i < len(demo) - 1:
+                next_robot_state = demo[i + 1]["robots"][robot_name]
+                target_dof_pos = [
+                    next_robot_state["dof_pos_target"][k] for k in sorted(next_robot_state["dof_pos_target"].keys())
+                ]
+            else:
+                # For the last timestep, use the same target as the current state
+                target_dof_pos = [
+                    robot_state["dof_pos_target"][k] for k in sorted(robot_state["dof_pos_target"].keys())
+                ]
         else:
-            # For the last timestep, use the same target as the current state
-            target_dof_pos = [robot_state["dof_pos_target"][k] for k in sorted(robot_state["dof_pos_target"].keys())]
+            target_dof_pos = None
 
         jsondata["joint_qpos_target"].append(target_dof_pos)
 

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 from itertools import chain
 
 import torch
+from loguru import logger as log
 
 from metasim.types import EnvState
 
@@ -93,6 +94,10 @@ def _body_tensor_to_dict(body_tensor: torch.Tensor, body_names: list[str]) -> di
 
 def tensor_state_to_env_states(handler: BaseSimHandler, tensor_state: TensorState) -> list[EnvState]:
     """Convert a tensor state to a list of env states. All the tensors will be converted to cpu for compatibility."""
+    log.warning(
+        "Users please ignore this message, we are working on it. For developers: You are using the very inefficient function to convert the tensorized states to old nested states. Please consider not using this function and optimize your code when number of environments is large."
+    )
+
     num_envs = next(iter(chain(tensor_state.objects.values(), tensor_state.robots.values()))).root_state.shape[0]
     env_states = []
     for env_id in range(num_envs):

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -110,7 +110,7 @@ def tensor_state_to_env_states(handler: BaseSimHandler, tensor_state: TensorStat
                 "ang_vel": obj_state.root_state[env_id, 10:13].cpu(),
             }
             if obj_state.body_state is not None:
-                bns = handler.get_object_body_names(obj_name)
+                bns = handler.get_body_names(obj_name)
                 object_states[obj_name]["body"] = _body_tensor_to_dict(obj_state.body_state[env_id], bns)
             if obj_state.joint_pos is not None:
                 jns = handler.get_object_joint_names(handler.object_dict[obj_name])
@@ -146,7 +146,7 @@ def tensor_state_to_env_states(handler: BaseSimHandler, tensor_state: TensorStat
                 else None
             )
             if robot_state.body_state is not None:
-                bns = handler.get_object_body_names(robot_name)
+                bns = handler.get_body_names(robot_name)
                 robot_states[robot_name]["body"] = _body_tensor_to_dict(robot_state.body_state[env_id], bns)
 
         camera_states = {}

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -21,10 +21,12 @@ class ObjectState:
 
     root_state: torch.Tensor
     """Root state ``[pos, quat, lin_vel, ang_vel]``. Shape is (num_envs, 13)."""
+    body_state: torch.Tensor | None = None
+    """Body state ``[pos, quat, lin_vel, ang_vel]``. Shape is (num_envs, num_bodies, 13). This is only available for articulation objects."""
     joint_pos: torch.Tensor | None = None
-    """Joint positions. Shape is (num_envs, num_joints)."""
+    """Joint positions. Shape is (num_envs, num_joints). This is only available for articulation objects."""
     joint_vel: torch.Tensor | None = None
-    """Joint velocities. Shape is (num_envs, num_joints)."""
+    """Joint velocities. Shape is (num_envs, num_joints). This is only available for articulation objects."""
 
 
 @dataclass
@@ -33,6 +35,8 @@ class RobotState:
 
     root_state: torch.Tensor
     """Root state ``[pos, quat, lin_vel, ang_vel]``. Shape is (num_envs, 13)."""
+    body_state: torch.Tensor
+    """Body state ``[pos, quat, lin_vel, ang_vel]``. Shape is (num_envs, num_bodies, 13)."""
     joint_pos: torch.Tensor
     """Joint positions. Shape is (num_envs, num_joints)."""
     joint_vel: torch.Tensor

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -92,7 +92,7 @@ def _body_tensor_to_dict(body_tensor: torch.Tensor, body_names: list[str]) -> di
     }
 
 
-def tensor_state_to_env_states(handler: BaseSimHandler, tensor_state: TensorState) -> list[EnvState]:
+def state_tensor_to_nested(handler: BaseSimHandler, tensor_state: TensorState) -> list[EnvState]:
     """Convert a tensor state to a list of env states. All the tensors will be converted to cpu for compatibility."""
     log.warning(
         "Users please ignore this message, we are working on it. For developers: You are using the very inefficient function to convert the tensorized states to old nested states. Please consider not using this function and optimize your code when number of environments is large."

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -121,7 +121,6 @@ def tensor_state_to_env_states(handler: BaseSimHandler, tensor_state: TensorStat
 
         robot_states = {}
         for robot_name, robot_state in tensor_state.robots.items():
-            bns = handler.get_object_body_names(robot_name)
             jns = handler.get_object_joint_names(handler.object_dict[robot_name])
             robot_states[robot_name] = {
                 "pos": robot_state.root_state[env_id, :3].cpu(),
@@ -129,7 +128,6 @@ def tensor_state_to_env_states(handler: BaseSimHandler, tensor_state: TensorStat
                 "vel": robot_state.root_state[env_id, 7:10].cpu(),
                 "ang_vel": robot_state.root_state[env_id, 10:13].cpu(),
             }
-            robot_states[robot_name]["body"] = _body_tensor_to_dict(robot_state.body_state[env_id], bns)
             robot_states[robot_name]["dof_pos"] = _dof_tensor_to_dict(robot_state.joint_pos[env_id], jns)
             robot_states[robot_name]["dof_vel"] = _dof_tensor_to_dict(robot_state.joint_vel[env_id], jns)
             robot_states[robot_name]["dof_pos_target"] = (
@@ -147,6 +145,9 @@ def tensor_state_to_env_states(handler: BaseSimHandler, tensor_state: TensorStat
                 if robot_state.joint_effort_target is not None
                 else None
             )
+            if hasattr(handler, "get_object_body_names"):
+                bns = handler.get_object_body_names(robot_name)
+                robot_states[robot_name]["body"] = _body_tensor_to_dict(robot_state.body_state[env_id], bns)
 
         camera_states = {}
         for camera_name, camera_state in tensor_state.cameras.items():

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -7,8 +7,12 @@ from itertools import chain
 
 import torch
 
-from metasim.sim.base import BaseSimHandler
 from metasim.types import EnvState
+
+try:
+    from metasim.sim.base import BaseSimHandler
+except:
+    pass
 
 
 @dataclass
@@ -100,9 +104,21 @@ def tensor_state_to_env_states(handler: BaseSimHandler, tensor_state: TensorStat
             }
             robot_states[robot_name]["dof_pos"] = _dof_tensor_to_dict(robot_state.joint_pos[env_id], jns)
             robot_states[robot_name]["dof_vel"] = _dof_tensor_to_dict(robot_state.joint_vel[env_id], jns)
-            robot_states[robot_name]["dof_pos_target"] = _dof_tensor_to_dict(robot_state.joint_pos_target[env_id], jns)
-            robot_states[robot_name]["dof_vel_target"] = _dof_tensor_to_dict(robot_state.joint_vel_target[env_id], jns)
-            robot_states[robot_name]["dof_torque"] = _dof_tensor_to_dict(robot_state.joint_effort_target[env_id], jns)
+            robot_states[robot_name]["dof_pos_target"] = (
+                _dof_tensor_to_dict(robot_state.joint_pos_target[env_id], jns)
+                if robot_state.joint_pos_target is not None
+                else None
+            )
+            robot_states[robot_name]["dof_vel_target"] = (
+                _dof_tensor_to_dict(robot_state.joint_vel_target[env_id], jns)
+                if robot_state.joint_vel_target is not None
+                else None
+            )
+            robot_states[robot_name]["dof_torque"] = (
+                _dof_tensor_to_dict(robot_state.joint_effort_target[env_id], jns)
+                if robot_state.joint_effort_target is not None
+                else None
+            )
 
         camera_states = {}
         for camera_name, camera_state in tensor_state.cameras.items():

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -145,7 +145,7 @@ def tensor_state_to_env_states(handler: BaseSimHandler, tensor_state: TensorStat
                 if robot_state.joint_effort_target is not None
                 else None
             )
-            if hasattr(handler, "get_object_body_names"):
+            if robot_state.body_state is not None:
                 bns = handler.get_object_body_names(robot_name)
                 robot_states[robot_name]["body"] = _body_tensor_to_dict(robot_state.body_state[env_id], bns)
 

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -1,0 +1,59 @@
+"""Tensorized state of the simulation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class ObjectState:
+    """State of a single object."""
+
+    root_state: torch.Tensor
+    """Root state ``[pos, quat, lin_vel, ang_vel]``. Shape is (num_envs, 13)."""
+    joint_pos: torch.Tensor | None = None
+    """Joint positions. Shape is (num_envs, num_joints)."""
+    joint_vel: torch.Tensor | None = None
+    """Joint velocities. Shape is (num_envs, num_joints)."""
+
+
+@dataclass
+class RobotState:
+    """State of a single robot."""
+
+    root_state: torch.Tensor
+    """Root state ``[pos, quat, lin_vel, ang_vel]``. Shape is (num_envs, 13)."""
+    joint_pos: torch.Tensor
+    """Joint positions. Shape is (num_envs, num_joints)."""
+    joint_vel: torch.Tensor
+    """Joint velocities. Shape is (num_envs, num_joints)."""
+    joint_pos_target: torch.Tensor
+    """Joint positions target. Shape is (num_envs, num_joints)."""
+    joint_vel_target: torch.Tensor
+    """Joint velocities target. Shape is (num_envs, num_joints)."""
+    joint_effort_target: torch.Tensor
+    """Joint effort targets. Shape is (num_envs, num_joints)."""
+
+
+@dataclass
+class CameraState:
+    """State of a single camera."""
+
+    rgb: torch.Tensor | None
+    """RGB image. Shape is (num_envs, H, W, 3)."""
+    depth: torch.Tensor | None
+    """Depth image. Shape is (num_envs, H, W)."""
+
+
+@dataclass
+class TensorState:
+    """Tensorized state of the simulation."""
+
+    objects: dict[str, ObjectState]
+    """States of all objects."""
+    robots: dict[str, RobotState]
+    """States of all robots."""
+    cameras: dict[str, CameraState]
+    """States of all cameras."""

--- a/roboverse_learn/humanoidbench_rl/wrapper_sb3.py
+++ b/roboverse_learn/humanoidbench_rl/wrapper_sb3.py
@@ -11,6 +11,7 @@ from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
 from metasim.utils.demo_util import get_traj
 from metasim.utils.setup_util import get_robot, get_sim_env_class, get_task
+from metasim.utils.state import tensor_state_to_env_states
 
 
 class Sb3EnvWrapper(VecEnv):
@@ -86,6 +87,7 @@ class Sb3EnvWrapper(VecEnv):
     def reset(self, options=None):
         """Reset the environment."""
         _, _ = self.env.reset(states=self.init_states)
+
         humanoid_observation = self.get_humanoid_observation(self.env.handler.get_states())
         observations = humanoid_observation.cpu().numpy()
 
@@ -204,11 +206,13 @@ class Sb3EnvWrapper(VecEnv):
         return observations, rewards, dones, infos
 
     def get_humanoid_observation(self, states) -> torch.Tensor:
+        states = tensor_state_to_env_states(self.env.handler, states)
         gym_observation = self.env.handler.task.humanoid_obs_flatten_func(states)
         return gym_observation
 
     def get_humanoid_reward(self, states):
         # NOTE: For IsaacLab, metasim_reward is None, so calculate reward here
+        states = tensor_state_to_env_states(self.env.handler, states)
         final_reward = torch.zeros(self.num_envs)
         for reward_func, reward_weight in zip(
             self.env.handler.task.reward_functions, self.env.handler.task.reward_weights

--- a/roboverse_learn/humanoidbench_rl/wrapper_sb3.py
+++ b/roboverse_learn/humanoidbench_rl/wrapper_sb3.py
@@ -11,7 +11,7 @@ from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
 from metasim.utils.demo_util import get_traj
 from metasim.utils.setup_util import get_robot, get_sim_env_class, get_task
-from metasim.utils.state import tensor_state_to_env_states
+from metasim.utils.state import state_tensor_to_nested
 
 
 class Sb3EnvWrapper(VecEnv):
@@ -206,13 +206,13 @@ class Sb3EnvWrapper(VecEnv):
         return observations, rewards, dones, infos
 
     def get_humanoid_observation(self, states) -> torch.Tensor:
-        states = tensor_state_to_env_states(self.env.handler, states)
+        states = state_tensor_to_nested(self.env.handler, states)
         gym_observation = self.env.handler.task.humanoid_obs_flatten_func(states)
         return gym_observation
 
     def get_humanoid_reward(self, states):
         # NOTE: For IsaacLab, metasim_reward is None, so calculate reward here
-        states = tensor_state_to_env_states(self.env.handler, states)
+        states = state_tensor_to_nested(self.env.handler, states)
         final_reward = torch.zeros(self.num_envs)
         for reward_func, reward_weight in zip(
             self.env.handler.task.reward_functions, self.env.handler.task.reward_weights


### PR DESCRIPTION
This PR changes state into tensorized representation to speed up for large scale parallel simulation

- Define new tensor states in `metasim/utils/state.py`
    - including the body states
- Modify the `get_states()` method in isaaclab, isaacgym, mujoco, genesis, sanpien2/3, pybullet to return the tensor state
    - isaaclab, isaacgym, mujoco support tensorized body states
- Modify scripts to fit tensorized state, including:
    - `replay_demo.py` and `collect_demo.py`
    - `get_started/*.py`
    - `roboverse_learn/humanoidbench_rl/train_sb3.py`, all 3 training command for humanoidbench in [doc](https://roboverse.wiki/roboverse_learn/reinforcement_learning/humanoidbench_rl) is tested: 
        ```
        python roboverse_learn/humanoidbench_rl/train_sb3.py --sim mujoco --num_envs 1 --robot=h1 --task humanoidbench:Stand
        ```
        ```
        python roboverse_learn/humanoidbench_rl/train_sb3.py --sim isaacgym --num_envs 2 --robot=h1 --task humanoidbench:Stand
        ```
        ```
        python roboverse_learn/humanoidbench_rl/train_sb3.py --sim isaaclab --num_envs 2 --robot=h1 --task humanoidbench:Stand
        ```
-  The key to quick adaptation with old code is using the `tensor_state_to_env_states` function, which convert the tensor state to old nested state, defined in `metasim/utils/state.py`. However, this function is not recommended and is just temporarily existing for code transition.
    
- profiling the speed improvement for `replay_demo.py` (see below for details)
    - isaaclab +50% (w/ camera)
    - isaacgym +400% (w/ camera)
    - genesis +50% (w/o camera)
