### PR TITLE
add viewer for MJX handler&fix bugs for set_states

### DIFF
--- a/metasim/cfg/robots/h1_cfg.py
+++ b/metasim/cfg/robots/h1_cfg.py
@@ -14,6 +14,7 @@ class H1Cfg(BaseRobotCfg):
     usd_path: str = "roboverse_data/robots/h1/usd/h1.usd"
     mjcf_path: str = "roboverse_data/robots/h1/mjcf/h1.xml"
     urdf_path: str = "roboverse_data/robots/h1/urdf/h1.urdf"
+    mjx_mjcf_path: str = "roboverse_data/robots/h1/mjcf/mjx_h1.xml"
     enabled_gravity: bool = True
     fix_base_link: bool = False
     enabled_self_collisions: bool = False

--- a/roboverse_learn/humanoidbench_rl/configs/mjx.yaml
+++ b/roboverse_learn/humanoidbench_rl/configs/mjx.yaml
@@ -1,0 +1,33 @@
+# Environment settings
+sim: mjx
+robot: h1
+task: humanoidbench:Stand
+decimation: 1
+num_envs: 2048
+add_table: false
+
+# Training settings
+train_or_eval: train
+total_timesteps: 50_000_000
+model_save_path: ./saved_models
+model_save_freq: 1_000_000
+
+# Eval settings
+eval_model_path: <path to eval model>
+
+
+# PPO parameters
+learning_rate: 0.0003
+n_steps: 256
+num_batch: 64
+n_epochs: 4
+
+# Learning rate schedule
+use_lr_schedule: true
+lr_schedule_type: linear  # Optional: linear, constant, cosine
+final_lr_fraction: 0.1    # Optional: final learning rate is 10% of initial learning rate
+
+# Wandb settings
+use_wandb: false
+wandb_project: humanoidbench_rl_training
+wandb_entity: <YOUR_WANDB_ENTITY>

--- a/roboverse_learn/humanoidbench_rl/train_sb3.py
+++ b/roboverse_learn/humanoidbench_rl/train_sb3.py
@@ -140,6 +140,8 @@ def main():
         env = Sb3EnvWrapper(scenario=scenario)
     elif config.get("sim") == "isaaclab":
         env = Sb3EnvWrapper(scenario=scenario)
+    elif config.get("sim") == "mjx":
+        env = Sb3EnvWrapper(scenario=scenario)
     else:
         raise ValueError(f"Invalid sim type: {config.get('sim')}")
 


### PR DESCRIPTION
* **Add MJX viewer**

  * `MJXHandler.refresh_render()` now supports MuJoCo’s built-in viewer.

* **Fix multi-env bugs**

  * `_write_root_joint` and `_write_articulated_block` in `mjx_helper` now work correctly when `num_envs > 1`.

* **Provide MJX config for HumanoidBench-RL**

  * New configuration file added.

All tests and pre-commit hooks pass.
