### PR TITLE
fix evaluation bug of humanoidbench

### DIFF
--- a/roboverse_learn/humanoidbench_rl/train_sb3.py
+++ b/roboverse_learn/humanoidbench_rl/train_sb3.py
@@ -97,7 +97,7 @@ def main():
     if config.get("sim") == "isaacgym":
         from isaacgym import gymapi, gymtorch, gymutil  # noqa: F401
 
-    if config.get("use_wandb"):
+    if config.get("use_wandb") and config.get("train_or_eval") == "train":
         run = wandb.init(
             project=config.get("wandb_project", "humanoidbench_rl_training"),
             entity=config.get("wandb_entity"),
@@ -251,7 +251,7 @@ def main():
         )
     elif config.get("train_or_eval") == "eval":
         # Load the trained model
-        model.load(config.get("model_path"))
+        model.load(config.get("eval_model_path"))
 
         # Evaluate the agent
         log.info("Starting evaluation...")
@@ -262,7 +262,7 @@ def main():
             obs, reward, done, info = env.step(action)
             rewards.append(reward)
             env.render()
-            if done:
+            if done[0]:
                 obs = env.reset()
                 import matplotlib.pyplot as plt
 


### PR DESCRIPTION
1. parralel training,  the type of var `done`  is  `np.array`, not single value.
2. it seem that we only need `wandb` when training? so i add training mode check for wandb initialization.