### PR TITLE
[refactor] autodownload use speed up

### DIFF
--- a/metasim/utils/hf_util.py
+++ b/metasim/utils/hf_util.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import os
 from multiprocessing import Pool
 
-from huggingface_hub import HfApi, HfFileSystem, hf_hub_download
+from huggingface_hub import HfApi, hf_hub_download
 from loguru import logger as log
 
 from metasim.cfg.objects import BaseObjCfg, PrimitiveCubeCfg, PrimitiveCylinderCfg, PrimitiveSphereCfg
@@ -22,7 +22,6 @@ REPO_ID = "RoboVerseOrg/roboverse_data"
 LOCAL_DIR = "roboverse_data"
 
 hf_api = HfApi()
-hf_fs = HfFileSystem()
 
 
 def _check_and_download_single(filepath: str):
@@ -33,12 +32,12 @@ def _check_and_download_single(filepath: str):
     """
     local_exists = os.path.exists(filepath)
     if local_exists:
-        ## In this case, the runner is a developer who has the file in their local machine.
+        ## In this case, the runner has the file in their local machine.
         log.info(f"File {filepath} found in local directory.")
         return
     else:
         ## In this case, we didn't find the file in the local directory, the circumstance is complicated.
-        hf_exists = hf_fs.exists(os.path.join("datasets", REPO_ID, os.path.relpath(filepath, LOCAL_DIR)))
+        hf_exists = hf_api.file_exists(REPO_ID, os.path.relpath(filepath, LOCAL_DIR), repo_type="dataset")
 
         ## Make sure the file exists in the huggingface dataset.
         if not hf_exists:
@@ -47,7 +46,7 @@ def _check_and_download_single(filepath: str):
                 " report this issue to the developers."
             )
 
-        ## Also, we need to exclude a circumstance that a developer forgot to update the submodule.
+        ## Also, we need to exclude a circumstance that user forgot to update the submodule.
         using_hf_git = os.path.exists(os.path.join(LOCAL_DIR, ".git"))
         if using_hf_git:
             raise Exception(


### PR DESCRIPTION
1. autodownload use `hf_api.file_exists` instead of `hf_fs.exists` to speed up, as recommended in [hf doc](https://huggingface.co/docs/huggingface_hub/main/en/package_reference/hf_file_system#huggingface_hub.HfFileSystem.exists)
2. fix related comments