### PR TITLE
[fix] call simulate before get_states

### DIFF
--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -151,6 +151,7 @@ class IsaaclabHandler(BaseSimHandler):
         _, _, _, time_out, extras = self.env.step(action_tensor_all)
         time_out = time_out.cpu()
         success = self.checker.check(self)
+        self.simulate()
         states = self.get_states()
 
         ## TODO: organize this
@@ -211,6 +212,7 @@ class IsaaclabHandler(BaseSimHandler):
 
         ## Update obs
         tic = time.time()
+        self.simulate()
         states = self.get_states()
         toc = time.time()
         log.trace(f"Reset getting obs time: {toc - tic:.2f}s")


### PR DESCRIPTION
### Describe the Bug

Introduced in #240 

Running `get_started/1_control_robot.py` with the Isaaclab simulator results in a static video output — the robot does not appear to move or update correctly during the simulation.

Video reference:  

https://github.com/user-attachments/assets/20612a19-f6aa-4562-8b0a-fb243d2ab5c1


### Steps to Reproduce

```bash
python get_started/1_control_robot.py --sim isaaclab

```

### Proposed Fix
Call `self.simulate()` before `self.get_states()` in `metasim/sim/isaaclab/isaaclab.py`  to ensure `_state_cache_expire` is set to `True`. This guarantees that the correct observation is obtained from the simulator.

### Expected Result
With the fix, the simulation runs as expected, showing the robot in motion.

Fixed result example:


https://github.com/user-attachments/assets/1e6f5df0-e660-40d3-8938-9293d4a9d590




