### PR TITLE
[fix] issue #98 on mujoco state inconsistency

### DIFF
--- a/metasim/sim/env_wrapper.py
+++ b/metasim/sim/env_wrapper.py
@@ -90,7 +90,7 @@ def GymEnvWrapper(cls: type[THandler]) -> type[EnvWrapper[THandler]]:
             self._episode_length_buf[env_ids] = 0
             if states is not None:
                 self.handler.set_states(states, env_ids=env_ids)
-            if self.handler.scenario.sim in ["mujoco", "isaacgym"]:
+            if self.handler.scenario.sim in ["isaacgym"]:
                 ## HACK
                 self.handler.simulate()
             self.handler.checker.reset(self.handler, env_ids=env_ids)

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -351,6 +351,7 @@ class MujocoHandler(BaseSimHandler):
         for obj_name, obj_state in states_flat[0].items():
             self._set_root_state(obj_name, obj_state, zero_vel)
             self._set_joint_state(obj_name, obj_state, zero_vel)
+        self.physics.forward()
 
     def _disable_robotgravity(self):
         gravity_vec = np.array([0.0, 0.0, -9.81])


### PR DESCRIPTION
This PR fixes #98 

 MuJoCo simulation uses `mj_step` in the gym wrapper instead of `mj_forward` to update derived quantities after modifying `qpos` and `qvel`. Using `mj_step` can introduce slight simulation discrepancies. Replacing it with `mj_forward` ensures that only the derived states are updated, resolving the inconsistency.

