### PR TITLE
[performance] add caching for get_states method

### DIFF
--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -92,7 +92,7 @@ class GenesisHandler(BaseSimHandler):
 
         self.scene_inst.build(n_envs=self.scenario.num_envs, env_spacing=(2, 2))
 
-    def get_states(self, env_ids: list[int] | None = None) -> list[EnvState]:
+    def _get_states(self, env_ids: list[int] | None = None) -> list[EnvState]:
         if env_ids is None:
             env_ids = list(range(self.num_envs))
 
@@ -221,7 +221,7 @@ class GenesisHandler(BaseSimHandler):
                 ],
             )
 
-    def simulate(self):
+    def _simulate(self):
         for _ in range(self.scenario.decimation):
             self.scene_inst.step()
 

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -497,7 +497,7 @@ class IsaacgymHandler(BaseSimHandler):
             self.gym.viewer_camera_look_at(self.viewer, middle_env, cam_pos, cam_target)
         ################################
 
-    def get_states(self, env_ids: list[int] | None = None) -> list[EnvState]:
+    def _get_states(self, env_ids: list[int] | None = None) -> list[EnvState]:
         if env_ids is None:
             env_ids = list(range(self.num_envs))
 
@@ -628,7 +628,7 @@ class IsaacgymHandler(BaseSimHandler):
             self.gym.simulate(self.sim)
             self.gym.fetch_results(self.sim, True)
 
-    def simulate(self) -> None:
+    def _simulate(self) -> None:
         # Step the physics
         self._simulate_one_physics_step(self.actions)
         # Refresh tensors

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -324,7 +324,7 @@ class IsaaclabHandler(BaseSimHandler):
     ############################################################
     ## Get states
     ############################################################
-    def get_states(self, env_ids: list[int] | None = None) -> TensorState:
+    def _get_states(self, env_ids: list[int] | None = None) -> TensorState:
         if env_ids is None:
             env_ids = list(range(self.num_envs))
 
@@ -430,7 +430,7 @@ class IsaaclabHandler(BaseSimHandler):
     ############################################################
     ## Misc
     ############################################################
-    def simulate(self):
+    def _simulate(self):
         pass
 
     def get_joint_names(self, obj_name: str, sort: bool = True) -> list[str]:

--- a/metasim/sim/mjx/mjx.py
+++ b/metasim/sim/mjx/mjx.py
@@ -93,12 +93,12 @@ class MJXHandler(BaseSimHandler):
         log.info(f"MJXHandler launched · envs={self.num_envs}")
         log.warning("MJX currently does not support batch rendering — only env_id = 0 will be used for camera output")
 
-    def simulate(self) -> None:
+    def _simulate(self) -> None:
         if self._gravity_compensation:
             self._disable_robotgravity()
         self._data = self._substep(self._mjx_model, self._data)
 
-    def get_states(self, env_ids: list[int] | None = None):
+    def _get_states(self, env_ids: list[int] | None = None):
         """Return a structured snapshot of all robots / objects in the scene."""
         data = self._data  # mjx_env.Data  (N, …)
         N = data.qpos.shape[0]

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -221,7 +221,7 @@ class MujocoHandler(BaseSimHandler):
         root_np = full[0]
         return root_np, full  # root, bodies
 
-    def get_states(self, env_ids: list[int] | None = None) -> list[dict]:
+    def _get_states(self, env_ids: list[int] | None = None) -> list[dict]:
         object_states = {}
         for obj in self.objects:
             model_name = self.mj_objects[obj.name].model
@@ -375,7 +375,7 @@ class MujocoHandler(BaseSimHandler):
         if self.viewer is not None:
             self.viewer.sync()
 
-    def simulate(self):
+    def _simulate(self):
         if self._gravity_compensation:
             self._disable_robotgravity()
 

--- a/metasim/sim/parallel.py
+++ b/metasim/sim/parallel.py
@@ -205,7 +205,7 @@ def ParallelSimWrapper(base_cls: type[BaseSimHandler]) -> type[BaseSimHandler]:
             for i in env_ids:
                 self.remotes[i].send(("set_pose", (obj_name, [pos[i]], [rot[i]])))
 
-        def get_states(self, env_ids: list[int] | None = None) -> list[EnvState]:
+        def _get_states(self, env_ids: list[int] | None = None) -> list[EnvState]:
             if env_ids is None:
                 env_ids = list(range(self.num_envs))
 
@@ -222,7 +222,7 @@ def ParallelSimWrapper(base_cls: type[BaseSimHandler]) -> type[BaseSimHandler]:
             log.trace(f"Time taken to concatenate states: {toc - tic:.4f}s")
             return concat_states
 
-        def simulate(self):
+        def _simulate(self):
             for remote in self.remotes:
                 remote.send(("simulate", (None,)))
 

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -250,7 +250,7 @@ class SinglePybulletHandler(BaseSimHandler):
         ])
         self._apply_action(action_arr, self.object_ids[obj_name])
 
-    def simulate(self):
+    def _simulate(self):
         """Step the simulation."""
         # # Rewrite this function for multi-env version
         # action = actions[0]
@@ -309,7 +309,7 @@ class SinglePybulletHandler(BaseSimHandler):
     ############################################################
     ## Get states
     ############################################################
-    def get_states(self, env_ids=None) -> list[EnvState]:
+    def _get_states(self, env_ids=None) -> list[EnvState]:
         """Get the states of the environment.
 
         Returns:

--- a/metasim/sim/pyrep/pyrep.py
+++ b/metasim/sim/pyrep/pyrep.py
@@ -93,5 +93,5 @@ class PyrepHandler(BaseSimHandler):
     ############################################################
     ## Get states
     ############################################################
-    def get_states(self) -> list[EnvState]:
+    def _get_states(self) -> list[EnvState]:
         pass

--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -329,7 +329,7 @@ class Sapien2Handler(BaseSimHandler):
             self._previous_dof_vel_target[obj_name] = vel_target
             self._apply_action(instance, pos_target, vel_target)
 
-    def simulate(self):
+    def _simulate(self):
         for i in range(self.scenario.decimation):
             self.scene.step()
             self.scene.update_render()
@@ -372,7 +372,7 @@ class Sapien2Handler(BaseSimHandler):
         link_state_tensor = torch.cat(link_state_list, dim=0)
         return link_name_list, link_state_tensor
 
-    def get_states(self, env_ids=None) -> list[EnvState]:
+    def _get_states(self, env_ids=None) -> list[EnvState]:
         object_states = {}
         for obj in self.objects:
             obj_inst = self.object_ids[obj.name]

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -353,7 +353,7 @@ class Sapien3Handler(BaseSimHandler):
             self._previous_dof_vel_target[obj_name] = vel_target_arr
             self._apply_action(instance, pos_target, vel_target)
 
-    def simulate(self):
+    def _simulate(self):
         for i in range(self.scenario.decimation):
             self.scene.step()
             self.scene.update_render()
@@ -389,7 +389,7 @@ class Sapien3Handler(BaseSimHandler):
         link_state_tensor = torch.cat(link_state_list, dim=0)
         return link_name_list, link_state_tensor
 
-    def get_states(self, env_ids=None) -> list[EnvState]:
+    def _get_states(self, env_ids=None) -> list[EnvState]:
         object_states = {}
         for obj in self.objects:
             obj_inst = self.object_ids[obj.name]


### PR DESCRIPTION
As title. every time `get_states()` is called, the states are cached, until the next `simulate()`