### PR TITLE
[doc] support matrix

### DIFF
--- a/docs/source/metasim/index.md
+++ b/docs/source/metasim/index.md
@@ -27,7 +27,7 @@ get_started/rl_example/index
 :maxdepth: 2
 :titlesonly:
 
-
+user_guide/support_matrix
 user_guide/replay_demo
 user_guide/collect_demo
 user_guide/render

--- a/docs/source/metasim/user_guide/support_matrix.rst
+++ b/docs/source/metasim/user_guide/support_matrix.rst
@@ -20,21 +20,21 @@ The following table shows the parameters that can be set for the physics engine 
      - SAPIEN v3
      - PyBullet
    * - ``friction_offset_threshold``
-     - `✓ <https://isaac-sim.github.io/IsaacLab/v2.0.2/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.friction_offset_threshold>`_
+     - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.friction_offset_threshold>`_
      - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=friction_correlation_distance#isaacgym.gymapi.PhysXParams.friction_offset_threshold>`_
      -
      -
      -
      -
    * - ``friction_correlation_distance``
-     - `✓ <https://isaac-sim.github.io/IsaacLab/v2.0.2/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.friction_correlation_distance>`_
+     - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.friction_correlation_distance>`_
      - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=friction_correlation_distance#isaacgym.gymapi.PhysXParams.friction_correlation_distance>`_
      -
      -
      -
      -
    * - ``bounce_threshold_velocity``
-     - `✓ <https://isaac-sim.github.io/IsaacLab/v2.0.2/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.bounce_threshold_velocity>`_
+     - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.bounce_threshold_velocity>`_
      - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=bounce_threshold_velocity#isaacgym.gymapi.PhysXParams.bounce_threshold_velocity>`_
      -
      -

--- a/docs/source/metasim/user_guide/support_matrix.rst
+++ b/docs/source/metasim/user_guide/support_matrix.rst
@@ -13,15 +13,22 @@ The following table shows the parameters that can be set for the physics engine 
    :widths: 20 20 20 20 20 20 20
 
    * - Parameter
-     - IsaacLab v2.0.2
+     - IsaacLab
      - IsaacGym
      - MuJoCo
      - Genesis
      - SAPIEN v3
      - PyBullet
-   * - ``friction_offset_threshold``
-     - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.friction_offset_threshold>`_
-     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=friction_correlation_distance#isaacgym.gymapi.PhysXParams.friction_offset_threshold>`_
+   * - ``bounce_threshold_velocity``
+     - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.bounce_threshold_velocity>`_
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=bounce_threshold_velocity#isaacgym.gymapi.PhysXParams.bounce_threshold_velocity>`_
+     -
+     -
+     -
+     -
+   * - ``contact_offset``
+     -
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?#isaacgym.gymapi.RigidShapeProperties.contact_offset>`_
      -
      -
      -
@@ -33,9 +40,23 @@ The following table shows the parameters that can be set for the physics engine 
      -
      -
      -
-   * - ``bounce_threshold_velocity``
-     - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.bounce_threshold_velocity>`_
-     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=bounce_threshold_velocity#isaacgym.gymapi.PhysXParams.bounce_threshold_velocity>`_
+   * - ``friction_offset_threshold``
+     - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.friction_offset_threshold>`_
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=friction_correlation_distance#isaacgym.gymapi.PhysXParams.friction_offset_threshold>`_
+     -
+     -
+     -
+     -
+   * - ``num_position_iterations``
+     -
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?#isaacgym.gymapi.PhysXParams.num_position_iterations>`_
+     -
+     -
+     -
+     -
+   * - ``num_velocity_iterations``
+     -
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?#isaacgym.gymapi.PhysXParams.num_position_iterations>`_
      -
      -
      -
@@ -43,6 +64,61 @@ The following table shows the parameters that can be set for the physics engine 
    * - ``rest_offset``
      -
      - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=rest_offset#isaacgym.gymapi.RigidShapeProperties.rest_offset>`_
+     -
+     -
+     -
+     -
+   * - ``solver_type``
+     - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.solver_type>`_
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html#isaacgym.gymapi.PhysXParams.solver_type>`_
+     -
+     -
+     -
+     -
+
+Resource Parameters
+--------------------
+
+The following table shows the parameters related to resource management in each simulator.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 20 20 20 20
+
+   * - Parameter
+     - IsaacLab
+     - IsaacGym
+     - MuJoCo
+     - Genesis
+     - SAPIEN v3
+     - PyBullet
+   * - ``num_threads``
+     -
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html#isaacgym.gymapi.PhysXParams.num_threads>`_
+     -
+     -
+     -
+     -
+
+Misc Parameters
+---------------
+
+The following table shows the parameters that are not categorized in the above tables in each simulator.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 20 20 20 20
+
+   * - Parameter
+     - IsaacLab
+     - IsaacGym
+     - MuJoCo
+     - Genesis
+     - SAPIEN v3
+     - PyBullet
+   * - ``replace_cylinder_with_capsule``
+     -
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html#isaacgym.gymapi.AssetOptions.replace_cylinder_with_capsule>`_
      -
      -
      -

--- a/docs/source/metasim/user_guide/support_matrix.rst
+++ b/docs/source/metasim/user_guide/support_matrix.rst
@@ -3,6 +3,37 @@ Support Matrix
 
 This page provides a matrix of the support for different simulators in MetaSim.
 
+Simulation Parameters
+---------------------
+
+The following table shows the parameters that can be set for the simulation in each simulator. ``✓`` means the parameter is supported. Empty cell means the parameter is not supported. Other values means the default value in the original simulator.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 20 20 20 20
+
+   * - Parameter
+     - IsaacLab
+     - IsaacGym
+     - MuJoCo
+     - Genesis
+     - SAPIEN v3
+     - PyBullet
+   * - ``dt``
+     - `1/60 <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.SimulationCfg.dt>`_
+     - `1/60 <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=substeps#isaacgym.gymapi.SimParams.substeps>`_
+     - `1/500 <https://mujoco.readthedocs.io/en/stable/XMLreference.html#option>`_
+     -
+     -
+     - `1/240 <https://docs.google.com/document/d/10sXEhzFRSnvFcl3XxNGhnD4N2SedqwdAvK3dsihxVUA/edit?tab=t.0#heading=h.kyqqrtg5v8nc>`_
+   * - ``solver_type``
+     - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.solver_type>`_
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html#isaacgym.gymapi.PhysXParams.solver_type>`_
+     -
+     -
+     -
+     -
+
 Physics Engine Parameters
 -------------------------
 
@@ -64,13 +95,6 @@ The following table shows the parameters that can be set for the physics engine 
    * - ``rest_offset``
      -
      - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=rest_offset#isaacgym.gymapi.RigidShapeProperties.rest_offset>`_
-     -
-     -
-     -
-     -
-   * - ``solver_type``
-     - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.solver_type>`_
-     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html#isaacgym.gymapi.PhysXParams.solver_type>`_
      -
      -
      -

--- a/docs/source/metasim/user_guide/support_matrix.rst
+++ b/docs/source/metasim/user_guide/support_matrix.rst
@@ -23,8 +23,8 @@ The following table shows the parameters that can be set for the simulation in e
      - `1/60 <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.SimulationCfg.dt>`_
      - `1/60 <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=substeps#isaacgym.gymapi.SimParams.substeps>`_
      - `1/500 <https://mujoco.readthedocs.io/en/stable/XMLreference.html#option>`_
-     -
-     -
+     - `1/100 <https://genesis-world.readthedocs.io/en/latest/api_reference/scene/simulator.html#genesis.engine.simulator.Simulator.dt>`_
+     - 1/100
      - `1/240 <https://docs.google.com/document/d/10sXEhzFRSnvFcl3XxNGhnD4N2SedqwdAvK3dsihxVUA/edit?tab=t.0#heading=h.kyqqrtg5v8nc>`_
    * - ``solver_type``
      - `✓ <https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.solver_type>`_

--- a/docs/source/metasim/user_guide/support_matrix.rst
+++ b/docs/source/metasim/user_guide/support_matrix.rst
@@ -6,43 +6,43 @@ This page provides a matrix of the support for different simulators in MetaSim.
 Physics Engine Parameters
 -------------------------
 
-The following table shows the parameters that can be set for the physics engine.
+The following table shows the parameters that can be set for the physics engine in each simulator.
 
 .. list-table::
    :header-rows: 1
-   :widths: 20 20 20 20 20
+   :widths: 20 20 20 20 20 20 20
 
-   * - Simulator
-     - IsaacLab v1.4
+   * - Parameter
+     - IsaacLab v2.0.2
      - IsaacGym
      - MuJoCo
      - Genesis
      - SAPIEN v3
      - PyBullet
-   * - friction_offset_threshold
-     - ✓
-     - ✓
-     - 𐄂
-     - 𐄂
-     - 𐄂
-     - 𐄂
-   * - friction_correlation_distance
-     - ✓
-     - ✓
-     - 𐄂
-     - 𐄂
-     - 𐄂
-     - 𐄂
-   * - bounce_threshold_velocity
-     - ✓
-     - ✓
-     - 𐄂
-     - 𐄂
-     - 𐄂
-     - 𐄂
-   * - rest_offset
+   * - ``friction_offset_threshold``
+     - `✓ <https://isaac-sim.github.io/IsaacLab/v2.0.2/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.friction_offset_threshold>`_
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=friction_correlation_distance#isaacgym.gymapi.PhysXParams.friction_offset_threshold>`_
      -
-     - ✓
+     -
+     -
+     -
+   * - ``friction_correlation_distance``
+     - `✓ <https://isaac-sim.github.io/IsaacLab/v2.0.2/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.friction_correlation_distance>`_
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=friction_correlation_distance#isaacgym.gymapi.PhysXParams.friction_correlation_distance>`_
+     -
+     -
+     -
+     -
+   * - ``bounce_threshold_velocity``
+     - `✓ <https://isaac-sim.github.io/IsaacLab/v2.0.2/source/api/lab/isaaclab.sim.html#isaaclab.sim.PhysxCfg.bounce_threshold_velocity>`_
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=bounce_threshold_velocity#isaacgym.gymapi.PhysXParams.bounce_threshold_velocity>`_
+     -
+     -
+     -
+     -
+   * - ``rest_offset``
+     -
+     - `✓ <https://docs.robotsfan.com/isaacgym/api/python/struct_py.html?highlight=rest_offset#isaacgym.gymapi.RigidShapeProperties.rest_offset>`_
      -
      -
      -

--- a/docs/source/metasim/user_guide/support_matrix.rst
+++ b/docs/source/metasim/user_guide/support_matrix.rst
@@ -1,0 +1,49 @@
+Support Matrix
+==============
+
+This page provides a matrix of the support for different simulators in MetaSim.
+
+Physics Engine Parameters
+-------------------------
+
+The following table shows the parameters that can be set for the physics engine.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 20 20
+
+   * - Simulator
+     - IsaacLab v1.4
+     - IsaacGym
+     - MuJoCo
+     - Genesis
+     - SAPIEN v3
+     - PyBullet
+   * - friction_offset_threshold
+     - ✓
+     - ✓
+     - 𐄂
+     - 𐄂
+     - 𐄂
+     - 𐄂
+   * - friction_correlation_distance
+     - ✓
+     - ✓
+     - 𐄂
+     - 𐄂
+     - 𐄂
+     - 𐄂
+   * - bounce_threshold_velocity
+     - ✓
+     - ✓
+     - 𐄂
+     - 𐄂
+     - 𐄂
+     - 𐄂
+   * - rest_offset
+     -
+     - ✓
+     -
+     -
+     -
+     -

--- a/metasim/cfg/simulator_params.py
+++ b/metasim/cfg/simulator_params.py
@@ -19,15 +19,20 @@ class SimParamCfg:
     # TODO: currently only support isaacgym; add compatibility cfgs for other simulators.
     timestep: float = 1.0 / 60.0
     substeps: int = 2
+
+    ## Physics
+    bounce_threshold_velocity: float = 0.2
     contact_offset: float = 0.001
     num_position_iterations: int = 8
     num_velocity_iterations: int = 1
-    bounce_threshold_velocity: float = 0.2
-    friction_offset_threshold: float = 0.001
     friction_correlation_distance: float = 0.0005
+    friction_offset_threshold: float = 0.001
     replace_cylinder_with_capsule: bool = False
-    solver_type: int = 1
     rest_offset: float = 0.0
+    solver_type: int = 1
+
+    ## Resource management
     num_threads: int = 0
+    # XXX: these parameters should be replaced by "device" in the future
     use_gpu_pipeline: bool = True
     use_gpu: bool = True

--- a/metasim/cfg/simulator_params.py
+++ b/metasim/cfg/simulator_params.py
@@ -18,7 +18,6 @@ class SimParamCfg:
 
     # TODO: currently only support isaacgym; add compatibility cfgs for other simulators.
     timestep: float = 1.0 / 60.0
-    substeps: int = 2
 
     ## Physics
     bounce_threshold_velocity: float = 0.2

--- a/metasim/cfg/simulator_params.py
+++ b/metasim/cfg/simulator_params.py
@@ -16,8 +16,8 @@ class SimParamCfg:
     Reference for IsaacGym: https://docs.robotsfan.com/isaacgym/api/python/struct_py.html#isaacgym.gymapi.PhysXParams
     """
 
-    # TODO: currently only support isaacgym; add compatibility cfgs for other simulators.
-    timestep: float = 1.0 / 60.0
+    ## Simulation
+    dt: float = 1.0 / 60.0
 
     ## Physics
     bounce_threshold_velocity: float = 0.2

--- a/metasim/cfg/simulator_params.py
+++ b/metasim/cfg/simulator_params.py
@@ -17,7 +17,13 @@ class SimParamCfg:
     """
 
     ## Simulation
-    dt: float = 1.0 / 60.0
+    dt: float | None = None
+    """The time-step of the simulation. If None, the default value in the original simulator will be used. The default value for each simulator is:
+    - IsaacGym: 1/60
+    - IsaacLab: 1/60
+    - MuJoCo: 1/500
+    - PyBullet: 1/240
+    """
 
     ## Physics
     bounce_threshold_velocity: float = 0.2

--- a/metasim/cfg/tasks/humanoidbench/base_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/base_cfg.py
@@ -49,7 +49,7 @@ class HumanoidTaskCfg(BaseRLTaskCfg):
     objects = []
     reward_weights = [1.0]
     sim_params = SimParamCfg(
-        timestep=0.001,
+        dt=0.001,
         contact_offset=0.01,
         num_position_iterations=8,
         num_velocity_iterations=0,

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -24,7 +24,10 @@ class GenesisHandler(BaseSimHandler):
     def launch(self) -> None:
         gs.init(backend=gs.gpu)  # TODO: add option for cpu
         self.scene_inst = gs.Scene(
-            sim_options=gs.options.SimOptions(substeps=1),  # TODO: substeps > 1 doesn't work
+            sim_options=gs.options.SimOptions(
+                dt=self.scenario.sim_params.dt if self.scenario.sim_params.dt is not None else 1 / 100,
+                substeps=1,
+            ),  # TODO: substeps > 1 doesn't work
             vis_options=gs.options.VisOptions(n_rendered_envs=self.scenario.num_envs),
             viewer_options=gs.options.ViewerOptions(
                 camera_pos=(3.5, 0.0, 2.5),

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -97,7 +97,8 @@ class IsaacgymHandler(BaseSimHandler):
         sim_params = gymapi.SimParams()
         sim_params.up_axis = gymapi.UP_AXIS_Z
         sim_params.gravity = gymapi.Vec3(0.0, 0.0, -9.8)
-        sim_params.dt = self.scenario.sim_params.dt
+        if self.scenario.sim_params.dt is not None:
+            sim_params.dt = self.scenario.sim_params.dt
         sim_params.substeps = self.scenario.decimation
         sim_params.use_gpu_pipeline = self.scenario.sim_params.use_gpu_pipeline
         sim_params.physx.solver_type = self.scenario.sim_params.solver_type

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -97,7 +97,7 @@ class IsaacgymHandler(BaseSimHandler):
         sim_params = gymapi.SimParams()
         sim_params.up_axis = gymapi.UP_AXIS_Z
         sim_params.gravity = gymapi.Vec3(0.0, 0.0, -9.8)
-        sim_params.dt = self.scenario.sim_params.timestep
+        sim_params.dt = self.scenario.sim_params.dt
         sim_params.substeps = self.scenario.decimation
         sim_params.use_gpu_pipeline = self.scenario.sim_params.use_gpu_pipeline
         sim_params.physx.solver_type = self.scenario.sim_params.solver_type

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -98,7 +98,7 @@ class IsaacgymHandler(BaseSimHandler):
         sim_params.up_axis = gymapi.UP_AXIS_Z
         sim_params.gravity = gymapi.Vec3(0.0, 0.0, -9.8)
         sim_params.dt = self.scenario.sim_params.timestep
-        sim_params.substeps = self.scenario.sim_params.substeps
+        sim_params.substeps = self.scenario.decimation
         sim_params.use_gpu_pipeline = self.scenario.sim_params.use_gpu_pipeline
         sim_params.physx.solver_type = self.scenario.sim_params.solver_type
         sim_params.physx.num_position_iterations = self.scenario.sim_params.num_position_iterations
@@ -617,8 +617,7 @@ class IsaacgymHandler(BaseSimHandler):
 
     def simulate(self) -> None:
         # Step the physics
-        for _ in range(self.scenario.decimation):
-            self._simulate_one_physics_step(self.actions)
+        self._simulate_one_physics_step(self.actions)
         # Refresh tensors
         if not self._manual_pd_on:
             self.gym.refresh_dof_state_tensor(self.sim)

--- a/metasim/sim/isaaclab/empty_env.py
+++ b/metasim/sim/isaaclab/empty_env.py
@@ -33,7 +33,6 @@ class EmptyEnvCfg(DirectRLEnvCfg):
     )
     sim: SimulationCfg = SimulationCfg(
         device="cuda:0",  # same as IsaacLab default
-        dt=1 / 60,  # same as IsaacLab default
         gravity=(0.0, 0.0, -9.81),  # same as IsaacLab default
         physx=PhysxCfg(),
     )

--- a/metasim/sim/isaaclab/empty_env.py
+++ b/metasim/sim/isaaclab/empty_env.py
@@ -21,8 +21,8 @@ from .utils.custom_direct_rl_env import CustomDirectRLEnv
 
 @configclass
 class EmptyEnvCfg(DirectRLEnvCfg):
-    decimation: int = 3
-    episode_length_s: float = 200 * (1 / 60) * decimation  # 200 steps
+    decimation: int = 3  # just a placeholder, value overwritten in isaaclab.py
+    episode_length_s: float = 200 * (1 / 60) * decimation  # just a placeholder, value overwritten in isaaclab.py
     observation_space: int = 0  # no use, but must be initialized
     action_space: int = 0  # no use, but must be initialized
     state_space: int = 0  # no use, but must be initialized

--- a/metasim/sim/isaaclab/empty_env.py
+++ b/metasim/sim/isaaclab/empty_env.py
@@ -34,7 +34,6 @@ class EmptyEnvCfg(DirectRLEnvCfg):
     sim: SimulationCfg = SimulationCfg(
         device="cuda:0",  # same as IsaacLab default
         dt=1 / 60,  # same as IsaacLab default
-        render_interval=decimation,
         gravity=(0.0, 0.0, -9.81),  # same as IsaacLab default
         physx=PhysxCfg(),
     )

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -80,10 +80,11 @@ class IsaaclabHandler(BaseSimHandler):
             from isaaclab_tasks.utils import parse_env_cfg
 
         env_cfg = parse_env_cfg("MetaSimEmptyTaskEnv")
+        env_cfg.sim.dt = self.scenario.sim_params.dt
         env_cfg.sim.render_interval = self.scenario.decimation
         env_cfg.scene.num_envs = self.num_envs
         env_cfg.decimation = self.scenario.decimation
-        env_cfg.episode_length_s = self.scenario.episode_length * (1 / 60) * self.scenario.decimation
+        env_cfg.episode_length_s = self.scenario.episode_length * self.scenario.sim_params.dt * self.scenario.decimation
 
         ## Physx settings
         env_cfg.sim.physx.bounce_threshold_velocity = self.scenario.sim_params.bounce_threshold_velocity

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -80,9 +80,15 @@ class IsaaclabHandler(BaseSimHandler):
             from isaaclab_tasks.utils import parse_env_cfg
 
         env_cfg = parse_env_cfg("MetaSimEmptyTaskEnv")
+        env_cfg.sim.render_interval = self.scenario.decimation
         env_cfg.scene.num_envs = self.num_envs
         env_cfg.decimation = self.scenario.decimation
         env_cfg.episode_length_s = self.scenario.episode_length * (1 / 60) * self.scenario.decimation
+
+        ## Physx settings
+        env_cfg.sim.physx.bounce_threshold_velocity = self.scenario.sim_params.bounce_threshold_velocity
+        env_cfg.sim.physx.friction_offset_threshold = self.scenario.sim_params.friction_offset_threshold
+        env_cfg.sim.physx.friction_correlation_distance = self.scenario.sim_params.friction_correlation_distance
 
         self.env: EmptyEnv = gym.make("MetaSimEmptyTaskEnv", cfg=env_cfg)
 

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -89,6 +89,7 @@ class IsaaclabHandler(BaseSimHandler):
         env_cfg.sim.physx.bounce_threshold_velocity = self.scenario.sim_params.bounce_threshold_velocity
         env_cfg.sim.physx.friction_offset_threshold = self.scenario.sim_params.friction_offset_threshold
         env_cfg.sim.physx.friction_correlation_distance = self.scenario.sim_params.friction_correlation_distance
+        env_cfg.sim.physx.solver_type = self.scenario.sim_params.solver_type
 
         self.env: EmptyEnv = gym.make("MetaSimEmptyTaskEnv", cfg=env_cfg)
 

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -80,7 +80,8 @@ class IsaaclabHandler(BaseSimHandler):
             from isaaclab_tasks.utils import parse_env_cfg
 
         env_cfg = parse_env_cfg("MetaSimEmptyTaskEnv")
-        env_cfg.sim.dt = self.scenario.sim_params.dt
+        if self.scenario.sim_params.dt is not None:
+            env_cfg.sim.dt = self.scenario.sim_params.dt
         env_cfg.sim.render_interval = self.scenario.decimation
         env_cfg.scene.num_envs = self.num_envs
         env_cfg.decimation = self.scenario.decimation

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -97,6 +97,8 @@ class MujocoHandler(BaseSimHandler):
 
     def _init_mujoco(self) -> mjcf.RootElement:
         mjcf_model = mjcf.RootElement()
+        if self.scenario.sim_params.dt is not None:
+            mjcf_model.option.timestep = self.scenario.sim_params.dt
 
         ## Optional: Add ground grid
         # mjcf_model.asset.add('texture', name="texplane", type="2d", builtin="checker", width=512, height=512, rgb1=[0.2, 0.3, 0.4], rgb2=[0.1, 0.2, 0.3])

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -40,7 +40,10 @@ class SinglePybulletHandler(BaseSimHandler):
 
     def _build_pybullet(self):
         self.client = p.connect(p.GUI)
-        p.setPhysicsEngineParameter(fixedTimeStep=1 / 60.0, numSolverIterations=300)
+        p.setPhysicsEngineParameter(
+            fixedTimeStep=self.scenario.sim_params.dt if self.scenario.sim_params.dt is not None else 1.0 / 240.0,
+            numSolverIterations=300,
+        )
         p.setAdditionalSearchPath(pybullet_data.getDataPath())
         p.setGravity(0, 0, -9.81)
 

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -54,8 +54,6 @@ class SingleSapien3Handler(BaseSimHandler):
         self.engine = sapien_core.Engine()  # Create a physical simulation engine
         self.renderer = sapien_core.SapienRenderer()  # Create a renderer
 
-        self.time_step = 1 / 100.0
-
         scene_config = sapien_core.SceneConfig()
         # scene_config.default_dynamic_friction = self.physical_params.dynamic_friction
         # scene_config.default_static_friction = self.physical_params.static_friction
@@ -69,7 +67,7 @@ class SingleSapien3Handler(BaseSimHandler):
 
         self.engine.set_renderer(self.renderer)
         self.scene = self.engine.create_scene(scene_config)
-        self.scene.set_timestep(self.time_step)
+        self.scene.set_timestep(self.scenario.sim_params.dt if self.scenario.sim_params.dt is not None else 1 / 100)
         ground_material = self.renderer.create_material()
         ground_material.base_color = np.array([202, 164, 114, 256]) / 256
         ground_material.specular = 0.5


### PR DESCRIPTION
This PR:
1. Add [support matrix](https://doc-support-matrix.roboverse-release.pages.dev/metasim/user_guide/support_matrix) to doc
2. Align isaaclab with recently added `sim_params` in #164 
3. Align `dt` across different simulators. Currently use their own default value in the original simulator by default. Not aligning them with a specific number is because MuJoCo has so much difference with other simulators. It seems MuJoCo must work with very high precision (dt=1/500) to work well