### PR TITLE
add camera poses to states; isaaclab: support it

### DIFF
--- a/metasim/cfg/sensors/cameras.py
+++ b/metasim/cfg/sensors/cameras.py
@@ -54,6 +54,19 @@ class PinholeCameraCfg(BaseCameraCfg):
         """Vertical field of view, in degrees."""
         return 2 * math.atan(self.vertical_aperture / (2 * self.focal_length)) / math.pi * 180
 
+    @property
+    def intrinsics(self) -> list[list[float]]:
+        """Intrinsics matrix of the camera. Type is 3x3 nested list of floats."""
+        fx = self.width * self.focal_length / self.horizontal_aperture
+        fy = self.height * self.focal_length / self.vertical_aperture
+        cx = self.width * 0.5
+        cy = self.height * 0.5
+        return [
+            [fx, 0.0, cx],
+            [0.0, fy, cy],
+            [0.0, 0.0, 1.0],
+        ]
+
 
 REALSENSE_CAMERA = PinholeCameraCfg(
     name="realsense_camera",

--- a/metasim/sim/isaaclab/isaaclab_helper.py
+++ b/metasim/sim/isaaclab/isaaclab_helper.py
@@ -15,6 +15,7 @@ from metasim.cfg.objects import (
 )
 from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.sensors import BaseCameraCfg, BaseSensorCfg, ContactForceSensorCfg, PinholeCameraCfg
+from metasim.utils.math import convert_camera_frame_orientation_convention
 
 try:
     from .empty_env import EmptyEnv
@@ -365,3 +366,13 @@ def joint_is_implicit_actuator(joint_name: str, obj_inst) -> bool:
         log.warning(f"Joint {joint_name} is found in multiple actuators of {obj_inst.cfg.prim_path}")
     actuator = actuators[0]
     return isinstance(actuator, ImplicitActuatorCfg)
+
+
+def _update_tiled_camera_pose(env: "EmptyEnv", cameras: list[BaseCameraCfg]):
+    for camera in cameras:
+        camera_inst = env.scene.sensors[camera.name]
+        pos, quat = camera_inst._view.get_world_poses()
+        camera_inst._data.pos_w = pos
+        camera_inst._data.quat_w_world = convert_camera_frame_orientation_convention(
+            quat, origin="opengl", target="world"
+        )

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -9,6 +9,7 @@ import torch
 from loguru import logger as log
 
 from metasim.types import EnvState
+from metasim.utils.math import convert_camera_frame_orientation_convention
 
 try:
     from metasim.sim.base import BaseSimHandler
@@ -73,6 +74,34 @@ class CameraState:
     """RGB image. Shape is (num_envs, H, W, 3)."""
     depth: torch.Tensor | None
     """Depth image. Shape is (num_envs, H, W)."""
+    pos: torch.Tensor | None = None  # TODO: remove N
+    """Position of the camera. Shape is (num_envs, 3)."""
+    quat_world: torch.Tensor | None = None  # TODO: remove N
+    """Quaternion ``(w, x, y, z)`` of the camera, following the world frame convention. Shape is (num_envs, 4).
+
+    Note:
+        World frame convention follows the camera aligned with forward axis +X and up axis +Z.
+    """
+    intrinsics: torch.Tensor | None = None  # TODO: remove N
+    """Intrinsics matrix of the camera. Shape is (num_envs, 3, 3)."""
+
+    @property
+    def quat_ros(self) -> torch.Tensor:
+        """Quaternion ``(w, x, y, z)`` of the camera, following the ROS convention. Shape is (num_envs, 4).
+
+        Note:
+            ROS convention follows the camera aligned with forward axis +Z and up axis -Y.
+        """
+        return convert_camera_frame_orientation_convention(self.quat_world, origin="world", target="ros")
+
+    @property
+    def quat_opengl(self) -> torch.Tensor:
+        """Quaternion ``(w, x, y, z)`` of the camera, following the OpenGL convention. Shape is (num_envs, 4).
+
+        Note:
+            OpenGL convention follows the camera aligned with forward axis -Z and up axis +Y.
+        """
+        return convert_camera_frame_orientation_convention(self.quat_world, origin="world", target="opengl")
 
 
 @dataclass


### PR DESCRIPTION
This PR
- Extend the states for camera poses and intrinsics
- ensure IsaacLab handler support it

To test it, run the following file as `tmp.py`:
```bash
python tmp.py
```

```python
from __future__ import annotations

import logging
import os

try:
    import isaacgym  # noqa: F401
except ImportError:
    pass

import rootutils
import torch
from loguru import logger as log
from rich.logging import RichHandler

logging.addLevelName(5, "TRACE")
log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
rootutils.setup_root(__file__, pythonpath=True)

from metasim.cfg.scenario import ScenarioCfg
from metasim.cfg.sensors import PinholeCameraCfg
from metasim.constants import SimType
from metasim.utils.camera_util import get_cam_params
from metasim.utils.demo_util import get_traj
from metasim.utils.math import matrix_from_quat
from metasim.utils.setup_util import get_sim_env_class


###########################################################
## Utils
###########################################################
def get_actions(all_actions, action_idx: int, num_envs: int):
    envs_actions = all_actions[:num_envs]
    actions = [
        env_actions[action_idx] if action_idx < len(env_actions) else env_actions[-1] for env_actions in envs_actions
    ]
    return actions


def main():
    camera = PinholeCameraCfg(pos=(1.5, -1.5, 1.5), look_at=(0.0, 0.0, 0.0))
    scenario = ScenarioCfg(
        task="stack_cube",
        robot="franka",
        cameras=[camera],
        sim="isaaclab",
        num_envs=1,
    )

    num_envs: int = scenario.num_envs
    env_class = get_sim_env_class(SimType(scenario.sim))
    env = env_class(scenario)

    ## Data
    assert os.path.exists(scenario.task.traj_filepath), (
        f"Trajectory file: {scenario.task.traj_filepath} does not exist."
    )
    init_states, all_actions, all_states = get_traj(scenario.task, scenario.robot, env.handler)

    ########################################################
    ## Main
    ########################################################

    obs, extras = env.reset(states=init_states[:num_envs])

    step = 0
    while True:
        cam = scenario.cameras[0]
        intrinsics = obs.cameras["camera0"].intrinsics[0]
        extrinsics = matrix_from_quat(obs.cameras["camera0"].quat_ros)
        extr, intr = get_cam_params(
            torch.tensor(cam.pos)[None, :],
            torch.tensor(cam.look_at)[None, :],
            cam.width,
            cam.height,
            cam.focal_length,
            cam.horizontal_aperture,
        )

        assert torch.allclose(intrinsics.cpu(), intr)
        assert torch.allclose(extrinsics.cpu(), extr[:, :3, :3].transpose(-1, -2), atol=1e-4)

        log.debug(f"Step {step}")

        actions = get_actions(all_actions, step, num_envs)
        obs, reward, success, time_out, extras = env.step(actions)

        step += 1

    env.close()


if __name__ == "__main__":
    main()
```