### PR TITLE
[fix] mujoco&mjx cvel  bugs

### DIFF
--- a/metasim/sim/mjx/mjx.py
+++ b/metasim/sim/mjx/mjx.py
@@ -107,14 +107,26 @@ class MJXHandler(BaseSimHandler):
             bid_r.insert(0, root_bid_r)
             bnames_r.insert(0, self.mj_objects[r_cfg.name].full_identifier)
 
-        # collect per-robot arrays ----------------------------------------------
-        root_state_r = jnp.concatenate(
-            [data.xpos[idx, root_bid_r], data.xquat[idx, root_bid_r], data.cvel[idx, root_bid_r]], axis=-1
-        )  # (N, 13)
 
-        body_state_r = jnp.concatenate(
-            [data.xpos[idx[:, None], bid_r], data.xquat[idx[:, None], bid_r], data.cvel[idx[:, None], bid_r]], axis=-1
-        )  # (N, Nbody, 13)
+            root_state_r = jnp.concatenate(
+                [
+                    data.xpos[idx, root_bid_r],           # (N, 3)
+                    data.xquat[idx, root_bid_r],          # (N, 4)
+                    data.cvel[idx, root_bid_r, 3:6],      # vx vy vz
+                    data.cvel[idx, root_bid_r, 0:3],      # wx wy wz
+                ],
+                axis=-1,
+            ) # (N, 13)
+
+            body_state_r = jnp.concatenate(
+                [
+                    data.xpos[idx[:, None], bid_r],           # (N, 3)
+                    data.xquat[idx[:, None],bid_r],          # (N, 4)
+                    data.cvel[idx[:, None], bid_r, 3:6],      # vx vy vz
+                    data.cvel[idx[:, None], bid_r, 0:3],      # wx wy wz
+                ],
+                axis=-1,
+            ) # (N, 13)
 
         robots[r_cfg.name] = RobotState(
             root_state=j2t(root_state_r),
@@ -138,15 +150,26 @@ class MJXHandler(BaseSimHandler):
                 bnames_o.insert(0, self.mj_objects[obj.name].full_identifier)
 
             root_state_o = jnp.concatenate(
-                [data.xpos[idx, root_bid_o], data.xquat[idx, root_bid_o], data.cvel[idx, root_bid_o]], axis=-1
-            )
+                [
+                    data.xpos[idx, root_bid_o],           # (N, 3)
+                    data.xquat[idx, root_bid_o],          # (N, 4)
+                    data.cvel[idx, root_bid_o, 3:6],      # vx vy vz
+                    data.cvel[idx, root_bid_o, 0:3],      # wx wy wz
+                ],
+                axis=-1,
+            ) # (N, 13)
 
             if isinstance(obj, ArticulationObjCfg):  # articulated
                 qadr_o, vadr_o = sorted_joint_info(self._mjx_model, prefix)
                 body_state_o = jnp.concatenate(
-                    [data.xpos[idx[:, None], bid_o], data.xquat[idx[:, None], bid_o], data.cvel[idx[:, None], bid_o]],
+                    [
+                        data.xpos[idx[:, None], bid_o],           # (N, 3)
+                        data.xquat[idx[:, None], bid_o],          # (N, 4)
+                        data.cvel[idx[:, None], bid_o, 3:6],      # vx vy vz
+                        data.cvel[idx[:, None], bid_o, 0:3],      # wx wy wz
+                    ],
                     axis=-1,
-                )
+                ) # (N, 13)
                 objects[obj.name] = ObjectState(
                     root_state=j2t(root_state_o),
                     body_names=bnames_o,

--- a/metasim/sim/mjx/mjx_helper.py
+++ b/metasim/sim/mjx/mjx_helper.py
@@ -1,6 +1,8 @@
 # helper/state_writer.py
 from __future__ import annotations
 
+from functools import partial
+
 import jax
 import jax.numpy as jnp
 import torch
@@ -244,3 +246,33 @@ def sorted_body_ids(model, prefix: str):
     body_ids = [i for _, i in filt]
     local_names = [n.split("/")[-1] for n, _ in filt]
     return body_ids, local_names
+
+
+def pack_body_state(data, env_idx, body_ids):
+    """
+    Args
+    ----
+    data      : mjx_env.Data          (N, …)
+    env_idx   : jnp.ndarray[int32]    (N,)    environment indices to slice
+    body_ids  : jnp.ndarray[int32]    (B,)    body ids whose state we want
+
+    Returns
+    -------
+    state     : jnp.ndarray           (N, B, 13)
+                [pos(3), quat(4), lin_vel_world(3), ang_vel_world(3)]
+    """
+    # pull raw pieces
+    pos = data.xpos[env_idx[:, None], body_ids]  # (N,B,3)
+    quat = data.xquat[env_idx[:, None], body_ids]  # (N,B,4)
+    w = data.cvel[env_idx[:, None], body_ids, 0:3]  # (N,B,3) ω
+    v_com = data.cvel[env_idx[:, None], body_ids, 3:6]  # (N,B,3) v @ subtree_com
+
+    # v_origin = v_com + ω × (xpos - subtree_com)
+    offset = pos - data.subtree_com[env_idx[:, None], body_ids]  # (N,B,3)
+    v_org = v_com + jnp.cross(w, offset)  # (N,B,3)
+
+    # (N,B,13)
+    return jnp.concatenate([pos, quat, v_org, w], axis=-1)
+
+
+pack_root_state = partial(lambda d, idx, bid: pack_body_state(d, idx, jnp.asarray([bid]))[:, 0])

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -207,14 +207,27 @@ class MujocoHandler(BaseSimHandler):
                     root_state=torch.concat([
                         torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
                         torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
-                        torch.from_numpy(self.physics.data.cvel[obj_body_id]).float(),  # (6,)
+                        torch.from_numpy(
+                            np.concatenate([
+                                self.physics.data.cvel[obj_body_id][3:6],  # vx vy vz
+                                self.physics.data.cvel[obj_body_id][0:3],  # wx wy wz
+                            ])
+                        ).float(),  # (6,)
                     ]).unsqueeze(0),
                     body_names=self.get_body_names(obj.name),
                     body_state=torch.concat(
                         [
                             torch.from_numpy(self.physics.data.xpos[body_ids_reindex]).float(),  # (n_body, 3)
                             torch.from_numpy(self.physics.data.xquat[body_ids_reindex]).float(),  # (n_body, 4)
-                            torch.from_numpy(self.physics.data.cvel[body_ids_reindex]).float(),  # (n_body, 6)
+                            torch.from_numpy(
+                                np.concatenate(
+                                    [
+                                        self.physics.data.cvel[body_ids_reindex][:, 3:6],  # vx vy vz
+                                        self.physics.data.cvel[body_ids_reindex][:, 0:3],  # wx wy wz
+                                    ],
+                                    axis=1,
+                                )
+                            ).float(),  # (n_body, 6)
                         ],
                         dim=1,
                     ).unsqueeze(0),
@@ -230,7 +243,12 @@ class MujocoHandler(BaseSimHandler):
                     root_state=torch.concat([
                         torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
                         torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
-                        torch.from_numpy(self.physics.data.cvel[obj_body_id]).float(),  # (6,)
+                        torch.from_numpy(
+                            np.concatenate([
+                                self.physics.data.cvel[obj_body_id][3:6],  # vx vy vz
+                                self.physics.data.cvel[obj_body_id][0:3],  # wx wy wz
+                            ])
+                        ).float(),  # (6,)
                     ]).unsqueeze(0),
                 )
             object_states[obj.name] = state
@@ -247,13 +265,26 @@ class MujocoHandler(BaseSimHandler):
                 root_state=torch.concat([
                     torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
                     torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
-                    torch.from_numpy(self.physics.data.cvel[obj_body_id]).float(),  # (6,)
+                    torch.from_numpy(
+                        np.concatenate([
+                            self.physics.data.cvel[obj_body_id][3:6],  # vx vy vz
+                            self.physics.data.cvel[obj_body_id][0:3],  # wx wy wz
+                        ])
+                    ).float(),  # (6,)
                 ]).unsqueeze(0),
                 body_state=torch.concat(
                     [
                         torch.from_numpy(self.physics.data.xpos[body_ids_reindex]).float(),  # (n_body, 3)
                         torch.from_numpy(self.physics.data.xquat[body_ids_reindex]).float(),  # (n_body, 4)
-                        torch.from_numpy(self.physics.data.cvel[body_ids_reindex]).float(),  # (n_body, 6)
+                        torch.from_numpy(
+                            np.concatenate(
+                                [
+                                    self.physics.data.cvel[body_ids_reindex][:, 3:6],  # vx vy vz
+                                    self.physics.data.cvel[body_ids_reindex][:, 0:3],  # wx wy wz
+                                ],
+                                axis=1,
+                            )
+                        ).float(),  # (n_body, 6)
                     ],
                     dim=1,
                 ).unsqueeze(0),

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -194,6 +194,33 @@ class MujocoHandler(BaseSimHandler):
 
         return actuator_states
 
+    def _pack_state(self, body_ids: list[int]):
+        """
+        Pack pos(3), quat(4), lin_vel_world(3), ang_vel(3) for one-env MuJoCo.
+
+        Args:
+            body_ids: list of body IDs, e.g. [root_id] or [root_id] + body_ids_reindex
+
+        Returns:
+            root_np: numpy (13,)      — the first body
+            body_np: numpy (n_body,13)     — n_body bodies
+        """
+        data = self.physics.data
+        pos = data.xpos[body_ids]
+        quat = data.xquat[body_ids]
+
+        # angular ω (world) & v @ subtree_com
+        w = data.cvel[body_ids, 0:3]
+        v = data.cvel[body_ids, 3:6]
+
+        # compute world‐frame linear velocity at body origin
+        offset = data.xpos[body_ids] - data.subtree_com[body_ids]
+        lin_world = v + np.cross(w, offset)
+
+        full = np.concatenate([pos, quat, lin_world, w], axis=1)
+        root_np = full[0]
+        return root_np, full  # root, bodies
+
     def get_states(self, env_ids: list[int] | None = None) -> list[dict]:
         object_states = {}
         for obj in self.objects:
@@ -203,34 +230,13 @@ class MujocoHandler(BaseSimHandler):
             if isinstance(obj, ArticulationObjCfg):
                 joint_names = self.get_joint_names(obj.name, sort=True)
                 body_ids_reindex = self._get_body_ids_reindex(obj.name)
+
+                root_np, body_np = self._pack_state([obj_body_id] + body_ids_reindex)
+
                 state = ObjectState(
-                    root_state=torch.concat([
-                        torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
-                        torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
-                        torch.from_numpy(
-                            np.concatenate([
-                                self.physics.data.cvel[obj_body_id][3:6],  # vx vy vz
-                                self.physics.data.cvel[obj_body_id][0:3],  # wx wy wz
-                            ])
-                        ).float(),  # (6,)
-                    ]).unsqueeze(0),
+                    root_state=torch.from_numpy(root_np).float().unsqueeze(0),  # (1,13)
                     body_names=self.get_body_names(obj.name),
-                    body_state=torch.concat(
-                        [
-                            torch.from_numpy(self.physics.data.xpos[body_ids_reindex]).float(),  # (n_body, 3)
-                            torch.from_numpy(self.physics.data.xquat[body_ids_reindex]).float(),  # (n_body, 4)
-                            torch.from_numpy(
-                                np.concatenate(
-                                    [
-                                        self.physics.data.cvel[body_ids_reindex][:, 3:6],  # vx vy vz
-                                        self.physics.data.cvel[body_ids_reindex][:, 0:3],  # wx wy wz
-                                    ],
-                                    axis=1,
-                                )
-                            ).float(),  # (n_body, 6)
-                        ],
-                        dim=1,
-                    ).unsqueeze(0),
+                    body_state=torch.from_numpy(body_np).float().unsqueeze(0),  # (1,n_body,13)
                     joint_pos=torch.tensor([
                         self.physics.data.joint(f"{model_name}/{jn}").qpos.item() for jn in joint_names
                     ]).unsqueeze(0),
@@ -239,17 +245,10 @@ class MujocoHandler(BaseSimHandler):
                     ]).unsqueeze(0),
                 )
             else:
+                root_np, _ = self._pack_state([obj_body_id])
+
                 state = ObjectState(
-                    root_state=torch.concat([
-                        torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
-                        torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
-                        torch.from_numpy(
-                            np.concatenate([
-                                self.physics.data.cvel[obj_body_id][3:6],  # vx vy vz
-                                self.physics.data.cvel[obj_body_id][0:3],  # wx wy wz
-                            ])
-                        ).float(),  # (6,)
-                    ]).unsqueeze(0),
+                    root_state=torch.from_numpy(root_np).float().unsqueeze(0),  # (1,13)
                 )
             object_states[obj.name] = state
 
@@ -260,34 +259,13 @@ class MujocoHandler(BaseSimHandler):
             joint_names = self.get_joint_names(robot.name, sort=True)
             actuator_reindex = self._get_actuator_reindex(robot.name)
             body_ids_reindex = self._get_body_ids_reindex(robot.name)
+
+            root_np, body_np = self._pack_state([obj_body_id] + body_ids_reindex)
+
             state = RobotState(
                 body_names=self.get_body_names(robot.name),
-                root_state=torch.concat([
-                    torch.from_numpy(self.physics.data.xpos[obj_body_id]).float(),  # (3,)
-                    torch.from_numpy(self.physics.data.xquat[obj_body_id]).float(),  # (4,)
-                    torch.from_numpy(
-                        np.concatenate([
-                            self.physics.data.cvel[obj_body_id][3:6],  # vx vy vz
-                            self.physics.data.cvel[obj_body_id][0:3],  # wx wy wz
-                        ])
-                    ).float(),  # (6,)
-                ]).unsqueeze(0),
-                body_state=torch.concat(
-                    [
-                        torch.from_numpy(self.physics.data.xpos[body_ids_reindex]).float(),  # (n_body, 3)
-                        torch.from_numpy(self.physics.data.xquat[body_ids_reindex]).float(),  # (n_body, 4)
-                        torch.from_numpy(
-                            np.concatenate(
-                                [
-                                    self.physics.data.cvel[body_ids_reindex][:, 3:6],  # vx vy vz
-                                    self.physics.data.cvel[body_ids_reindex][:, 0:3],  # wx wy wz
-                                ],
-                                axis=1,
-                            )
-                        ).float(),  # (n_body, 6)
-                    ],
-                    dim=1,
-                ).unsqueeze(0),
+                root_state=torch.from_numpy(root_np).float().unsqueeze(0),  # (1,13)
+                body_state=torch.from_numpy(body_np).float().unsqueeze(0),  # (1,n_body,13)
                 joint_pos=torch.tensor([
                     self.physics.data.joint(f"{model_name}/{jn}").qpos.item() for jn in joint_names
                 ]).unsqueeze(0),


### PR DESCRIPTION
According to the official MuJoCo API docs and forum clarification, all c * spatial vectors store angular components first, then linear components

MuJoCo API reference → “c-frame variables” 
https://mujoco.readthedocs.io/en/stable/APIreference/APItypes.html#c-frame-variables

In RoboVerse we assume linear-then-angular ( vx vy vz wx wy wz ) for every velocity-like field exposed to agents.

The previous implementation in metasim/sim/mujoco.py and metasim/sim/mjx/mjx.py directly forwarded MuJoCo’s raw data.cvel, leading to a silent mismatch between: