### PR TITLE
[fix] state_consistency in isaacgym 

### DIFF
--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -836,13 +836,12 @@ class IsaacgymHandler(BaseSimHandler):
     ############################################################
     def get_joint_names(self, obj_name: str, sort: bool = True) -> list[str]:
         if isinstance(self.object_dict[obj_name], ArticulationObjCfg):
-            # read as indiced format
+            # read as indiced sorted format
             joint_names = [
                 name
                 for name, _ in sorted(self._joint_info[obj_name]["global_indices"].items(), key=lambda item: item[1])
             ]
-
-            # sorted as alphabet format
+            # read asalphabet sorted format
             if sort:
                 joint_names.sort()
             return joint_names

--- a/metasim/test/state_consistency.py
+++ b/metasim/test/state_consistency.py
@@ -96,7 +96,7 @@ init_states = [
                 "rot": torch.tensor([1.0, 0.0, 0.0, 0.0]),
             },
             "sphere": {
-                "pos": torch.tensor([0.4, -0.6, 0.05]),
+                "pos": torch.tensor([0.4, -0.6, 0.10]),
                 "rot": torch.tensor([1.0, 0.0, 0.0, 0.0]),
             },
             "bbq_sauce": {
@@ -129,6 +129,9 @@ init_states = [
     }
 ]
 
+if args.sim == "isaacgym":
+    # In IsaacGym, we need to call gym.simulate before we can effectively get states from physics engine.
+    env.handler.simulate()
 env.handler.set_states(init_states)
 states = state_tensor_to_nested(env.handler, env.handler.get_states())
 
@@ -159,3 +162,5 @@ for i in range(args.num_envs):
             states[i]["robots"]["franka"]["dof_pos"][k],
             init_states[i]["robots"]["franka"]["dof_pos"][k],
         )
+
+log.info("Test passed !!!")

--- a/metasim/test/state_consistency.py
+++ b/metasim/test/state_consistency.py
@@ -130,7 +130,7 @@ init_states = [
 ]
 
 if args.sim == "isaacgym":
-    # In IsaacGym, we need to call gym.simulate before we can effectively get states from physics engine.
+    # In IsaacGym, we need to call gym.simulate before we can effectively get tensor states from physics engine.
     env.handler.simulate()
 env.handler.set_states(init_states)
 states = state_tensor_to_nested(env.handler, env.handler.get_states())
@@ -163,4 +163,4 @@ for i in range(args.num_envs):
             init_states[i]["robots"]["franka"]["dof_pos"][k],
         )
 
-log.info("Test passed !!!")
+log.info("Test passed !!!!!")

--- a/metasim/utils/state.py
+++ b/metasim/utils/state.py
@@ -241,6 +241,9 @@ def state_tensor_to_nested(handler: BaseSimHandler, tensor_state: TensorState) -
                 "vel": obj_state.root_state[env_id, 7:10].cpu(),
                 "ang_vel": obj_state.root_state[env_id, 10:13].cpu(),
             }
+            if handler.scenario.sim == "isaacgym":
+                # for IsaacGym,convert quat format: xyzw -> wxyz
+                object_states[obj_name]["rot"] = object_states[obj_name]["rot"][[3, 0, 1, 2]]
             if obj_state.body_state is not None:
                 bns = handler.get_body_names(obj_name)
                 object_states[obj_name]["body"] = _body_tensor_to_dict(obj_state.body_state[env_id], bns)
@@ -260,6 +263,9 @@ def state_tensor_to_nested(handler: BaseSimHandler, tensor_state: TensorState) -
                 "vel": robot_state.root_state[env_id, 7:10].cpu(),
                 "ang_vel": robot_state.root_state[env_id, 10:13].cpu(),
             }
+            if handler.scenario.sim == "isaacgym":
+                # for IsaacGym,convert quat format: xyzw -> wxyz
+                robot_states[robot_name]["rot"] = robot_states[robot_name]["rot"][[3, 0, 1, 2]]
             robot_states[robot_name]["dof_pos"] = _dof_tensor_to_dict(robot_state.joint_pos[env_id], jns)
             robot_states[robot_name]["dof_vel"] = _dof_tensor_to_dict(robot_state.joint_vel[env_id], jns)
             robot_states[robot_name]["dof_pos_target"] = (


### PR DESCRIPTION
1. fix reindex error in IsaacGym
2. increase z corrdinate of shpere, otherwise the it will be "cut" (embededd into) by the plane (z should be larger than radius)
2. fix IsaacGym set_state and get_state inconsistencty https://github.com/RoboVerseOrg/RoboVerse/issues/99#event-18038639168

test command: 
```
python3 metasim/test/state_consistency.py --sim=isaacgym
```