### PR TITLE
[refactor] reorganize `objects.py`

### DIFF
--- a/docs/source/metasim/api/metasim/metasim.cfg.objects.rst
+++ b/docs/source/metasim/api/metasim/metasim.cfg.objects.rst
@@ -2,6 +2,7 @@
 ===================
 
 Dependency graph:
+
 .. mermaid::
    %%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
    flowchart LR

--- a/docs/source/metasim/api/metasim/metasim.cfg.objects.rst
+++ b/docs/source/metasim/api/metasim/metasim.cfg.objects.rst
@@ -1,6 +1,38 @@
 ﻿metasim.cfg.objects
 ===================
 
+Dependency graph:
+.. mermaid::
+   %%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
+   flowchart LR
+      N0[BaseObjCfg]
+      N11[BaseRigidObjCfg]
+      N12[BaseArticulationObjCfg]
+
+      subgraph "Level 0"
+         N0
+      end
+      subgraph "Level 1"
+         N11
+         N12
+      end
+      subgraph "Level 2"
+         RigidObjCfg
+         ArticulationObjCfg
+         PrimitiveCubeCfg & PrimitiveSphereCfg & PrimitiveCylinderCfg
+      end
+      subgraph "Mixins"
+         direction LR
+         FileBasedMixin
+         PrimitiveMixin
+      end
+
+      N0 --> N11 & N12
+      N11 & FileBasedMixin ---> RigidObjCfg
+      N12 & FileBasedMixin ---> ArticulationObjCfg
+      N11 & PrimitiveMixin ---> PrimitiveCubeCfg & PrimitiveSphereCfg &PrimitiveCylinderCfg
+
+
 .. automodule:: metasim.cfg.objects
 
    .. rubric:: Base Class

--- a/docs/source/metasim/api/metasim/metasim.cfg.objects.rst
+++ b/docs/source/metasim/api/metasim/metasim.cfg.objects.rst
@@ -4,6 +4,7 @@
 Dependency graph:
 
 .. mermaid::
+
    %%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
    flowchart LR
       N0[BaseObjCfg]

--- a/docs/source/metasim/api/metasim/metasim.cfg.objects.rst
+++ b/docs/source/metasim/api/metasim/metasim.cfg.objects.rst
@@ -7,32 +7,32 @@ Dependency graph:
 
    %%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
    flowchart LR
-      N0[BaseObjCfg]
-      N11[BaseRigidObjCfg]
-      N12[BaseArticulationObjCfg]
+   N0[BaseObjCfg]
+   N11[BaseRigidObjCfg]
+   N12[BaseArticulationObjCfg]
 
-      subgraph "Level 0"
-         N0
-      end
-      subgraph "Level 1"
-         N11
-         N12
-      end
-      subgraph "Level 2"
-         RigidObjCfg
-         ArticulationObjCfg
-         PrimitiveCubeCfg & PrimitiveSphereCfg & PrimitiveCylinderCfg
-      end
-      subgraph "Mixins"
-         direction LR
-         FileBasedMixin
-         PrimitiveMixin
-      end
+   subgraph "Level 0"
+      N0
+   end
+   subgraph "Level 1"
+      N11
+      N12
+   end
+   subgraph "Level 2"
+      RigidObjCfg
+      ArticulationObjCfg
+      PrimitiveCubeCfg & PrimitiveSphereCfg & PrimitiveCylinderCfg
+   end
+   subgraph "Mixins"
+      direction LR
+      FileBasedMixin
+      PrimitiveMixin
+   end
 
-      N0 --> N11 & N12
-      N11 & FileBasedMixin ---> RigidObjCfg
-      N12 & FileBasedMixin ---> ArticulationObjCfg
-      N11 & PrimitiveMixin ---> PrimitiveCubeCfg & PrimitiveSphereCfg &PrimitiveCylinderCfg
+   N0 --> N11 & N12
+   N11 & FileBasedMixin ---> RigidObjCfg
+   N12 & FileBasedMixin ---> ArticulationObjCfg
+   N11 & PrimitiveMixin ---> PrimitiveCubeCfg & PrimitiveSphereCfg & PrimitiveCylinderCfg
 
 
 .. automodule:: metasim.cfg.objects

--- a/docs/source/metasim/api/metasim/metasim.cfg.objects.rst
+++ b/docs/source/metasim/api/metasim/metasim.cfg.objects.rst
@@ -25,14 +25,14 @@ Dependency graph:
    end
    subgraph "Mixins"
       direction LR
-      FileBasedMixin
-      PrimitiveMixin
+      _FileBasedMixin
+      _PrimitiveMixin
    end
 
    N0 --> N11 & N12
-   N11 & FileBasedMixin ---> RigidObjCfg
-   N12 & FileBasedMixin ---> ArticulationObjCfg
-   N11 & PrimitiveMixin ---> PrimitiveCubeCfg & PrimitiveSphereCfg & PrimitiveCylinderCfg
+   N11 & _FileBasedMixin ---> RigidObjCfg
+   N12 & _FileBasedMixin ---> ArticulationObjCfg
+   N11 & _PrimitiveMixin ---> PrimitiveCubeCfg & PrimitiveSphereCfg & PrimitiveCylinderCfg
 
 
 .. automodule:: metasim.cfg.objects

--- a/metasim/cfg/objects.py
+++ b/metasim/cfg/objects.py
@@ -14,7 +14,7 @@ from metasim.utils import configclass
 
 
 @configclass
-class FileBasedMixin:
+class _FileBasedMixin:
     """File-based mixin."""
 
     mesh_path: str | None = None
@@ -48,7 +48,7 @@ class FileBasedMixin:
 
 
 @configclass
-class PrimitiveMixin:
+class _PrimitiveMixin:
     """Primitive mixin."""
 
     mass: float = 0.1
@@ -134,17 +134,17 @@ class BaseArticulationObjCfg(BaseObjCfg):
 
 
 @configclass
-class RigidObjCfg(FileBasedMixin, BaseRigidObjCfg):
+class RigidObjCfg(_FileBasedMixin, BaseRigidObjCfg):
     """Rigid object cfg."""
 
 
 @configclass
-class ArticulationObjCfg(FileBasedMixin, BaseArticulationObjCfg):
+class ArticulationObjCfg(_FileBasedMixin, BaseArticulationObjCfg):
     """Articulation object cfg."""
 
 
 @configclass
-class PrimitiveCubeCfg(PrimitiveMixin, BaseRigidObjCfg):
+class PrimitiveCubeCfg(_PrimitiveMixin, BaseRigidObjCfg):
     """Primitive cube object cfg."""
 
     size: list[float] = MISSING
@@ -162,7 +162,7 @@ class PrimitiveCubeCfg(PrimitiveMixin, BaseRigidObjCfg):
 
 
 @configclass
-class PrimitiveSphereCfg(PrimitiveMixin, BaseRigidObjCfg):
+class PrimitiveSphereCfg(_PrimitiveMixin, BaseRigidObjCfg):
     """Primitive sphere object cfg."""
 
     radius: float = MISSING
@@ -175,7 +175,7 @@ class PrimitiveSphereCfg(PrimitiveMixin, BaseRigidObjCfg):
 
 
 @configclass
-class PrimitiveCylinderCfg(PrimitiveMixin, BaseRigidObjCfg):
+class PrimitiveCylinderCfg(_PrimitiveMixin, BaseRigidObjCfg):
     """Primitive cylinder object cfg."""
 
     radius: float = MISSING

--- a/metasim/cfg/objects.py
+++ b/metasim/cfg/objects.py
@@ -1,7 +1,37 @@
-"""Configuration classes for various types of objects used in the simulation.
+"""Configuration classes for various types of objects.
 
-Configurations include the object name, source file, geometries (scaling, radius, etc.),
-and physics (mass, density, etc.).
+Dependency graph:
+```mermaid
+%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
+flowchart LR
+    N0[BaseObjCfg]
+    N11[BaseRigidObjCfg]
+    N12[BaseArticulationObjCfg]
+
+    subgraph "Level 0"
+        N0
+    end
+    subgraph "Level 1"
+        N11
+        N12
+    end
+    subgraph "Level 2"
+        RigidObjCfg
+        ArticulationObjCfg
+        PrimitiveCubeCfg & PrimitiveSphereCfg & PrimitiveCylinderCfg
+    end
+    subgraph "Mixins"
+        direction LR
+        FileBasedMixin
+        PrimitiveMixin
+    end
+
+    N0 --> N11 & N12
+    N11 & FileBasedMixin ---> RigidObjCfg
+    N12 & FileBasedMixin ---> ArticulationObjCfg
+    N11 & PrimitiveMixin ---> PrimitiveCubeCfg & PrimitiveSphereCfg & PrimitiveCylinderCfg
+```
+
 """
 
 from __future__ import annotations
@@ -12,6 +42,70 @@ from dataclasses import MISSING
 from metasim.constants import PhysicStateType
 from metasim.utils import configclass
 
+##################################################
+# Mixins: File-based or Primitive
+##################################################
+
+
+@configclass
+class FileBasedMixin:
+    """File-based mixin."""
+
+    mesh_path: str | None = None
+    """Path to the mesh file."""
+
+    usd_path: str | None = None
+    """Path to the USD file."""
+
+    urdf_path: str | None = None
+    """Path to the URDF file."""
+
+    mjcf_path: str | None = None
+    """Path to the MJCF file."""
+
+    mjx_mjcf_path: str | None = None
+    """Path to the MJCF file only used for MJX. If not specified, it will be the same as mjcf_path."""
+
+    scale: float | tuple[float, float, float] = 1.0
+    """Object scaling (in scalar) for the object, default is 1.0"""
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        ## Transform the 1d scale to a tuple of (x-scale, y-scale, z-scale).
+        if isinstance(self.scale, float):
+            self.scale = (self.scale, self.scale, self.scale)
+
+        ## Set the mjx_mjcf_path if it is not specified.
+        if self.mjx_mjcf_path is None:
+            self.mjx_mjcf_path = self.mjcf_path
+
+
+@configclass
+class PrimitiveMixin:
+    """Primitive mixin."""
+
+    mass: float = 0.1
+    """Mass of the object (in kg), default is 0.1 kg"""
+
+    color: list[float] = MISSING
+    """Color of the object in RGB"""
+
+    @property
+    def volume(self) -> float:
+        """Volume of the object."""
+        raise NotImplementedError
+
+    @property
+    def density(self) -> float:
+        """Density of the object."""
+        return self.mass / self.volume
+
+
+##################################################
+# Level 0: Base
+##################################################
+
 
 @configclass
 class BaseObjCfg:
@@ -19,45 +113,36 @@ class BaseObjCfg:
 
     name: str = MISSING
     """Object name"""
+
     default_position: tuple[float, float, float] = (0.0, 0.0, 0.0)
     """Default position of the object, default is (0.0, 0.0, 0.0)"""
+
     default_orientation: tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)  # w, x, y, z
     """Default orientation of the object, default is (1.0, 0.0, 0.0, 0.0)"""
 
-
-# File-based object
-@configclass
-class RigidObjCfg(BaseObjCfg):
-    """Rigid object cfg.
-
-    The file source should be specified, from a USD, URDF, MJCF, or mesh file,
-    with the path specified by the members below.
-
-    Attributes:
-        usd_path: Path to the USD file
-        urdf_path: Path to the URDF file
-        mjcf_path: Path to the MJCF file
-        mesh_path: Path to the Mesh file
-        physics: Specify the physics APIs applied on the object
-    """
-
-    usd_path: str | None = None
-    urdf_path: str | None = None
-    mjcf_path: str | None = None
-    mjx_mjcf_path: str | None = None
-    """Path to the MJCF file only used for MJX. If not specified, it will be the same as mjcf_path."""
-    mesh_path: str | None = None
-    collision_enabled: bool = True
-    physics: PhysicStateType | None = None
     fix_base_link: bool = False
     """Whether to fix the base link of the object, default is False"""
-    scale: float | tuple[float, float, float] = 1.0
-    """Object scaling (in scalar) for the object, default is 1.0"""
+
+
+##################################################
+# Level 1: Base rigid object and base articulation object
+##################################################
+
+
+@configclass
+class BaseRigidObjCfg(BaseObjCfg):
+    """Base rigid object cfg."""
+
+    collision_enabled: bool = True
+    """Whether to enable collision."""
+
+    physics: PhysicStateType | None = None
+    """IsaacSim's convention for collision and gravity state. Default to None. If specified, it will be translated to :attr:`collision_enabled` and :attr:`fix_base_link`."""
 
     def __post_init__(self):
         super().__post_init__()
 
-        ## Parse the physics state to the enabled and fix_base_link.
+        ## Parse physics to collision_enabled and fix_base_link.
         if self.physics is not None:
             if self.physics == PhysicStateType.XFORM:
                 self.collision_enabled = False
@@ -71,61 +156,33 @@ class RigidObjCfg(BaseObjCfg):
             else:
                 raise ValueError(f"Invalid physics type: {self.physics}")
 
-        ## Transform the 1d scale to a tuple of (x-scale, y-scale, z-scale).
-        if isinstance(self.scale, float):
-            self.scale = (self.scale, self.scale, self.scale)
 
-        ## Set the mjx_mjcf_path if it is not specified.
-        if self.mjx_mjcf_path is None:
-            self.mjx_mjcf_path = self.mjcf_path
+@configclass
+class BaseArticulationObjCfg(BaseObjCfg):
+    """Base articulation object cfg."""
+
+
+##################################################
+# Level 2: Concrete object
+##################################################
 
 
 @configclass
-class NonConvexRigidObjCfg(RigidObjCfg):
-    """Non-convex rigid object class."""
-
-    mesh_pose: list[float] = MISSING
+class RigidObjCfg(FileBasedMixin, BaseRigidObjCfg):
+    """Rigid object cfg."""
 
 
 @configclass
-class ArticulationObjCfg(BaseObjCfg):
+class ArticulationObjCfg(FileBasedMixin, BaseArticulationObjCfg):
     """Articulation object cfg."""
 
-    usd_path: str | None = None
-    urdf_path: str | None = None
-    mjcf_path: str | None = None
-    mjx_mjcf_path: str | None = None
-    """Path to the MJCF file only used for MJX. If not specified, it will be the same as mjcf_path."""
-    fix_base_link: bool = False
-    """Whether to fix the base link of the object, default is False"""
-    scale: float | tuple[float, float, float] = 1.0
-    """Object scaling (in scalar) for the object, default is 1.0"""
 
-    def __post_init__(self):
-        super().__post_init__()
-
-        ## Transform the 1d scale to a tuple of (x-scale, y-scale, z-scale).
-        if isinstance(self.scale, float):
-            self.scale = (self.scale, self.scale, self.scale)
-
-        ## Set the mjx_mjcf_path if it is not specified.
-        if self.mjx_mjcf_path is None:
-            self.mjx_mjcf_path = self.mjcf_path
-
-
-# Primitive object are all rigid objects
 @configclass
-class PrimitiveCubeCfg(RigidObjCfg):
+class PrimitiveCubeCfg(PrimitiveMixin, BaseRigidObjCfg):
     """Primitive cube object cfg."""
 
-    mass: float = 0.1
-    """Mass of the object (in kg), default is 0.1 kg"""
-    color: list[float] = MISSING
-    """Color of the object in RGB"""
     size: list[float] = MISSING
-    """Size of the object (in m)"""
-    physics: PhysicStateType = MISSING
-    """Physics state of the object"""
+    """Size of the object (in m)."""
 
     @property
     def half_size(self) -> list[float]:
@@ -133,34 +190,54 @@ class PrimitiveCubeCfg(RigidObjCfg):
         return [size / 2 for size in self.size]
 
     @property
-    def density(self) -> float:
-        """Object density, for SAPIEN usage."""
-        return self.mass / (self.size[0] * self.size[1] * self.size[2])
+    def volume(self) -> float:
+        """Volume of the cube."""
+        return self.size[0] * self.size[1] * self.size[2]
 
 
 @configclass
-class PrimitiveSphereCfg(RigidObjCfg):
+class PrimitiveSphereCfg(PrimitiveMixin, BaseRigidObjCfg):
     """Primitive sphere object cfg."""
 
-    mass: float = 0.1
-    color: list[float] = MISSING
     radius: float = MISSING
-    physics: PhysicStateType = MISSING
+    """Radius of the sphere (in m)."""
 
     @property
-    def density(self) -> float:
-        """For SAPIEN usage."""
-        return self.mass / (4 / 3 * math.pi * self.radius**3)
+    def volume(self) -> float:
+        """Volume of the sphere."""
+        return 4 / 3 * math.pi * self.radius**3
+
+
+@configclass
+class PrimitiveCylinderCfg(PrimitiveMixin, BaseRigidObjCfg):
+    """Primitive cylinder object cfg."""
+
+    radius: float = MISSING
+    """Radius of the cylinder (in m)."""
+
+    height: float = MISSING
+    """Height of the cylinder (in m)."""
+
+    @property
+    def volume(self) -> float:
+        """Volume of the cylinder."""
+        return math.pi * self.radius**2 * self.height
+
+
+##################################################
+# Other objects
+##################################################
 
 
 @configclass
 class PrimitiveFrameCfg(RigidObjCfg):
-    """Primitive coordinate frame cfg."""
+    """Primitive coordinate frame cfg.
+
+    .. warning::
+        This class is experimental and subject to change.
+    """
 
     # TODO: This is object shouldn't inherit from RigidObjCfg?
-    name: str = MISSING
-    scale: float = 1.0
-    """Scale of the frame"""
     base_link: str | tuple[str, str] | None = None
     """Base link to attach the frame.
         If ``None``, the frame will be attached to the world origin.
@@ -170,16 +247,12 @@ class PrimitiveFrameCfg(RigidObjCfg):
 
 
 @configclass
-class PrimitiveCylinderCfg(RigidObjCfg):
-    """Primitive cylinder object cfg."""
+class NonConvexRigidObjCfg(RigidObjCfg):
+    """Non-convex rigid object class.
 
-    mass: float = 0.1
-    color: list[float] = MISSING
-    radius: float = MISSING
-    height: float = MISSING
-    physics: PhysicStateType = MISSING
+    .. warning::
+        This class is deprecated and will be removed in the future.
+    """
 
-    @property
-    def density(self) -> float:
-        """For SAPIEN usage."""
-        return self.mass / (math.pi * self.radius**2 * self.height)
+    # TODO: remove this
+    mesh_pose: list[float] = MISSING

--- a/metasim/cfg/objects.py
+++ b/metasim/cfg/objects.py
@@ -1,38 +1,4 @@
-"""Configuration classes for various types of objects.
-
-Dependency graph:
-```{mermaid}
-%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
-flowchart LR
-    N0[BaseObjCfg]
-    N11[BaseRigidObjCfg]
-    N12[BaseArticulationObjCfg]
-
-    subgraph "Level 0"
-        N0
-    end
-    subgraph "Level 1"
-        N11
-        N12
-    end
-    subgraph "Level 2"
-        RigidObjCfg
-        ArticulationObjCfg
-        PrimitiveCubeCfg & PrimitiveSphereCfg & PrimitiveCylinderCfg
-    end
-    subgraph "Mixins"
-        direction LR
-        FileBasedMixin
-        PrimitiveMixin
-    end
-
-    N0 --> N11 & N12
-    N11 & FileBasedMixin ---> RigidObjCfg
-    N12 & FileBasedMixin ---> ArticulationObjCfg
-    N11 & PrimitiveMixin ---> PrimitiveCubeCfg & PrimitiveSphereCfg & PrimitiveCylinderCfg
-```
-
-"""
+"""Configuration classes for various types of objects."""
 
 from __future__ import annotations
 

--- a/metasim/cfg/objects.py
+++ b/metasim/cfg/objects.py
@@ -1,7 +1,7 @@
 """Configuration classes for various types of objects.
 
 Dependency graph:
-```mermaid
+```{mermaid}
 %%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
 flowchart LR
     N0[BaseObjCfg]

--- a/metasim/cfg/tasks/calvin/scene/scene_A.py
+++ b/metasim/cfg/tasks/calvin/scene/scene_A.py
@@ -17,26 +17,23 @@ class SceneA(BaseTaskCfg):
         PrimitiveCubeCfg(
             name="block_red",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.07, 0.05, 0.05),
+            size=(0.056, 0.04, 0.04),
             color=(1.0, 0.0, 0.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
         PrimitiveCubeCfg(
             name="block_blue",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.1, 0.05, 0.05),
+            size=(0.08, 0.04, 0.04),
             color=(0.0, 0.0, 1.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
         PrimitiveCubeCfg(
             name="block_pink",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.05, 0.05, 0.05),
+            size=(0.04, 0.04, 0.04),
             color=(1.0, 0.0, 1.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
     ]
 

--- a/metasim/cfg/tasks/calvin/scene/scene_B.py
+++ b/metasim/cfg/tasks/calvin/scene/scene_B.py
@@ -17,26 +17,23 @@ class SceneB(BaseTaskCfg):
         PrimitiveCubeCfg(
             name="block_red",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.05, 0.05, 0.05),  # block_red_small
+            size=(0.04, 0.04, 0.04),  # block_red_small
             color=(1.0, 0.0, 0.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
         PrimitiveCubeCfg(
             name="block_blue",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.1, 0.05, 0.05),  # block_blue_big
+            size=(0.08, 0.04, 0.04),  # block_blue_big
             color=(0.0, 0.0, 1.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
         PrimitiveCubeCfg(
             name="block_pink",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.07, 0.05, 0.05),  # block_pink_middle
+            size=(0.056, 0.04, 0.04),  # block_pink_middle
             color=(1.0, 0.0, 1.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
     ]
 

--- a/metasim/cfg/tasks/calvin/scene/scene_C.py
+++ b/metasim/cfg/tasks/calvin/scene/scene_C.py
@@ -17,26 +17,23 @@ class SceneC(BaseTaskCfg):
         PrimitiveCubeCfg(
             name="block_red",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.1, 0.05, 0.05),  # block_red_big
+            size=(0.08, 0.04, 0.04),  # block_red_big
             color=(1.0, 0.0, 0.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
         PrimitiveCubeCfg(
             name="block_blue",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.05, 0.05, 0.05),  # block_blue_small
+            size=(0.04, 0.04, 0.04),  # block_blue_small
             color=(0.0, 0.0, 1.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
         PrimitiveCubeCfg(
             name="block_pink",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.07, 0.05, 0.05),  # block_pink_middle
+            size=(0.056, 0.04, 0.04),  # block_pink_middle
             color=(1.0, 0.0, 1.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
     ]
 

--- a/metasim/cfg/tasks/calvin/scene/scene_D.py
+++ b/metasim/cfg/tasks/calvin/scene/scene_D.py
@@ -17,26 +17,23 @@ class SceneD(BaseTaskCfg):
         PrimitiveCubeCfg(
             name="block_red",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.07, 0.05, 0.05),  # block_red_middle
+            size=(0.056, 0.04, 0.04),  # block_red_middle
             color=(1.0, 0.0, 0.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
         PrimitiveCubeCfg(
             name="block_blue",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.05, 0.05, 0.05),  # block_blue_small
+            size=(0.04, 0.04, 0.04),  # block_blue_small
             color=(0.0, 0.0, 1.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
         PrimitiveCubeCfg(
             name="block_pink",
             mass=0.1,  # origin is 1, smaller mass is easier to grasp
-            size=(0.1, 0.05, 0.05),  # block_pink_big
+            size=(0.08, 0.04, 0.04),  # block_pink_big
             color=(1.0, 0.0, 1.0),
             physics=PhysicStateType.RIGIDBODY,
-            scale=0.8,
         ),
     ]
 

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -7,7 +7,7 @@ from genesis.engine.entities.rigid_entity import RigidEntity, RigidJoint
 from genesis.vis.camera import Camera
 from loguru import logger as log
 
-from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
+from metasim.cfg.objects import ArticulationObjCfg, FileBasedMixin, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, GymEnvWrapper
 from metasim.types import Action, EnvState
@@ -54,11 +54,12 @@ class GenesisHandler(BaseSimHandler):
 
         ## Add objects
         for obj in self.scenario.objects:
-            if isinstance(obj.scale, tuple) or isinstance(obj.scale, list):
-                obj.scale = obj.scale[0]
-                log.warning(
-                    f"Genesis does not support different scaling for each axis for {obj.name}, using scale={obj.scale}"
-                )
+            if isinstance(obj, FileBasedMixin):
+                if isinstance(obj.scale, tuple) or isinstance(obj.scale, list):
+                    obj.scale = obj.scale[0]
+                    log.warning(
+                        f"Genesis does not support different scaling for each axis for {obj.name}, using scale={obj.scale}"
+                    )
             if isinstance(obj, PrimitiveCubeCfg):
                 obj_inst = self.scene_inst.add_entity(
                     gs.morphs.Box(size=obj.size), surface=gs.surfaces.Default(color=obj.color)

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -7,7 +7,7 @@ from genesis.engine.entities.rigid_entity import RigidEntity, RigidJoint
 from genesis.vis.camera import Camera
 from loguru import logger as log
 
-from metasim.cfg.objects import ArticulationObjCfg, FileBasedMixin, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
+from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg, _FileBasedMixin
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, GymEnvWrapper
 from metasim.types import Action, EnvState
@@ -54,7 +54,7 @@ class GenesisHandler(BaseSimHandler):
 
         ## Add objects
         for obj in self.scenario.objects:
-            if isinstance(obj, FileBasedMixin):
+            if isinstance(obj, _FileBasedMixin):
                 if isinstance(obj.scale, tuple) or isinstance(obj.scale, list):
                     obj.scale = obj.scale[0]
                     log.warning(

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -7,7 +7,14 @@ import torch
 from isaacgym import gymapi, gymtorch, gymutil  # noqa: F401
 from loguru import logger as log
 
-from metasim.cfg.objects import ArticulationObjCfg, BaseObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
+from metasim.cfg.objects import (
+    ArticulationObjCfg,
+    BaseObjCfg,
+    FileBasedMixin,
+    PrimitiveCubeCfg,
+    PrimitiveSphereCfg,
+    RigidObjCfg,
+)
 from metasim.cfg.robots.base_robot_cfg import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
@@ -428,8 +435,9 @@ class IsaacgymHandler(BaseSimHandler):
                 obj_pose.r = gymapi.Quat.from_axis_angle(gymapi.Vec3(0, 0, 1), 0)
                 obj_handle = self.gym.create_actor(env, obj_asset, obj_pose, "object", i, 0)
 
-                self.gym.set_actor_scale(env, obj_handle, self.objects[obj_i].scale[0])
-                if isinstance(self.objects[obj_i], PrimitiveCubeCfg):
+                if isinstance(self.objects[obj_i], FileBasedMixin):
+                    self.gym.set_actor_scale(env, obj_handle, self.objects[obj_i].scale[0])
+                elif isinstance(self.objects[obj_i], PrimitiveCubeCfg):
                     color = gymapi.Vec3(
                         self.objects[obj_i].color[0],
                         self.objects[obj_i].color[1],

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -10,10 +10,10 @@ from loguru import logger as log
 from metasim.cfg.objects import (
     ArticulationObjCfg,
     BaseObjCfg,
-    FileBasedMixin,
     PrimitiveCubeCfg,
     PrimitiveSphereCfg,
     RigidObjCfg,
+    _FileBasedMixin,
 )
 from metasim.cfg.robots.base_robot_cfg import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
@@ -435,7 +435,7 @@ class IsaacgymHandler(BaseSimHandler):
                 obj_pose.r = gymapi.Quat.from_axis_angle(gymapi.Vec3(0, 0, 1), 0)
                 obj_handle = self.gym.create_actor(env, obj_asset, obj_pose, "object", i, 0)
 
-                if isinstance(self.objects[obj_i], FileBasedMixin):
+                if isinstance(self.objects[obj_i], _FileBasedMixin):
                     self.gym.set_actor_scale(env, obj_handle, self.objects[obj_i].scale[0])
                 elif isinstance(self.objects[obj_i], PrimitiveCubeCfg):
                     color = gymapi.Vec3(

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -7,7 +7,13 @@ import gymnasium as gym
 import torch
 from loguru import logger as log
 
-from metasim.cfg.objects import ArticulationObjCfg, BaseObjCfg, PrimitiveFrameCfg, RigidObjCfg
+from metasim.cfg.objects import (
+    ArticulationObjCfg,
+    BaseArticulationObjCfg,
+    BaseObjCfg,
+    BaseRigidObjCfg,
+    PrimitiveFrameCfg,
+)
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import ContactForceSensorCfg
 from metasim.sim import BaseSimHandler, EnvWrapper, IdentityEnvWrapper
@@ -234,9 +240,9 @@ class IsaaclabHandler(BaseSimHandler):
         assert position.shape == (len(env_ids), 3)
         assert rotation.shape == (len(env_ids), 4)
 
-        if isinstance(object, ArticulationObjCfg):
+        if isinstance(object, BaseArticulationObjCfg):
             obj_inst = self.env.scene.articulations[object.name]
-        elif isinstance(object, RigidObjCfg):
+        elif isinstance(object, BaseRigidObjCfg):
             obj_inst = self.env.scene.rigid_objects[object.name]
         else:
             raise ValueError(f"Invalid object type: {type(object)}")

--- a/metasim/sim/isaaclab/isaaclab_helper.py
+++ b/metasim/sim/isaaclab/isaaclab_helper.py
@@ -33,93 +33,6 @@ def _add_object(env: "EmptyEnv", obj: BaseObjCfg) -> None:
 
     assert isinstance(obj, BaseObjCfg)
     prim_path = f"/World/envs/env_.*/{obj.name}"
-    ## Rigid object
-    if isinstance(obj, RigidObjCfg):
-        if obj.fix_base_link:
-            rigid_props = sim_utils.RigidBodyPropertiesCfg(disable_gravity=True, kinematic_enabled=True)
-        else:
-            rigid_props = sim_utils.RigidBodyPropertiesCfg()
-        if obj.collision_enabled:
-            collision_props = sim_utils.CollisionPropertiesCfg(collision_enabled=True)
-        else:
-            collision_props = None
-
-        ## Primitive object
-        if isinstance(obj, PrimitiveCubeCfg):
-            env.scene.rigid_objects[obj.name] = RigidObject(
-                RigidObjectCfg(
-                    prim_path=prim_path,
-                    spawn=sim_utils.MeshCuboidCfg(
-                        size=tuple([x * s for x, s in zip(obj.size, obj.scale)]),
-                        mass_props=sim_utils.MassPropertiesCfg(mass=obj.mass),
-                        visual_material=sim_utils.PreviewSurfaceCfg(
-                            diffuse_color=(obj.color[0], obj.color[1], obj.color[2])
-                        ),
-                        rigid_props=rigid_props,
-                        collision_props=collision_props,
-                    ),
-                )
-            )
-            return
-        if isinstance(obj, PrimitiveSphereCfg):
-            env.scene.rigid_objects[obj.name] = RigidObject(
-                RigidObjectCfg(
-                    prim_path=prim_path,
-                    spawn=sim_utils.MeshSphereCfg(
-                        radius=obj.radius,
-                        mass_props=sim_utils.MassPropertiesCfg(mass=obj.mass),
-                        visual_material=sim_utils.PreviewSurfaceCfg(
-                            diffuse_color=(obj.color[0], obj.color[1], obj.color[2])
-                        ),
-                        rigid_props=rigid_props,
-                        collision_props=collision_props,
-                    ),
-                )
-            )
-            return
-        if isinstance(obj, PrimitiveCylinderCfg):
-            env.scene.rigid_objects[obj.name] = RigidObject(
-                RigidObjectCfg(
-                    prim_path=prim_path,
-                    spawn=sim_utils.MeshCylinderCfg(
-                        radius=obj.radius,
-                        height=obj.height,
-                        mass_props=sim_utils.MassPropertiesCfg(mass=obj.mass),
-                        visual_material=sim_utils.PreviewSurfaceCfg(
-                            diffuse_color=(obj.color[0], obj.color[1], obj.color[2])
-                        ),
-                        rigid_props=rigid_props,
-                        collision_props=collision_props,
-                    ),
-                )
-            )
-            return
-        if isinstance(obj, PrimitiveFrameCfg):
-            env.scene.rigid_objects[obj.name] = RigidObject(
-                RigidObjectCfg(
-                    prim_path=prim_path,
-                    spawn=sim_utils.UsdFileCfg(
-                        usd_path="metasim/data/quick_start/assets/COMMON/frame/usd/frame.usd",
-                        rigid_props=sim_utils.RigidBodyPropertiesCfg(
-                            disable_gravity=True, kinematic_enabled=True
-                        ),  # fixed
-                        collision_props=None,  # no collision
-                        scale=obj.scale,
-                    ),
-                )
-            )
-            return
-
-        ## File-based object
-        usd_file_cfg = sim_utils.UsdFileCfg(
-            usd_path=obj.usd_path,
-            rigid_props=rigid_props,
-            collision_props=collision_props,
-            scale=obj.scale,
-        )
-        if isinstance(obj, RigidObjCfg):
-            env.scene.rigid_objects[obj.name] = RigidObject(RigidObjectCfg(prim_path=prim_path, spawn=usd_file_cfg))
-            return
 
     ## Articulation object
     if isinstance(obj, ArticulationObjCfg):
@@ -131,6 +44,92 @@ def _add_object(env: "EmptyEnv", obj: BaseObjCfg) -> None:
             )
         )
         return
+
+    if obj.fix_base_link:
+        rigid_props = sim_utils.RigidBodyPropertiesCfg(disable_gravity=True, kinematic_enabled=True)
+    else:
+        rigid_props = sim_utils.RigidBodyPropertiesCfg()
+    if obj.collision_enabled:
+        collision_props = sim_utils.CollisionPropertiesCfg(collision_enabled=True)
+    else:
+        collision_props = None
+
+    ## Primitive object
+    if isinstance(obj, PrimitiveCubeCfg):
+        env.scene.rigid_objects[obj.name] = RigidObject(
+            RigidObjectCfg(
+                prim_path=prim_path,
+                spawn=sim_utils.MeshCuboidCfg(
+                    size=obj.size,
+                    mass_props=sim_utils.MassPropertiesCfg(mass=obj.mass),
+                    visual_material=sim_utils.PreviewSurfaceCfg(
+                        diffuse_color=(obj.color[0], obj.color[1], obj.color[2])
+                    ),
+                    rigid_props=rigid_props,
+                    collision_props=collision_props,
+                ),
+            )
+        )
+        return
+    if isinstance(obj, PrimitiveSphereCfg):
+        env.scene.rigid_objects[obj.name] = RigidObject(
+            RigidObjectCfg(
+                prim_path=prim_path,
+                spawn=sim_utils.MeshSphereCfg(
+                    radius=obj.radius,
+                    mass_props=sim_utils.MassPropertiesCfg(mass=obj.mass),
+                    visual_material=sim_utils.PreviewSurfaceCfg(
+                        diffuse_color=(obj.color[0], obj.color[1], obj.color[2])
+                    ),
+                    rigid_props=rigid_props,
+                    collision_props=collision_props,
+                ),
+            )
+        )
+        return
+    if isinstance(obj, PrimitiveCylinderCfg):
+        env.scene.rigid_objects[obj.name] = RigidObject(
+            RigidObjectCfg(
+                prim_path=prim_path,
+                spawn=sim_utils.MeshCylinderCfg(
+                    radius=obj.radius,
+                    height=obj.height,
+                    mass_props=sim_utils.MassPropertiesCfg(mass=obj.mass),
+                    visual_material=sim_utils.PreviewSurfaceCfg(
+                        diffuse_color=(obj.color[0], obj.color[1], obj.color[2])
+                    ),
+                    rigid_props=rigid_props,
+                    collision_props=collision_props,
+                ),
+            )
+        )
+        return
+    if isinstance(obj, PrimitiveFrameCfg):
+        env.scene.rigid_objects[obj.name] = RigidObject(
+            RigidObjectCfg(
+                prim_path=prim_path,
+                spawn=sim_utils.UsdFileCfg(
+                    usd_path="metasim/data/quick_start/assets/COMMON/frame/usd/frame.usd",
+                    rigid_props=sim_utils.RigidBodyPropertiesCfg(disable_gravity=True, kinematic_enabled=True),  # fixed
+                    collision_props=None,  # no collision
+                    scale=obj.scale,
+                ),
+            )
+        )
+        return
+
+    ## Rigid object
+    if isinstance(obj, RigidObjCfg):
+        usd_file_cfg = sim_utils.UsdFileCfg(
+            usd_path=obj.usd_path,
+            rigid_props=rigid_props,
+            collision_props=collision_props,
+            scale=obj.scale,
+        )
+        if isinstance(obj, RigidObjCfg):
+            env.scene.rigid_objects[obj.name] = RigidObject(RigidObjectCfg(prim_path=prim_path, spawn=usd_file_cfg))
+            return
+
     raise ValueError(f"Unsupported object type: {type(obj)}")
 
 

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -152,15 +152,12 @@ class MujocoHandler(BaseSimHandler):
         )
         self.object_body_names = []
         self.mj_objects = {}
-        object_paths = []
         for obj in self.objects:
-            object_paths.append(obj.mjcf_path)
-        for i, (obj, obj_path) in enumerate(zip(self.objects, object_paths)):
             if isinstance(obj, (PrimitiveCubeCfg, PrimitiveCylinderCfg, PrimitiveSphereCfg)):
                 xml_str = self._create_primitive_xml(obj)
                 obj_mjcf = mjcf.from_xml_string(xml_str)
             else:
-                obj_mjcf = mjcf.from_path(obj_path)
+                obj_mjcf = mjcf.from_path(obj.mjcf_path)
             obj_attached = mjcf_model.attach(obj_mjcf)
             if not obj.fix_base_link:
                 obj_attached.add("freejoint")

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -148,7 +148,7 @@ class SinglePybulletHandler(BaseSimHandler):
                 # p.resetBasePositionAndOrientation(agent.instance, pos, wxyz_to_xyzw(rot))
 
             elif isinstance(object, PrimitiveCubeCfg):
-                box_dimensions = [x * s for x, s in zip(object.half_size, object.scale)]
+                box_dimensions = object.half_size
                 pos = np.array([0, 0, 0])
                 rot = np.array([1, 0, 0, 0])
                 box_id = p.createCollisionShape(p.GEOM_BOX, halfExtents=box_dimensions)
@@ -162,7 +162,7 @@ class SinglePybulletHandler(BaseSimHandler):
                 self.object_joint_order[object.name] = []
 
             elif isinstance(object, PrimitiveSphereCfg):
-                radius = object.radius * object.scale[0]
+                radius = object.radius
                 pos = np.array([0, 0, 0])
                 rot = np.array([1, 0, 0, 0])
                 sphere_id = p.createCollisionShape(p.GEOM_SPHERE, radius=radius)

--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -152,12 +152,12 @@ class Sapien2Handler(BaseSimHandler):
                 actor_builder = self.scene.create_actor_builder()
                 # material = get_material(self.scene, agent.rigid_shape_property)
                 actor_builder.add_box_collision(
-                    half_size=[x * s for x, s in zip(object.half_size, object.scale)],
+                    half_size=object.half_size,
                     density=object.density,
                     # material=material,
                 )
                 actor_builder.add_box_visual(
-                    half_size=[x * s for x, s in zip(object.half_size, object.scale)],
+                    half_size=object.half_size,
                     color=object.color if object.color else [1.0, 1.0, 0.0],
                 )
                 box = actor_builder.build(name="box")  # Add a box
@@ -179,7 +179,7 @@ class Sapien2Handler(BaseSimHandler):
                 # material = get_material(self.scene, agent.rigid_shape_property)
                 actor_builder.add_sphere_collision(radius=object.radius, density=object.density)
                 actor_builder.add_sphere_visual(
-                    radius=object.radius * object.scale[0], color=object.color if object.color else [1.0, 1.0, 0.0]
+                    radius=object.radius, color=object.color if object.color else [1.0, 1.0, 0.0]
                 )
                 sphere = actor_builder.build(name="sphere")  # Add a sphere
                 sphere.set_pose(sapien_core.Pose(p=[0, 0, 0], q=[1, 0, 0, 0]))

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -152,12 +152,12 @@ class Sapien3Handler(BaseSimHandler):
                 actor_builder = self.scene.create_actor_builder()
                 # material = get_material(self.scene, agent.rigid_shape_property)
                 actor_builder.add_box_collision(
-                    half_size=[x * s for x, s in zip(object.half_size, object.scale)],
+                    half_size=object.half_size,
                     density=object.density,
                     # material=material,
                 )
                 actor_builder.add_box_visual(
-                    half_size=[x * s for x, s in zip(object.half_size, object.scale)],
+                    half_size=object.half_size,
                     # color=object.color if object.color else [1.0, 1.0, 0.0],
                     material=sapien_core.render.RenderMaterial(
                         base_color=object.color[:3] + [1] if object.color else [1.0, 1.0, 0.0, 1.0]
@@ -182,7 +182,7 @@ class Sapien3Handler(BaseSimHandler):
                 # material = get_material(self.scene, agent.rigid_shape_property)
                 actor_builder.add_sphere_collision(radius=object.radius, density=object.density)
                 actor_builder.add_sphere_visual(
-                    radius=object.radius * object.scale[0],
+                    radius=object.radius,
                     material=sapien_core.render.RenderMaterial(
                         base_color=object.color[:3] + [1] if object.color else [1.0, 1.0, 0.0, 1.0]
                     ),

--- a/metasim/utils/configclass.py
+++ b/metasim/utils/configclass.py
@@ -393,7 +393,7 @@ def _custom_post_init(obj):
         # get data member
         value = getattr(obj, key)
         # check annotation
-        ann = obj.__class__.__dict__.get(key)
+        ann = inspect.getattr_static(obj.__class__, key, None)
         # duplicate data members that are mutable
         if not callable(value) and not isinstance(ann, property):
             setattr(obj, key, deepcopy(value))


### PR DESCRIPTION
This PR makes the following modifications:
1. reorganize `objects.py` using [mixin](https://en.wikipedia.org/wiki/Mixin) style;
    - I personally think mixin style is better than the composition style utilized by IsaacLab, e.g. [RigidObjectCfg](https://isaac-sim.github.io/IsaacLab/main/source/api/lab/isaaclab.assets.html#isaaclab.assets.RigidObjectCfg). mixin style keeps everything at the same level and avoid nested access for an attribute. It also shorten the code length compared to composition style. Moreover, the usual weakness of mixin style -- hard to write unittest / debug -- is avoided, because all these classes serve only as configurations 
3. improve docstrings; 
4. fix `configclass` bug about inherited property; 
5. primitive object doesn't support scale