### PR TITLE
Make the project more compatible with `uv add/sync`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ isaaclab2 = [
     "torch==2.5.1+cu118",
     "torchvision==0.20.1+cu118",
     "isaacsim[all,extscache]==4.5.0",
+    "omniverse-kit",
 ]
 isaacgym = [
     "numpy<2",
@@ -45,6 +46,27 @@ genesis = ["genesis-world"]
 
 [tool.uv]
 index-strategy = "unsafe-best-match"
+
+[tool.uv.sources]
+torch = [
+  { index = "pytorch-cu118", extra = "isaaclab2" },
+]
+torchvision = [
+  { index = "pytorch-cu118", extra = "isaaclab2" },
+]
+omniverse-kit = [
+  { index = "nvidia", extra = "isaaclab2" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cu118"
+url = "https://download.pytorch.org/whl/cu118"
+explicit = true
+
+[[tool.uv.index]]
+name = "nvidia"
+url = "https://pypi.nvidia.com/"
+explicit = true
 
 [tool.uv.pip]
 extra-index-url = [


### PR DESCRIPTION
`tool.uv.pip.extra-index-url` only works for `uv pip install` but not `uv add/sync`
but since isaaclab is not compatible with `uv add`, we are still not compatible with `uv add/sync`.

```toml
[project]
name = "test"
version = "0.1.0"
description = "Add your description here"
readme = "README.md"
requires-python = "==3.10.*"
dependencies = [
    "roboverse-py[isaaclab2]",
    "diffusion_policy",
    "wandb>=0.19.11",
    "pandas>=2.2.3",
    "pip>=25.1.1",
]

[tool.uv.sources]
roboverse-py = { path = "RoboVerse" }
diffusion_policy = { path = "RoboVerse/roboverse_learn/algorithms/diffusion_policy" }

```
with this change, `uv sync` with above `pyproject.toml` (given `RoboVerse` get cloned into `./RoboVerse`) will succeed.
without this change, `uv sync` will fail with one of the following errors.
```
  × No solution found when resolving dependencies for split (python_full_version == '3.10.*' and platform_machine == 'aarch64' and sys_platform == 'linux'):
  ╰─▶ Because roboverse-py[isaaclab2]==0.1.17 depends on torch==2.5.1+cu118 and there is no version of torch==2.5.1+cu118, we can conclude that roboverse-py[isaaclab2]==0.1.17
      cannot be used.
      And because only roboverse-py[isaaclab2]==0.1.17 is available and your project depends on roboverse-py[isaaclab2], we can conclude that your project's requirements are
      unsatisfiable.
```
(`torchvision` is similar)
or
```
× Failed to build `omniverse-kit==106.5.0.162521`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `wheel_stub.buildapi.build_wheel` failed (exit status: 1)

      [stderr]
      INFO:wheel-stub:Testing wheel omniverse_kit-106.5.0.162521-cp310-none-manylinux_2_34_x86_64.whl against tag cp310-none-manylinux_2_34_x86_64
      INFO:wheel-stub:Testing wheel omniverse_kit-106.5.0.162521-cp310-none-win_amd64.whl against tag cp310-none-win_amd64
        File "/home/youjiacheng/.cache/uv/builds-v0/.tmpig93kK/lib/python3.10/site-packages/wheel_stub/wheel.py", line 249, in download_wheel
          return download_manual(wheel_directory, distribution, version, config)
        File "/home/youjiacheng/.cache/uv/builds-v0/.tmpig93kK/lib/python3.10/site-packages/wheel_stub/wheel.py", line 185, in download_manual
          raise RuntimeError(f"Didn't find wheel for {distribution} {version}")
      Traceback (most recent call last):
        File "/home/youjiacheng/.cache/uv/builds-v0/.tmpig93kK/lib/python3.10/site-packages/wheel_stub/wheel.py", line 249, in download_wheel
          return download_manual(wheel_directory, distribution, version, config)
        File "/home/youjiacheng/.cache/uv/builds-v0/.tmpig93kK/lib/python3.10/site-packages/wheel_stub/wheel.py", line 185, in download_manual
          raise RuntimeError(f"Didn't find wheel for {distribution} {version}")
      RuntimeError: Didn't find wheel for omniverse-kit 106.5.0.162521

      During handling of the above exception, another exception occurred:

      Traceback (most recent call last):
        File "<string>", line 11, in <module>
        File "/home/youjiacheng/.cache/uv/builds-v0/.tmpig93kK/lib/python3.10/site-packages/wheel_stub/buildapi.py", line 29, in build_wheel
          return download_wheel(pathlib.Path(wheel_directory), config_settings)
        File "/home/youjiacheng/.cache/uv/builds-v0/.tmpig93kK/lib/python3.10/site-packages/wheel_stub/wheel.py", line 251, in download_wheel
          report_install_failure(distribution, version, config, exception_context)
        File "/home/youjiacheng/.cache/uv/builds-v0/.tmpig93kK/lib/python3.10/site-packages/wheel_stub/error.py", line 67, in report_install_failure
          raise InstallFailedError(
      wheel_stub.error.InstallFailedError:
      *******************************************************************************

      The installation of omniverse-kit for version 106.5.0.162521 failed.

      This is a special placeholder package which downloads a real wheel package
      from https://pypi.nvidia.com/. If https://pypi.nvidia.com/ is not reachable, we
      cannot download the real wheel file to install.

      You might try installing this package via
      ```
      $ pip install --extra-index-url https://pypi.nvidia.com/ omniverse-kit
      ```

      Here is some debug information about your platform to include in any bug
      report:

      Python Version: CPython 3.10.15
      Operating System: Linux 5.15.0-136-generic
      CPU Architecture: x86_64
      Driver Version: 535.183
      CUDA Version: 12.2

      *******************************************************************************


      hint: This usually indicates a problem with the package or the build environment.
```