### PR TITLE
Fix `joint_pos_target` order problem for sapien2/3

### DIFF
--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -70,9 +70,9 @@ class Sapien2Handler(BaseSimHandler):
 
         # Add agents
         self.object_ids: dict[str, sapien_core.Actor | sapien_core.Articulation] = {}
-        self._previous_dof_pos_target: dict[str, list[float]] = {}
-        self._previous_dof_vel_target: dict[str, list[float]] = {}
-        self._previous_dof_torque_target: dict[str, list[float]] = {}
+        self._previous_dof_pos_target: dict[str, np.ndarray] = {}
+        self._previous_dof_vel_target: dict[str, np.ndarray] = {}
+        self._previous_dof_torque_target: dict[str, np.ndarray] = {}
         self.link_ids: dict[str, list[sapien_core.LinkBase]] = {}
         self.object_joint_order = {}
         self.camera_ids = {}
@@ -315,18 +315,13 @@ class Sapien2Handler(BaseSimHandler):
         instance = self.object_ids[obj_name]
         if isinstance(instance, sapien_core.Articulation):
             action = target[0]
-            pos_target = None
-            vel_target = None
-            if "dof_pos_target" in action:
-                pos_target = np.array([
-                    action["dof_pos_target"][name] for name in self.object_joint_order[self.robot.name]
-                ])
-            if "dof_vel_target" in action:
-                vel_target = np.array([
-                    action["dof_vel_target"][name] for name in self.object_joint_order[self.robot.name]
-                ])
-            self._previous_dof_pos_target[obj_name] = pos_target
-            self._previous_dof_vel_target[obj_name] = vel_target
+            pos_target = action.get("dof_pos_target", None)
+            vel_target = action.get("dof_vel_target", None)
+            jns = self.get_joint_names(obj_name, sort=True)
+            if pos_target is not None:
+                self._previous_dof_pos_target[obj_name] = np.array([pos_target[name] for name in jns])
+            if vel_target is not None:
+                self._previous_dof_vel_target[obj_name] = np.array([vel_target[name] for name in jns])
             self._apply_action(instance, pos_target, vel_target)
 
     def simulate(self):
@@ -418,21 +413,9 @@ class Sapien2Handler(BaseSimHandler):
             root_state = torch.cat([pos, rot, vel, ang_vel], dim=-1).unsqueeze(0)
             joint_reindex = self.get_joint_reindex(robot.name)
             link_names, link_state = self._get_link_states(robot.name)
-            pos_target = (
-                torch.tensor(self._previous_dof_pos_target[robot.name]).unsqueeze(0)
-                if self._previous_dof_pos_target[robot.name] is not None
-                else None
-            )
-            vel_target = (
-                torch.tensor(self._previous_dof_vel_target[robot.name]).unsqueeze(0)
-                if self._previous_dof_vel_target[robot.name] is not None
-                else None
-            )
-            torque_target = (
-                torch.tensor(self._previous_dof_torque_target[robot.name]).unsqueeze(0)
-                if self._previous_dof_torque_target[robot.name] is not None
-                else None
-            )
+            pos_target = torch.tensor(self._previous_dof_pos_target[robot.name]).unsqueeze(0)
+            vel_target = torch.tensor(self._previous_dof_vel_target[robot.name]).unsqueeze(0)
+            effort_target = torch.tensor(self._previous_dof_torque_target[robot.name]).unsqueeze(0)
             state = RobotState(
                 root_state=root_state,
                 body_names=link_names,
@@ -441,7 +424,7 @@ class Sapien2Handler(BaseSimHandler):
                 joint_vel=torch.tensor(robot_inst.get_qvel()[joint_reindex]).unsqueeze(0),
                 joint_pos_target=pos_target,
                 joint_vel_target=vel_target,
-                joint_effort_target=torque_target,
+                joint_effort_target=effort_target,
             )
             robot_states[robot.name] = state
 

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -343,14 +343,11 @@ class Sapien3Handler(BaseSimHandler):
             action = target[0]
             pos_target = action.get("dof_pos_target", None)
             vel_target = action.get("dof_vel_target", None)
-            pos_target_arr = (
-                np.array([pos_target[name] for name in self.object_joint_order[obj_name]]) if pos_target else None
-            )
-            vel_target_arr = (
-                np.array([vel_target[name] for name in self.object_joint_order[obj_name]]) if vel_target else None
-            )
-            self._previous_dof_pos_target[obj_name] = pos_target_arr
-            self._previous_dof_vel_target[obj_name] = vel_target_arr
+            jns = self.get_joint_names(obj_name, sort=True)
+            if pos_target is not None:
+                self._previous_dof_pos_target[obj_name] = np.array([pos_target[name] for name in jns])
+            if vel_target is not None:
+                self._previous_dof_vel_target[obj_name] = np.array([vel_target[name] for name in jns])
             self._apply_action(instance, pos_target, vel_target)
 
     def simulate(self):
@@ -432,21 +429,9 @@ class Sapien3Handler(BaseSimHandler):
             root_state = torch.cat([pos, rot, vel, ang_vel], dim=-1).unsqueeze(0)
             joint_reindex = self.get_joint_reindex(robot.name)
             link_names, link_state = self._get_link_states(robot.name)
-            pos_target = (
-                torch.tensor(self._previous_dof_pos_target[robot.name]).unsqueeze(0)
-                if self._previous_dof_pos_target[robot.name] is not None
-                else None
-            )
-            vel_target = (
-                torch.tensor(self._previous_dof_vel_target[robot.name]).unsqueeze(0)
-                if self._previous_dof_vel_target[robot.name] is not None
-                else None
-            )
-            effort_target = (
-                torch.tensor(self._previous_dof_torque_target[robot.name]).unsqueeze(0)
-                if self._previous_dof_torque_target[robot.name] is not None
-                else None
-            )
+            pos_target = torch.tensor(self._previous_dof_pos_target[robot.name]).unsqueeze(0)
+            vel_target = torch.tensor(self._previous_dof_vel_target[robot.name]).unsqueeze(0)
+            effort_target = torch.tensor(self._previous_dof_torque_target[robot.name]).unsqueeze(0)
             state = RobotState(
                 root_state=root_state,
                 body_names=link_names,


### PR DESCRIPTION
also fix `joint_vel_targer` order problem;
also make it adhere to typing (`self._previous_dof_*_target[robot.name]` can't be None).
(Note: ideally we should make it optional to improve performance, but `RobotState` annotate `joint_pos_target` as `Tensor` instead of `Tensor | None`)

According to
https://github.com/RoboVerseOrg/RoboVerse/blob/3b34b659de693205563f721a0d6b609ac16e94f9/metasim/utils/state.py#L170-L188

`joint_pos_target` and `joint_pos` should follow the same order -- sorted order (`get_joint_names` has `sort=True` default), but `object_joint_order` is not sorted.