### PR TITLE
[fix/isaacgym] reset pipeline 

### DIFF
--- a/metasim/sim/env_wrapper.py
+++ b/metasim/sim/env_wrapper.py
@@ -90,9 +90,6 @@ def GymEnvWrapper(cls: type[THandler]) -> type[EnvWrapper[THandler]]:
             self._episode_length_buf[env_ids] = 0
             if states is not None:
                 self.handler.set_states(states, env_ids=env_ids)
-            ## HACK
-            # if self.handler.scenario.sim in ["isaacgym"]:
-            #     self.handler.simulate()
             self.handler.checker.reset(self.handler, env_ids=env_ids)
             self.handler.refresh_render()
             states = self.handler.get_states()

--- a/metasim/sim/env_wrapper.py
+++ b/metasim/sim/env_wrapper.py
@@ -81,7 +81,7 @@ def GymEnvWrapper(cls: type[THandler]) -> type[EnvWrapper[THandler]]:
         def __init__(self, *args, **kwargs):
             self.handler = cls(*args, **kwargs)
             self.handler.launch()
-            self._episode_length_buf = torch.zeros(self.handler.num_envs, dtype=torch.int32)
+            self._episode_length_buf = torch.zeros(self.handler.num_envs, dtype=torch.int32, device=self.handler.device)
 
         def reset(self, states: list[EnvState] | None = None, env_ids: list[int] | None = None) -> tuple[Obs, Extra]:
             if env_ids is None:
@@ -90,9 +90,9 @@ def GymEnvWrapper(cls: type[THandler]) -> type[EnvWrapper[THandler]]:
             self._episode_length_buf[env_ids] = 0
             if states is not None:
                 self.handler.set_states(states, env_ids=env_ids)
-            if self.handler.scenario.sim in ["isaacgym"]:
-                ## HACK
-                self.handler.simulate()
+            ## HACK
+            # if self.handler.scenario.sim in ["isaacgym"]:
+            #     self.handler.simulate()
             self.handler.checker.reset(self.handler, env_ids=env_ids)
             self.handler.refresh_render()
             states = self.handler.get_states()

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -80,6 +80,7 @@ class IsaacgymHandler(BaseSimHandler):
         self._p_gains: torch.Tensor | None = None  # parameter for PD controller in for pd effort control
         self._d_gains: torch.Tensor | None = None
         self._torque_limits: torch.Tensor | None = None
+        self._effort: torch.Tensor | None = None  # output of pd controller, used for effort control
         self._pos_ctrl_dof_dix = []  # joint index in dof state, built-in position control mode
         self._manual_pd_on: bool = False  # turn on maunual pd controller if effort joint exist
 

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -526,6 +526,7 @@ class IsaacgymHandler(BaseSimHandler):
             joint_reindex = self.get_joint_reindex(robot.name)
             body_ids_reindex = self._get_body_ids_reindex(robot.name)
             state = RobotState(
+                # HACK: robot is always after objects
                 root_state=self._root_states.view(self.num_envs, -1, 13)[:, len(self.objects) + robot_id, :],
                 body_names=self.get_body_names(robot.name),
                 body_state=self._rigid_body_states.view(self.num_envs, -1, 13)[:, body_ids_reindex, :],
@@ -742,7 +743,7 @@ class IsaacgymHandler(BaseSimHandler):
         self._set_actor_root_state(pos_list, rot_list, env_ids)
         self._set_actor_joint_state(q_list, env_ids)
 
-        self.gym.simulate(self.sim)
+        self.gym.simulate(self.sim)  # FIXME: update the state, but has the side effect of stepping the physics
         # Refresh tensors
         self.gym.refresh_rigid_body_state_tensor(self.sim)
         self.gym.refresh_actor_root_state_tensor(self.sim)


### PR DESCRIPTION
fix some bugs in `isaacgym` and `env_wrapper.py` reset pipeline
1. delete `simulate()` after every time reset && fix missing declaring `self._effort` in in isaacgym (it will raise error if we apply 1.)
2. fix passing device in when initializing  `_episode_length_buf` in env_wrapper
3. remove redudant for loop in `set_states`