### PR TITLE
Optimize IsaacLab when no cameras

### DIFF
--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -58,7 +58,7 @@ class IsaaclabHandler(BaseSimHandler):
         parser = argparse.ArgumentParser()
         AppLauncher.add_app_launcher_args(parser)
         args = parser.parse_args([])
-        args.enable_cameras = True
+        # args.enable_cameras = True
         args.headless = self.headless
 
         ## Only set args.renderer seems not enough
@@ -88,28 +88,28 @@ class IsaaclabHandler(BaseSimHandler):
 
         ## Render mode setting, must be done after isaaclab is launched
         ## For more info, see the import below
-        import carb
-        import omni.replicator.core as rep
+        # import carb
+        # import omni.replicator.core as rep
 
-        # from omni.rtx.settings.core.widgets.pt_widgets import PathTracingSettingsFrame
+        # # from omni.rtx.settings.core.widgets.pt_widgets import PathTracingSettingsFrame
 
-        rep.settings.set_render_rtx_realtime()  # fix noising rendered images
+        # rep.settings.set_render_rtx_realtime()  # fix noising rendered images
 
-        settings = carb.settings.get_settings()
-        if self.scenario.render.mode == "pathtracing":
-            settings.set_string("/rtx/rendermode", "PathTracing")
-        elif self.scenario.render.mode == "raytracing":
-            settings.set_string("/rtx/rendermode", "RayTracedLighting")
-        elif self.scenario.render.mode == "rasterization":
-            raise ValueError("Isaaclab does not support rasterization")
-        else:
-            raise ValueError(f"Unknown render mode: {self.scenario.render.mode}")
+        # settings = carb.settings.get_settings()
+        # if self.scenario.render.mode == "pathtracing":
+        #     settings.set_string("/rtx/rendermode", "PathTracing")
+        # elif self.scenario.render.mode == "raytracing":
+        #     settings.set_string("/rtx/rendermode", "RayTracedLighting")
+        # elif self.scenario.render.mode == "rasterization":
+        #     raise ValueError("Isaaclab does not support rasterization")
+        # else:
+        #     raise ValueError(f"Unknown render mode: {self.scenario.render.mode}")
 
-        log.info(f"Render mode: {settings.get_as_string('/rtx/rendermode')}")
-        log.info(f"Render totalSpp: {settings.get('/rtx/pathtracing/totalSpp')}")
-        log.info(f"Render spp: {settings.get('/rtx/pathtracing/spp')}")
-        log.info(f"Render adaptiveSampling/enabled: {settings.get('/rtx/pathtracing/adaptiveSampling/enabled')}")
-        log.info(f"Render maxBounces: {settings.get('/rtx/pathtracing/maxBounces')}")
+        # log.info(f"Render mode: {settings.get_as_string('/rtx/rendermode')}")
+        # log.info(f"Render totalSpp: {settings.get('/rtx/pathtracing/totalSpp')}")
+        # log.info(f"Render spp: {settings.get('/rtx/pathtracing/spp')}")
+        # log.info(f"Render adaptiveSampling/enabled: {settings.get('/rtx/pathtracing/adaptiveSampling/enabled')}")
+        # log.info(f"Render maxBounces: {settings.get('/rtx/pathtracing/maxBounces')}")
 
     ############################################################
     ## Gymnasium main methods

--- a/metasim/sim/isaaclab/utils/ground_util.py
+++ b/metasim/sim/isaaclab/utils/ground_util.py
@@ -1,7 +1,7 @@
 import omni
 from pxr import Sdf, UsdShade
 
-from .material_util import apply_mdl_to_prim
+# from .material_util import apply_mdl_to_prim
 
 try:
     import omni.isaac.core.utils.prims as prim_utils
@@ -23,6 +23,7 @@ def create_ground():
 
 
 def set_ground_material_scale(scale: float):
+    return
     ground_prim = prim_utils.get_prim_at_path(GROUND_PRIM_PATH)
     material = UsdShade.MaterialBindingAPI(ground_prim).GetDirectBinding().GetMaterial()
     shader = UsdShade.Shader(omni.usd.get_shader_from_material(material, get_prim=True))
@@ -31,4 +32,5 @@ def set_ground_material_scale(scale: float):
 
 
 def set_ground_material(material_mdl_path: str):
-    apply_mdl_to_prim(material_mdl_path, GROUND_PRIM_PATH)
+    pass
+    # apply_mdl_to_prim(material_mdl_path, GROUND_PRIM_PATH)

--- a/metasim/sim/isaaclab/utils/usd_util.py
+++ b/metasim/sim/isaaclab/utils/usd_util.py
@@ -8,12 +8,19 @@ import numpy as np
 import omni
 import yaml
 from loguru import logger as log
-from omni.kit.material.library import get_material_prim_path
+
+try:
+    from omni.kit.material.library import get_material_prim_path
+except:
+    pass
 from pxr import Gf, Sdf, Usd, UsdShade
 
 from metasim.utils.hf_util import check_and_download
 
-from .material_util import apply_mdl_to_prim
+try:
+    from .material_util import apply_mdl_to_prim
+except:
+    pass
 
 try:
     import omni.isaac.core.utils.prims as prim_utils


### PR DESCRIPTION
This PR optimize the launching speed and VRAM consumption of isaaclab handler when no camera.

This PR is experimental and is continually updating.


### Results
- The launch time reduced from 6.5s to 3.75s
- The VRAM usage reduced from ~4GB to ~3GB
- The per step time remain the same: ~0.12s

Tested on RTX4060 + i7-14700F

### How to reproduce
Remove the default camera in `replay_demo.py` from 
```python
scenario = ScenarioCfg(
    ...
    cameras=[camera],
    ...
)
```
to
```python
scenario = ScenarioCfg(
    ...
    cameras=[],
    ...
)
```

And test using
```bash
LOGURU_LEVEL=TRACE python metasim/scripts/replay_demo.py --task=stack_cube --sim=isaaclab --num-envs=960 --headless
```

### Discussion
It is worth-noting that the test using IsaacGym handler with same setup:
```
python metasim/scripts/replay_demo.py --task=stack_cube --sim=isaacgym --num-envs=960 --headless
```
achieves ~0.022s per step, which is 500% faster than IsaacLab. Still figuring out why IsaacLab is so slow.

### Other attempt to speed up IsaacLab
- Tried using `torch.inference_mode` but not faster
