### PR TITLE
Dev/organize get object joint names

### DIFF
--- a/docs/source/metasim/developer_guide/docstring.md
+++ b/docs/source/metasim/developer_guide/docstring.md
@@ -97,7 +97,7 @@ Document methods and functions (including properties) with a clear description o
 ```python
 class BaseSimHandler
     # ...
-    def get_object_joint_names(self, object: ArticulationObjMetaCfg) -> list[str]:
+    def get_joint_names(self, object: ArticulationObjMetaCfg) -> list[str]:
         """Get the joint names for a specified articulated object.
 
         Args:

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -160,7 +160,7 @@ class BaseSimHandler:
     ############################################################
     ## Misc
     ############################################################
-    def get_object_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str) -> list[str]:
         """Get the joint names for a specified object in the order of the simulator default joint order. For same object, different simulator may have different joint order, but joint names are the same.
 
         Args:
@@ -184,7 +184,7 @@ class BaseSimHandler:
             self._joint_reindex_cache = {}
 
         if obj_name not in self._joint_reindex_cache:
-            origin_joint_names = self.get_object_joint_names(obj_name)
+            origin_joint_names = self.get_joint_names(obj_name)
             sorted_joint_names = sorted(origin_joint_names)
             self._joint_reindex_cache[obj_name] = [origin_joint_names.index(jn) for jn in sorted_joint_names]
 

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import torch
 from loguru import logger as log
 
-from metasim.cfg.objects import BaseObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, TimeOut
 from metasim.utils.state import TensorState, state_tensor_to_nested
@@ -161,11 +160,11 @@ class BaseSimHandler:
     ############################################################
     ## Misc
     ############################################################
-    def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
+    def get_object_joint_names(self, obj_name: str) -> list[str]:
         """Get the joint names for a specified object in the order of the simulator default joint order. For same object, different simulator may have different joint order, but joint names are the same.
 
         Args:
-            object (BaseObjCfg): The target object.
+            obj_name (str): The name of the object.
 
         Returns:
             list[str]: A list of strings including the joint names. For non-articulation objects, return an empty list.
@@ -185,8 +184,7 @@ class BaseSimHandler:
             self._joint_reindex_cache = {}
 
         if obj_name not in self._joint_reindex_cache:
-            obj_cfg = self.object_dict[obj_name]
-            origin_joint_names = self.get_object_joint_names(obj_cfg)
+            origin_joint_names = self.get_object_joint_names(obj_name)
             sorted_joint_names = sorted(origin_joint_names)
             self._joint_reindex_cache[obj_name] = [origin_joint_names.index(jn) for jn in sorted_joint_names]
 

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -160,11 +160,12 @@ class BaseSimHandler:
     ############################################################
     ## Misc
     ############################################################
-    def get_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str, sort: bool = True) -> list[str]:
         """Get the joint names for a specified object in the order of the simulator default joint order. For same object, different simulator may have different joint order, but joint names are the same.
 
         Args:
             obj_name (str): The name of the object.
+            sort (bool): Whether to sort the joint names. Default is True.
 
         Returns:
             list[str]: A list of strings including the joint names. For non-articulation objects, return an empty list.
@@ -184,8 +185,8 @@ class BaseSimHandler:
             self._joint_reindex_cache = {}
 
         if obj_name not in self._joint_reindex_cache:
-            origin_joint_names = self.get_joint_names(obj_name)
-            sorted_joint_names = sorted(origin_joint_names)
+            origin_joint_names = self.get_joint_names(obj_name, sort=False)
+            sorted_joint_names = self.get_joint_names(obj_name, sort=True)
             self._joint_reindex_cache[obj_name] = [origin_joint_names.index(jn) for jn in sorted_joint_names]
 
         return self._joint_reindex_cache[obj_name]

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -9,7 +9,7 @@ from genesis.vis.camera import Camera
 from loguru import logger as log
 
 rootutils.setup_root(__file__, pythonpath=True)
-from metasim.cfg.objects import ArticulationObjCfg, BaseObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
+from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, GymEnvWrapper
 from metasim.types import Action, EnvState
@@ -176,13 +176,16 @@ class GenesisHandler(BaseSimHandler):
                 if obj.fix_base_link:
                     obj_inst.set_qpos(
                         np.array([
-                            [states_flat[env_id][obj.name]["dof_pos"][jn] for jn in self.get_object_joint_names(obj)]
+                            [
+                                states_flat[env_id][obj.name]["dof_pos"][jn]
+                                for jn in self.get_object_joint_names(obj.name)
+                            ]
                             for env_id in env_ids
                         ]),
                         envs_idx=env_ids,
                     )
                 else:
-                    joint_names = self.get_object_joint_names(obj)
+                    joint_names = self.get_object_joint_names(obj.name)
                     qs_idx_local = torch.arange(1, 1 + len(joint_names), dtype=torch.int32, device=gs.device).tolist()
                     obj_inst.set_qpos(
                         np.array([
@@ -195,7 +198,7 @@ class GenesisHandler(BaseSimHandler):
     def set_dof_targets(self, obj_name: str, actions: list[Action]) -> None:
         self._actions_cache = actions
         position = [
-            [actions[env_id]["dof_pos_target"][jn] for jn in self.get_object_joint_names(self.object_dict[obj_name])]
+            [actions[env_id]["dof_pos_target"][jn] for jn in self.get_object_joint_names(obj_name)]
             for env_id in range(self.num_envs)
         ]
         if self.object_dict[obj_name].fix_base_link:
@@ -226,13 +229,13 @@ class GenesisHandler(BaseSimHandler):
     def close(self):
         pass
 
-    def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
-        if isinstance(object, ArticulationObjCfg):
-            joints: list[RigidJoint] = self.object_inst_dict[object.name].joints
+    def get_object_joint_names(self, obj_name: str) -> list[str]:
+        if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
+            joints: list[RigidJoint] = self.object_inst_dict[obj_name].joints
             return [
                 j.name
                 for j in joints
-                if j.dof_idx_local is not None and j.name != self.object_inst_dict[object.name].base_joint.name
+                if j.dof_idx_local is not None and j.name != self.object_inst_dict[obj_name].base_joint.name
             ]
         else:
             return []

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -176,13 +176,16 @@ class GenesisHandler(BaseSimHandler):
                 if obj.fix_base_link:
                     obj_inst.set_qpos(
                         np.array([
-                            [states_flat[env_id][obj.name]["dof_pos"][jn] for jn in self.get_joint_names(obj.name)]
+                            [
+                                states_flat[env_id][obj.name]["dof_pos"][jn]
+                                for jn in self.get_joint_names(obj.name, sort=False)
+                            ]
                             for env_id in env_ids
                         ]),
                         envs_idx=env_ids,
                     )
                 else:
-                    joint_names = self.get_joint_names(obj.name)
+                    joint_names = self.get_joint_names(obj.name, sort=False)
                     qs_idx_local = torch.arange(1, 1 + len(joint_names), dtype=torch.int32, device=gs.device).tolist()
                     obj_inst.set_qpos(
                         np.array([
@@ -195,7 +198,7 @@ class GenesisHandler(BaseSimHandler):
     def set_dof_targets(self, obj_name: str, actions: list[Action]) -> None:
         self._actions_cache = actions
         position = [
-            [actions[env_id]["dof_pos_target"][jn] for jn in self.get_joint_names(obj_name)]
+            [actions[env_id]["dof_pos_target"][jn] for jn in self.get_joint_names(obj_name, sort=False)]
             for env_id in range(self.num_envs)
         ]
         if self.object_dict[obj_name].fix_base_link:
@@ -226,14 +229,17 @@ class GenesisHandler(BaseSimHandler):
     def close(self):
         pass
 
-    def get_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str, sort: bool = True) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             joints: list[RigidJoint] = self.object_inst_dict[obj_name].joints
-            return [
+            joint_names = [
                 j.name
                 for j in joints
                 if j.dof_idx_local is not None and j.name != self.object_inst_dict[obj_name].base_joint.name
             ]
+            if sort:
+                joint_names.sort()
+            return joint_names
         else:
             return []
 

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -176,16 +176,13 @@ class GenesisHandler(BaseSimHandler):
                 if obj.fix_base_link:
                     obj_inst.set_qpos(
                         np.array([
-                            [
-                                states_flat[env_id][obj.name]["dof_pos"][jn]
-                                for jn in self.get_object_joint_names(obj.name)
-                            ]
+                            [states_flat[env_id][obj.name]["dof_pos"][jn] for jn in self.get_joint_names(obj.name)]
                             for env_id in env_ids
                         ]),
                         envs_idx=env_ids,
                     )
                 else:
-                    joint_names = self.get_object_joint_names(obj.name)
+                    joint_names = self.get_joint_names(obj.name)
                     qs_idx_local = torch.arange(1, 1 + len(joint_names), dtype=torch.int32, device=gs.device).tolist()
                     obj_inst.set_qpos(
                         np.array([
@@ -198,7 +195,7 @@ class GenesisHandler(BaseSimHandler):
     def set_dof_targets(self, obj_name: str, actions: list[Action]) -> None:
         self._actions_cache = actions
         position = [
-            [actions[env_id]["dof_pos_target"][jn] for jn in self.get_object_joint_names(obj_name)]
+            [actions[env_id]["dof_pos_target"][jn] for jn in self.get_joint_names(obj_name)]
             for env_id in range(self.num_envs)
         ]
         if self.object_dict[obj_name].fix_base_link:
@@ -229,7 +226,7 @@ class GenesisHandler(BaseSimHandler):
     def close(self):
         pass
 
-    def get_object_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             joints: list[RigidJoint] = self.object_inst_dict[obj_name].joints
             return [

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -684,9 +684,12 @@ class IsaacgymHandler(BaseSimHandler):
     ############################################################
     ## Utils
     ############################################################
-    def get_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str, sort: bool = True) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
-            return list(self._joint_info[obj_name]["global_indices"].keys())
+            joint_names = list(self._joint_info[obj_name]["global_indices"].keys())
+            if sort:
+                joint_names.sort()
+            return joint_names
         else:
             return []
 

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -684,7 +684,7 @@ class IsaacgymHandler(BaseSimHandler):
     ############################################################
     ## Utils
     ############################################################
-    def get_object_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             return list(self._joint_info[obj_name]["global_indices"].keys())
         else:

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -684,9 +684,9 @@ class IsaacgymHandler(BaseSimHandler):
     ############################################################
     ## Utils
     ############################################################
-    def get_object_joint_names(self, obj: BaseObjCfg) -> list[str]:
-        if isinstance(obj, ArticulationObjCfg):
-            return list(self._joint_info[obj.name]["global_indices"].keys())
+    def get_object_joint_names(self, obj_name: str) -> list[str]:
+        if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
+            return list(self._joint_info[obj_name]["global_indices"].keys())
         else:
             return []
 

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -114,7 +114,7 @@ class IsaaclabHandler(BaseSimHandler):
     ############################################################
     def step(self, action: list[Action]) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
         self._actions_cache = action
-        joint_names = self.get_joint_names(self.robot.name)
+        joint_names = self.get_joint_names(self.robot.name, sort=False)
         action_env_tensors = torch.zeros((self.num_envs, len(joint_names)), device=self.env.device)
         for env_id in range(self.num_envs):
             action_env = action[env_id]
@@ -264,7 +264,7 @@ class IsaaclabHandler(BaseSimHandler):
                     log.warning(f"No dof_pos found for {obj.name}")
                 else:
                     dof_dict = [states_flat[env_id][obj.name]["dof_pos"] for env_id in env_ids]
-                    joint_names = self.get_joint_names(obj.name)
+                    joint_names = self.get_joint_names(obj.name, sort=False)
                     joint_pos = torch.zeros((len(env_ids), len(joint_names)), device=self.env.device)
                     for i, joint_name in enumerate(joint_names):
                         if joint_name in dof_dict[0]:
@@ -364,9 +364,12 @@ class IsaaclabHandler(BaseSimHandler):
     def simulate(self):
         pass
 
-    def get_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str, sort: bool = True) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
-            return self.env.scene.articulations[obj_name].joint_names
+            joint_names = self.env.scene.articulations[obj_name].joint_names
+            if sort:
+                joint_names.sort()
+            return joint_names
         else:
             return []
 

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -114,7 +114,7 @@ class IsaaclabHandler(BaseSimHandler):
     ############################################################
     def step(self, action: list[Action]) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
         self._actions_cache = action
-        joint_names = self.get_object_joint_names(self.robot)
+        joint_names = self.get_object_joint_names(self.robot.name)
         action_env_tensors = torch.zeros((self.num_envs, len(joint_names)), device=self.env.device)
         for env_id in range(self.num_envs):
             action_env = action[env_id]
@@ -264,7 +264,7 @@ class IsaaclabHandler(BaseSimHandler):
                     log.warning(f"No dof_pos found for {obj.name}")
                 else:
                     dof_dict = [states_flat[env_id][obj.name]["dof_pos"] for env_id in env_ids]
-                    joint_names = self.get_object_joint_names(obj)
+                    joint_names = self.get_object_joint_names(obj.name)
                     joint_pos = torch.zeros((len(env_ids), len(joint_names)), device=self.env.device)
                     for i, joint_name in enumerate(joint_names):
                         if joint_name in dof_dict[0]:
@@ -364,9 +364,9 @@ class IsaaclabHandler(BaseSimHandler):
     def simulate(self):
         pass
 
-    def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
-        if isinstance(object, ArticulationObjCfg):
-            return self.env.scene.articulations[object.name].joint_names
+    def get_object_joint_names(self, obj_name: str) -> list[str]:
+        if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
+            return self.env.scene.articulations[obj_name].joint_names
         else:
             return []
 

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -114,7 +114,7 @@ class IsaaclabHandler(BaseSimHandler):
     ############################################################
     def step(self, action: list[Action]) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
         self._actions_cache = action
-        joint_names = self.get_object_joint_names(self.robot.name)
+        joint_names = self.get_joint_names(self.robot.name)
         action_env_tensors = torch.zeros((self.num_envs, len(joint_names)), device=self.env.device)
         for env_id in range(self.num_envs):
             action_env = action[env_id]
@@ -264,7 +264,7 @@ class IsaaclabHandler(BaseSimHandler):
                     log.warning(f"No dof_pos found for {obj.name}")
                 else:
                     dof_dict = [states_flat[env_id][obj.name]["dof_pos"] for env_id in env_ids]
-                    joint_names = self.get_object_joint_names(obj.name)
+                    joint_names = self.get_joint_names(obj.name)
                     joint_pos = torch.zeros((len(env_ids), len(joint_names)), device=self.env.device)
                     for i, joint_name in enumerate(joint_names):
                         if joint_name in dof_dict[0]:
@@ -364,7 +364,7 @@ class IsaaclabHandler(BaseSimHandler):
     def simulate(self):
         pass
 
-    def get_object_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             return self.env.scene.articulations[obj_name].joint_names
         else:

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -210,7 +210,7 @@ class MujocoHandler(BaseSimHandler):
 
             obj_body_id = self.physics.model.body(f"{model_name}/").id
             if isinstance(obj, ArticulationObjCfg):
-                joint_names = sorted(self.get_object_joint_names(obj.name))
+                joint_names = sorted(self.get_joint_names(obj.name))
                 body_reindex = self.get_body_reindex(obj.name)
                 body_ids_origin = [
                     bi
@@ -256,7 +256,7 @@ class MujocoHandler(BaseSimHandler):
         for robot in [self.robot]:
             model_name = self.mj_objects[robot.name].model
             obj_body_id = self.physics.model.body(f"{model_name}/").id
-            joint_names = sorted(self.get_object_joint_names(robot.name))
+            joint_names = sorted(self.get_joint_names(robot.name))
             actuator_reindex = self.get_actuator_reindex(robot.name)
             body_reindex = self.get_body_reindex(robot.name)
             body_ids_origin = [
@@ -411,7 +411,7 @@ class MujocoHandler(BaseSimHandler):
     ############################################################
     ## Utils
     ############################################################
-    def get_object_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             joint_names = [
                 self.physics.model.joint(joint_id).name
@@ -429,7 +429,7 @@ class MujocoHandler(BaseSimHandler):
             actuator_names = [self.physics.model.actuator(i).name for i in range(self.physics.model.nu)]
             actuator_names = [name.split("/")[-1] for name in actuator_names if name.split("/")[0] == robot_name]
             actuator_names = [name for name in actuator_names if name != ""]
-            joint_names = self.get_object_joint_names(robot_name)
+            joint_names = self.get_joint_names(robot_name)
             assert set(actuator_names) == set(joint_names), (
                 f"Actuator names {actuator_names} do not match joint names {joint_names}"
             )

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -9,7 +9,6 @@ from loguru import logger as log
 
 from metasim.cfg.objects import (
     ArticulationObjCfg,
-    BaseObjCfg,
     PrimitiveCubeCfg,
     PrimitiveCylinderCfg,
     PrimitiveSphereCfg,
@@ -211,7 +210,7 @@ class MujocoHandler(BaseSimHandler):
 
             obj_body_id = self.physics.model.body(f"{model_name}/").id
             if isinstance(obj, ArticulationObjCfg):
-                joint_names = sorted(self.get_object_joint_names(obj))
+                joint_names = sorted(self.get_object_joint_names(obj.name))
                 body_reindex = self.get_body_reindex(obj.name)
                 body_ids_origin = [
                     bi
@@ -257,7 +256,7 @@ class MujocoHandler(BaseSimHandler):
         for robot in [self.robot]:
             model_name = self.mj_objects[robot.name].model
             obj_body_id = self.physics.model.body(f"{model_name}/").id
-            joint_names = sorted(self.get_object_joint_names(robot))
+            joint_names = sorted(self.get_object_joint_names(robot.name))
             actuator_reindex = self.get_actuator_reindex(robot.name)
             body_reindex = self.get_body_reindex(robot.name)
             body_ids_origin = [
@@ -412,12 +411,12 @@ class MujocoHandler(BaseSimHandler):
     ############################################################
     ## Utils
     ############################################################
-    def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
-        if isinstance(object, ArticulationObjCfg):
+    def get_object_joint_names(self, obj_name: str) -> list[str]:
+        if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             joint_names = [
                 self.physics.model.joint(joint_id).name
                 for joint_id in range(self.physics.model.njnt)
-                if self.physics.model.joint(joint_id).name.startswith(object.name + "/")
+                if self.physics.model.joint(joint_id).name.startswith(obj_name + "/")
             ]
             joint_names = [name.split("/")[-1] for name in joint_names]
             joint_names = [name for name in joint_names if name != ""]
@@ -426,12 +425,11 @@ class MujocoHandler(BaseSimHandler):
             return []
 
     def get_actuator_names(self, robot_name: str) -> list[str]:
-        robot_cfg = self.object_dict[robot_name]
-        if isinstance(robot_cfg, BaseRobotCfg):
+        if isinstance(self.object_dict[robot_name], BaseRobotCfg):
             actuator_names = [self.physics.model.actuator(i).name for i in range(self.physics.model.nu)]
             actuator_names = [name.split("/")[-1] for name in actuator_names if name.split("/")[0] == robot_name]
             actuator_names = [name for name in actuator_names if name != ""]
-            joint_names = self.get_object_joint_names(robot_cfg)
+            joint_names = self.get_object_joint_names(robot_name)
             assert set(actuator_names) == set(joint_names), (
                 f"Actuator names {actuator_names} do not match joint names {joint_names}"
             )

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -210,7 +210,7 @@ class MujocoHandler(BaseSimHandler):
 
             obj_body_id = self.physics.model.body(f"{model_name}/").id
             if isinstance(obj, ArticulationObjCfg):
-                joint_names = sorted(self.get_joint_names(obj.name))
+                joint_names = self.get_joint_names(obj.name, sort=True)
                 body_reindex = self.get_body_reindex(obj.name)
                 body_ids_origin = [
                     bi
@@ -256,7 +256,7 @@ class MujocoHandler(BaseSimHandler):
         for robot in [self.robot]:
             model_name = self.mj_objects[robot.name].model
             obj_body_id = self.physics.model.body(f"{model_name}/").id
-            joint_names = sorted(self.get_joint_names(robot.name))
+            joint_names = self.get_joint_names(robot.name, sort=True)
             actuator_reindex = self.get_actuator_reindex(robot.name)
             body_reindex = self.get_body_reindex(robot.name)
             body_ids_origin = [
@@ -411,7 +411,7 @@ class MujocoHandler(BaseSimHandler):
     ############################################################
     ## Utils
     ############################################################
-    def get_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str, sort: bool = True) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             joint_names = [
                 self.physics.model.joint(joint_id).name
@@ -420,6 +420,8 @@ class MujocoHandler(BaseSimHandler):
             ]
             joint_names = [name.split("/")[-1] for name in joint_names]
             joint_names = [name for name in joint_names if name != ""]
+            if sort:
+                joint_names.sort()
             return joint_names
         else:
             return []

--- a/metasim/sim/parallel.py
+++ b/metasim/sim/parallel.py
@@ -76,8 +76,8 @@ def _worker(
             elif cmd == "get_reward":
                 reward = env.get_reward()
                 remote.send(reward)
-            elif cmd == "get_object_joint_names":
-                names = env.get_object_joint_names(data[0])
+            elif cmd == "get_joint_names":
+                names = env.get_joint_names(data[0])
                 remote.send(names)
             elif cmd == "handshake":
                 # This is used to make sure that the environment is initialized
@@ -303,8 +303,8 @@ def ParallelSimWrapper(base_cls: type[BaseSimHandler]) -> type[BaseSimHandler]:
         def get_reward(self):
             log.error("get_reward not supported in parallel mode")
 
-        def get_object_joint_names(self, obj_name: str) -> list[str]:
-            self.remotes[0].send(("get_object_joint_names", (obj_name,)))
+        def get_joint_names(self, obj_name: str) -> list[str]:
+            self.remotes[0].send(("get_joint_names", (obj_name,)))
             names = self.remotes[0].recv()
             return names[0]
 

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -379,7 +379,7 @@ class SinglePybulletHandler(BaseSimHandler):
     ############################################################
     ## Utils
     ############################################################
-    def get_object_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             return self.object_joint_order[obj_name]
         else:

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -14,7 +14,7 @@ import pybullet as p
 import pybullet_data
 import torch
 
-from metasim.cfg.objects import ArticulationObjCfg, BaseObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
+from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
@@ -379,9 +379,9 @@ class SinglePybulletHandler(BaseSimHandler):
     ############################################################
     ## Utils
     ############################################################
-    def get_object_joint_names(self, obj: BaseObjCfg) -> list[str]:
-        if isinstance(obj, ArticulationObjCfg):
-            return self.object_joint_order[obj.name]
+    def get_object_joint_names(self, obj_name: str) -> list[str]:
+        if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
+            return self.object_joint_order[obj_name]
         else:
             return []
 

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -379,9 +379,12 @@ class SinglePybulletHandler(BaseSimHandler):
     ############################################################
     ## Utils
     ############################################################
-    def get_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str, sort: bool = True) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
-            return self.object_joint_order[obj_name]
+            joint_names = self.object_joint_order[obj_name]
+            if sort:
+                joint_names.sort()
+            return joint_names
         else:
             return []
 

--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -18,7 +18,6 @@ from sapien.utils import Viewer
 
 from metasim.cfg.objects import (
     ArticulationObjCfg,
-    BaseObjCfg,
     NonConvexRigidObjCfg,
     PrimitiveCubeCfg,
     PrimitiveSphereCfg,
@@ -437,9 +436,9 @@ class SingleSapienHandler(BaseSimHandler):
     def device(self) -> torch.device:
         return torch.device("cpu")
 
-    def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
-        if isinstance(object, ArticulationObjCfg):
-            return self.object_joint_order[object.name]
+    def get_object_joint_names(self, obj_name: str) -> list[str]:
+        if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
+            return self.object_joint_order[obj_name]
         else:
             return []
 

--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -436,9 +436,12 @@ class SingleSapienHandler(BaseSimHandler):
     def device(self) -> torch.device:
         return torch.device("cpu")
 
-    def get_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str, sort: bool = True) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
-            return self.object_joint_order[obj_name]
+            joint_names = self.object_joint_order[obj_name]
+            if sort:
+                joint_names.sort()
+            return joint_names
         else:
             return []
 

--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -436,7 +436,7 @@ class SingleSapienHandler(BaseSimHandler):
     def device(self) -> torch.device:
         return torch.device("cpu")
 
-    def get_object_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             return self.object_joint_order[obj_name]
         else:

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -467,9 +467,12 @@ class SingleSapien3Handler(BaseSimHandler):
     def device(self) -> torch.device:
         return torch.device("cpu")
 
-    def get_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str, sort: bool = True) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
-            return self.object_joint_order[obj_name]
+            joint_names = self.object_joint_order[obj_name]
+            if sort:
+                joint_names.sort()
+            return joint_names
         else:
             return []
 

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -19,7 +19,6 @@ from sapien.utils import Viewer
 
 from metasim.cfg.objects import (
     ArticulationObjCfg,
-    BaseObjCfg,
     NonConvexRigidObjCfg,
     PrimitiveCubeCfg,
     PrimitiveSphereCfg,
@@ -468,9 +467,9 @@ class SingleSapien3Handler(BaseSimHandler):
     def device(self) -> torch.device:
         return torch.device("cpu")
 
-    def get_object_joint_names(self, object: BaseObjCfg) -> list[str]:
-        if isinstance(object, ArticulationObjCfg):
-            return self.object_joint_order[object.name]
+    def get_object_joint_names(self, obj_name: str) -> list[str]:
+        if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
+            return self.object_joint_order[obj_name]
         else:
             return []
 

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -467,7 +467,7 @@ class SingleSapien3Handler(BaseSimHandler):
     def device(self) -> torch.device:
         return torch.device("cpu")
 
-    def get_object_joint_names(self, obj_name: str) -> list[str]:
+    def get_joint_names(self, obj_name: str) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
             return self.object_joint_order[obj_name]
         else:

--- a/metasim/utils/demo_util/demo_util_v1.py
+++ b/metasim/utils/demo_util/demo_util_v1.py
@@ -49,7 +49,7 @@ def get_actions(demo_original, robot: BaseRobotCfg, handler: BaseSimHandler):
         for action_idx in range(len(demo_original[demo_idx]["robot_traj"]["q"])):
             dof_pos_target = {}
             dof_array = demo_original[demo_idx]["robot_traj"]["q"][action_idx]
-            for i, joint_name in enumerate(handler.get_object_joint_names(robot)):
+            for i, joint_name in enumerate(handler.get_object_joint_names(robot.name)):
                 value = dof_array[i]
                 if type(value) is np.ndarray:
                     value = value.item()
@@ -87,7 +87,7 @@ def get_init_states(demo_original: list[dict], num_envs: int, task, handler, rob
             d["rot"] = demo_original[i]["env_setup"][f"init_{obj.name}_quat"]
             dof = {}
             if isinstance(obj, ArticulationObjCfg):
-                for joint_name in handler.get_object_joint_names(obj):
+                for joint_name in handler.get_object_joint_names(obj.name):
                     value = demo_original[i]["env_setup"][f"init_{joint_name}_q"]
                     if type(value) is np.ndarray:
                         value = value.item()
@@ -103,7 +103,7 @@ def get_init_states(demo_original: list[dict], num_envs: int, task, handler, rob
         d["rot"] = demo_original[i]["env_setup"]["init_robot_quat"]
         dof = {}
         dof_array = demo_original[i]["env_setup"]["init_q"]
-        for i, joint_name in enumerate(handler.get_object_joint_names(robot)):
+        for i, joint_name in enumerate(handler.get_object_joint_names(robot.name)):
             value = dof_array[i]
             if type(value) is np.ndarray:
                 value = value.item()
@@ -148,7 +148,7 @@ def get_all_states(demo_original, task: BaseTaskCfg, handler: BaseSimHandler, ro
 
                 if isinstance(obj, ArticulationObjCfg):
                     dof = {}
-                    for joint_name in handler.get_object_joint_names(obj):
+                    for joint_name in handler.get_object_joint_names(obj.name):
                         value = demo_original[demo_idx]["object_states"][i][f"{joint_name}_q"]
                         if type(value) is np.ndarray:
                             value = value.item()
@@ -163,7 +163,7 @@ def get_all_states(demo_original, task: BaseTaskCfg, handler: BaseSimHandler, ro
             robot_state["pos"] = demo_original[demo_idx]["env_setup"]["init_robot_pos"]
             robot_state["rot"] = demo_original[demo_idx]["env_setup"]["init_robot_quat"]
             dof = {}
-            for j, joint_name in enumerate(handler.get_object_joint_names(robot)):
+            for j, joint_name in enumerate(handler.get_object_joint_names(robot.name)):
                 value = demo_original[demo_idx]["robot_traj"]["q"][i][j]
                 if type(value) is np.ndarray:
                     value = value.item()

--- a/metasim/utils/demo_util/demo_util_v1.py
+++ b/metasim/utils/demo_util/demo_util_v1.py
@@ -49,7 +49,7 @@ def get_actions(demo_original, robot: BaseRobotCfg, handler: BaseSimHandler):
         for action_idx in range(len(demo_original[demo_idx]["robot_traj"]["q"])):
             dof_pos_target = {}
             dof_array = demo_original[demo_idx]["robot_traj"]["q"][action_idx]
-            for i, joint_name in enumerate(handler.get_object_joint_names(robot.name)):
+            for i, joint_name in enumerate(handler.get_joint_names(robot.name)):
                 value = dof_array[i]
                 if type(value) is np.ndarray:
                     value = value.item()
@@ -87,7 +87,7 @@ def get_init_states(demo_original: list[dict], num_envs: int, task, handler, rob
             d["rot"] = demo_original[i]["env_setup"][f"init_{obj.name}_quat"]
             dof = {}
             if isinstance(obj, ArticulationObjCfg):
-                for joint_name in handler.get_object_joint_names(obj.name):
+                for joint_name in handler.get_joint_names(obj.name):
                     value = demo_original[i]["env_setup"][f"init_{joint_name}_q"]
                     if type(value) is np.ndarray:
                         value = value.item()
@@ -103,7 +103,7 @@ def get_init_states(demo_original: list[dict], num_envs: int, task, handler, rob
         d["rot"] = demo_original[i]["env_setup"]["init_robot_quat"]
         dof = {}
         dof_array = demo_original[i]["env_setup"]["init_q"]
-        for i, joint_name in enumerate(handler.get_object_joint_names(robot.name)):
+        for i, joint_name in enumerate(handler.get_joint_names(robot.name)):
             value = dof_array[i]
             if type(value) is np.ndarray:
                 value = value.item()
@@ -148,7 +148,7 @@ def get_all_states(demo_original, task: BaseTaskCfg, handler: BaseSimHandler, ro
 
                 if isinstance(obj, ArticulationObjCfg):
                     dof = {}
-                    for joint_name in handler.get_object_joint_names(obj.name):
+                    for joint_name in handler.get_joint_names(obj.name):
                         value = demo_original[demo_idx]["object_states"][i][f"{joint_name}_q"]
                         if type(value) is np.ndarray:
                             value = value.item()
@@ -163,7 +163,7 @@ def get_all_states(demo_original, task: BaseTaskCfg, handler: BaseSimHandler, ro
             robot_state["pos"] = demo_original[demo_idx]["env_setup"]["init_robot_pos"]
             robot_state["rot"] = demo_original[demo_idx]["env_setup"]["init_robot_quat"]
             dof = {}
-            for j, joint_name in enumerate(handler.get_object_joint_names(robot.name)):
+            for j, joint_name in enumerate(handler.get_joint_names(robot.name)):
                 value = demo_original[demo_idx]["robot_traj"]["q"][i][j]
                 if type(value) is np.ndarray:
                     value = value.item()

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -117,15 +117,15 @@ def state_tensor_to_nested(handler: BaseSimHandler, tensor_state: TensorState) -
                 bns = handler.get_body_names(obj_name)
                 object_states[obj_name]["body"] = _body_tensor_to_dict(obj_state.body_state[env_id], bns)
             if obj_state.joint_pos is not None:
-                jns = handler.get_object_joint_names(obj_name)
+                jns = handler.get_joint_names(obj_name)
                 object_states[obj_name]["dof_pos"] = _dof_tensor_to_dict(obj_state.joint_pos[env_id], jns)
             if obj_state.joint_vel is not None:
-                jns = handler.get_object_joint_names(obj_name)
+                jns = handler.get_joint_names(obj_name)
                 object_states[obj_name]["dof_vel"] = _dof_tensor_to_dict(obj_state.joint_vel[env_id], jns)
 
         robot_states = {}
         for robot_name, robot_state in tensor_state.robots.items():
-            jns = handler.get_object_joint_names(robot_name)
+            jns = handler.get_joint_names(robot_name)
             robot_states[robot_name] = {
                 "pos": robot_state.root_state[env_id, :3].cpu(),
                 "rot": robot_state.root_state[env_id, 3:7].cpu(),

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -117,15 +117,15 @@ def state_tensor_to_nested(handler: BaseSimHandler, tensor_state: TensorState) -
                 bns = handler.get_body_names(obj_name)
                 object_states[obj_name]["body"] = _body_tensor_to_dict(obj_state.body_state[env_id], bns)
             if obj_state.joint_pos is not None:
-                jns = handler.get_object_joint_names(handler.object_dict[obj_name])
+                jns = handler.get_object_joint_names(obj_name)
                 object_states[obj_name]["dof_pos"] = _dof_tensor_to_dict(obj_state.joint_pos[env_id], jns)
             if obj_state.joint_vel is not None:
-                jns = handler.get_object_joint_names(handler.object_dict[obj_name])
+                jns = handler.get_object_joint_names(obj_name)
                 object_states[obj_name]["dof_vel"] = _dof_tensor_to_dict(obj_state.joint_vel[env_id], jns)
 
         robot_states = {}
         for robot_name, robot_state in tensor_state.robots.items():
-            jns = handler.get_object_joint_names(handler.object_dict[robot_name])
+            jns = handler.get_object_joint_names(robot_name)
             robot_states[robot_name] = {
                 "pos": robot_state.root_state[env_id, :3].cpu(),
                 "rot": robot_state.root_state[env_id, 3:7].cpu(),


### PR DESCRIPTION
This PR rename and rewrite `get_object_joint_names()` method in handler is a more elegant manner