### PR TITLE
[refactor] remove rootutils 

### DIFF
--- a/dashboard/minimal_test_script.py
+++ b/dashboard/minimal_test_script.py
@@ -1,18 +1,16 @@
 from __future__ import annotations
 
-import os
-from dataclasses import dataclass
-
 try:
     import isaacgym  # noqa: F401
 except ImportError:
     pass
 
-import rootutils
+import os
+from dataclasses import dataclass
+
 import tyro
 from loguru import logger as log
 
-rootutils.setup_root(__file__, pythonpath=True)
 from metasim.utils.state import TensorState
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -189,7 +189,6 @@ autodoc_mock_imports = [
     "imageio",
     "loguru",
     "gymnasium",
-    "rootutils",
     "rich",
     "tyro",
     "tqdm",

--- a/metasim/scripts/collect_demo.py
+++ b/metasim/scripts/collect_demo.py
@@ -23,10 +23,8 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Literal
 
-import rootutils
 import tyro
 
-rootutils.setup_root(__file__, pythonpath=True)
 from metasim.cfg.randomization import RandomizationCfg
 from metasim.cfg.render import RenderCfg
 

--- a/metasim/scripts/empty_demo.py
+++ b/metasim/scripts/empty_demo.py
@@ -1,22 +1,17 @@
 from __future__ import annotations
 
-from typing import Literal
-
 try:
     import isaacgym  # noqa: F401
 except ImportError:
     pass
 
+from typing import Literal
+
 import imageio
-import rootutils
 import torch
 import tyro
 from loguru import logger as log
 from rich.logging import RichHandler
-
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
-
 
 from metasim.cfg.objects import PrimitiveCubeCfg
 from metasim.cfg.randomization import RandomizationCfg
@@ -26,6 +21,8 @@ from metasim.cfg.sensors import PinholeCameraCfg
 from metasim.constants import PhysicStateType, SimType
 from metasim.utils import configclass
 from metasim.utils.setup_util import get_sim_handler_class
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 @configclass

--- a/metasim/scripts/motion_planning.py
+++ b/metasim/scripts/motion_planning.py
@@ -1,22 +1,18 @@
 from __future__ import annotations
 
-import argparse
-import os
-import time
-
 try:
     import isaacgym  # noqa: F401
 except ImportError:
     pass
 
-import rootutils
+import argparse
+import os
+import time
+
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
 from rich.logging import RichHandler
-
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
@@ -24,6 +20,8 @@ from metasim.utils.demo_util import get_traj
 from metasim.utils.kinematics_utils import get_curobo_models
 from metasim.utils.math import quat_from_euler_xyz
 from metasim.utils.setup_util import get_robot, get_sim_env_class
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 def parse_args():

--- a/metasim/scripts/motion_planning_gapartnet.py
+++ b/metasim/scripts/motion_planning_gapartnet.py
@@ -1,24 +1,21 @@
 from __future__ import annotations
 
-import argparse
-import json
-import os
-import time
-
 try:
     import isaacgym  # noqa: F401
 except ImportError:
     pass
 
+import argparse
+import json
+import os
+import time
+
 import numpy as np
-import rootutils
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
 from rich.logging import RichHandler
 
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg
 from metasim.constants import SimType
@@ -26,6 +23,8 @@ from metasim.utils.demo_util import get_traj
 from metasim.utils.kinematics_utils import get_curobo_models
 from metasim.utils.math import quat_from_euler_xyz
 from metasim.utils.setup_util import get_robot, get_sim_env_class
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 def parse_args():

--- a/metasim/scripts/random_action.py
+++ b/metasim/scripts/random_action.py
@@ -37,11 +37,9 @@ try:
 except ImportError:
     pass
 
-import rootutils
 import torch
 from curobo.types.math import Pose
 
-rootutils.setup_root(__file__, pythonpath=True)
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg
 from metasim.constants import SimType

--- a/metasim/scripts/random_action_ee.py
+++ b/metasim/scripts/random_action_ee.py
@@ -23,14 +23,10 @@ try:
 except ImportError:
     pass
 
-import rootutils
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
 from rich.logging import RichHandler
-
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg
@@ -38,6 +34,8 @@ from metasim.constants import SimType
 from metasim.utils.kinematics_utils import get_curobo_models
 from metasim.utils.math import quat_apply, quat_from_euler_xyz, quat_inv
 from metasim.utils.setup_util import get_robot, get_sim_env_class
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 def main():

--- a/metasim/scripts/random_action_pure.py
+++ b/metasim/scripts/random_action_pure.py
@@ -8,17 +8,16 @@ try:
 except ImportError:
     pass
 
-import rootutils
 import torch
 from loguru import logger as log
 from rich.logging import RichHandler
 
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
 from metasim.utils.demo_util import get_traj
 from metasim.utils.setup_util import get_sim_env_class
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 def parse_args():

--- a/metasim/scripts/random_action_really_pure.py
+++ b/metasim/scripts/random_action_really_pure.py
@@ -7,19 +7,16 @@ except ImportError:
 
 from dataclasses import dataclass
 
-import rootutils
 import torch
 import tyro
 from loguru import logger as log
 from rich.logging import RichHandler
 
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
-
-
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
 from metasim.utils.setup_util import get_sim_env_class
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 @dataclass

--- a/metasim/scripts/replay_demo.py
+++ b/metasim/scripts/replay_demo.py
@@ -12,17 +12,12 @@ except ImportError:
 
 import imageio as iio
 import numpy as np
-import rootutils
 import tyro
 from loguru import logger as log
 from numpy.typing import NDArray
 from rich.logging import RichHandler
 from torchvision.utils import make_grid, save_image
 from tyro import MISSING
-
-logging.addLevelName(5, "TRACE")
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
-rootutils.setup_root(__file__, pythonpath=True)
 
 from metasim.cfg.randomization import RandomizationCfg
 from metasim.cfg.render import RenderCfg
@@ -34,6 +29,9 @@ from metasim.utils import configclass
 from metasim.utils.demo_util import get_traj
 from metasim.utils.setup_util import get_sim_env_class
 from metasim.utils.state import TensorState
+
+logging.addLevelName(5, "TRACE")
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 @configclass

--- a/metasim/scripts/retarget_demo.py
+++ b/metasim/scripts/retarget_demo.py
@@ -33,30 +33,26 @@ args = tyro.cli(Args)
 #########################################
 ### Normal code
 #########################################
-import os
-
 try:
     import isaacgym  # noqa: F401
 except ImportError:
     pass
 
+import os
+from glob import glob
+
 import numpy as np
-import rootutils
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
 from rich.logging import RichHandler
 from tqdm.rich import tqdm, trange
 
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
-
-from glob import glob
-
 from metasim.utils.demo_util.loader import load_traj_file, save_traj_file
 from metasim.utils.kinematics_utils import ee_pose_from_tcp_pose, get_curobo_models, tcp_pose_from_ee_pose
 from metasim.utils.setup_util import get_robot, get_task
 
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 NUM_SEED = 20
 
 

--- a/metasim/scripts/teleop_keyboard.py
+++ b/metasim/scripts/teleop_keyboard.py
@@ -11,14 +11,10 @@ except ImportError:
     pass
 
 import pygame
-import rootutils
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
 from rich.logging import RichHandler
-
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg
@@ -28,6 +24,8 @@ from metasim.utils.kinematics_utils import get_curobo_models
 from metasim.utils.math import matrix_from_euler, quat_apply, quat_from_matrix, quat_inv, quat_mul
 from metasim.utils.setup_util import get_robot, get_sim_env_class, get_task
 from metasim.utils.teleop_utils import PygameKeyboardClient, process_kb_input
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 def parse_args():

--- a/metasim/scripts/teleop_phone.py
+++ b/metasim/scripts/teleop_phone.py
@@ -11,14 +11,10 @@ except ImportError:
     pass
 
 import numpy as np
-import rootutils
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
 from rich.logging import RichHandler
-
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg
@@ -33,6 +29,8 @@ from metasim.utils.teleop_utils import (
     quaternion_to_rotation_matrix,
     transform_orientation,
 )
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 def parse_args():

--- a/metasim/scripts/train_ppo.py
+++ b/metasim/scripts/train_ppo.py
@@ -1,6 +1,5 @@
 import gymnasium as gym
 import numpy as np
-import rootutils
 import torch
 from gymnasium import spaces
 from loguru import logger as log
@@ -8,13 +7,12 @@ from rich.logging import RichHandler
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import DummyVecEnv
 
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
-
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
 from metasim.sim import BaseSimHandler, EnvWrapper
 from metasim.utils.setup_util import get_robot, get_sim_env_class, get_task
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 class MetaSimGymEnv(gym.Env):

--- a/metasim/scripts/train_ppo_vec.py
+++ b/metasim/scripts/train_ppo_vec.py
@@ -10,7 +10,6 @@ from dataclasses import dataclass
 from typing import Literal
 
 import numpy as np
-import rootutils
 import torch
 import tyro
 from gymnasium import spaces
@@ -20,14 +19,13 @@ from rich.logging import RichHandler
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import VecEnv
 
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
-
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
 from metasim.sim import BaseSimHandler, EnvWrapper
 from metasim.utils.demo_util import get_traj
 from metasim.utils.setup_util import get_sim_env_class
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 @dataclass

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -2,13 +2,11 @@ from __future__ import annotations
 
 import genesis as gs
 import numpy as np
-import rootutils
 import torch
 from genesis.engine.entities.rigid_entity import RigidEntity, RigidJoint
 from genesis.vis.camera import Camera
 from loguru import logger as log
 
-rootutils.setup_root(__file__, pythonpath=True)
 from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, GymEnvWrapper

--- a/metasim/test/state_consistency.py
+++ b/metasim/test/state_consistency.py
@@ -11,15 +11,10 @@ except ImportError:
     pass
 
 
-import rootutils
 import torch
 import tyro
 from loguru import logger as log
 from rich.logging import RichHandler
-
-rootutils.setup_root(__file__, pythonpath=True)
-log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
-
 
 from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.scenario import ScenarioCfg
@@ -28,6 +23,8 @@ from metasim.constants import PhysicStateType, SimType
 from metasim.utils import configclass
 from metasim.utils.setup_util import get_sim_env_class
 from metasim.utils.state import state_tensor_to_nested
+
+log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
 
 @configclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ dependencies = [
     "loguru",
     "opencv-python",
     "rich",
-    "rootutils",
     "torch",
     "torchvision",
     "tqdm",

--- a/scripts/convert_traj_v1_to_v2.py
+++ b/scripts/convert_traj_v1_to_v2.py
@@ -3,11 +3,8 @@ import os
 import pickle as pkl
 
 import numpy as np
-import rootutils
 import torch
 from loguru import logger as log
-
-rootutils.setup_root(__file__, pythonpath=True)
 
 from metasim.cfg.robots.base_robot_cfg import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg

--- a/scripts/statistics/main.py
+++ b/scripts/statistics/main.py
@@ -2,11 +2,9 @@ import os
 import pickle as pkl
 
 import numpy as np
-import rootutils
 from loguru import logger as log
 from matplotlib import pyplot as plt
 
-rootutils.setup_root(__file__, pythonpath=True)
 from metasim.cfg.tasks.base_task_cfg import BaseTaskCfg
 from metasim.constants import TaskType
 from metasim.utils.demo_util import get_traj

--- a/scripts/test_usd.py
+++ b/scripts/test_usd.py
@@ -51,7 +51,6 @@ simulation_app = launch_isaaclab()
 
 import omni
 import omni.isaac.lab.sim as sim_utils
-import rootutils
 from loguru import logger as log
 from omni.isaac.lab.assets import (
     Articulation,
@@ -67,7 +66,6 @@ try:
 except ModuleNotFoundError:
     import isaacsim.core.utils.prims as prim_utils
 
-rootutils.setup_root(__file__, pythonpath=True)
 from metasim.sim.isaaclab.utils.ground_util import create_ground, set_ground_material, set_ground_material_scale
 from metasim.sim.isaaclab.utils.usd_util import ShaderFixer
 


### PR DESCRIPTION
This PR remove dependency on `rootutils` package, and remove its import in `metasim` module, since we already use pip install for it. The `roboverse_learn` and `get_started` are still allowd to keep using `rootutils` since they may not be prepared as a python module