### PR TITLE
[fix] fix bugs for RL infra and configs caused by multirobots

### DIFF
--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -624,6 +624,27 @@ class IsaacgymHandler(BaseSimHandler):
         else:
             self.gym.set_dof_position_target_tensor(self.sim, gymtorch.unwrap_tensor(action_input[:,]))
 
+    def set_actions(self, obj_name: str, actions: torch.Tensor) -> None:
+        action_input = torch.zeros_like(self._dof_states[:, 0])
+
+        if not hasattr(self, "_robot_dim_index"):
+            chunk = action_input.shape[0] // self._num_envs
+            robot_dim = actions.shape[1]
+            self._robot_dim_index = [
+                env * chunk + (chunk - robot_dim) + i for env in range(self._num_envs) for i in range(robot_dim)
+            ]
+
+        action_input[self._robot_dim_index] = actions.to(self.device).reshape(-1)
+
+        if self._manual_pd_on:
+            self.actions = action_input.view(self._num_envs, self._obj_num_dof + self._robot_num_dof)[
+                :, self._obj_num_dof :
+            ]
+            if self._pos_ctrl_dof_dix:
+                self.gym.set_dof_position_target_tensor(self.sim, gymtorch.unwrap_tensor(action_input))
+        else:
+            self.gym.set_dof_position_target_tensor(self.sim, gymtorch.unwrap_tensor(action_input))
+
     def refresh_render(self) -> None:
         # Step the physics
         self.gym.simulate(self.sim)

--- a/metasim/sim/mjx/mjx.py
+++ b/metasim/sim/mjx/mjx.py
@@ -109,7 +109,7 @@ class MJXHandler(BaseSimHandler):
         objects: dict[str, ObjectState] = {}
 
         # --------------------------- ROBOT ---------------------------------------
-        r_cfg = self._scenario.robot
+        r_cfg = self._scenario.robots[0]  # FIXME support multiple robots
         prefix = f"{r_cfg.name}/"
 
         # body IDs ---------------------------------------------------------------
@@ -341,7 +341,7 @@ class MJXHandler(BaseSimHandler):
         tgt_jax = t2j(tgt_torch)
 
         # -------- id maps ---------------------------------------------
-        if obj_name == self._scenario.robot.name:
+        if obj_name == self._scenario.robots[0].name:
             a_ids = self._robot_act_ids.get(obj_name)
         else:
             a_ids = self._object_act_ids.get(obj_name)
@@ -519,7 +519,7 @@ class MJXHandler(BaseSimHandler):
     def _build_joint_name_map(self) -> None:
         pool = self._mjx_model.names
         adr = self._mjx_model.name_jntadr
-        robot_prefix = self._scenario.robot.name
+        robot_prefix = self._scenario.robots[0].name
         self._joint_name2id = {}
 
         for jid, a in enumerate(adr):

--- a/roboverse_learn/fast_td3/configs/isaacgym.yaml
+++ b/roboverse_learn/fast_td3/configs/isaacgym.yaml
@@ -3,9 +3,9 @@
 # Environment
 # -------------------------------------------------------------------------------
 sim: isaacgym
-robot: h1
+robots: [h1]
 task: humanoidbench:Stand
-decimation: 4
+decimation: 10
 train_or_eval: train
 
 # -------------------------------------------------------------------------------
@@ -23,7 +23,7 @@ num_envs: 128
 num_eval_envs: 128
 total_timesteps: 100000
 learning_starts: 10
-num_steps: 1
+num_steps: 4
 
 # -------------------------------------------------------------------------------
 # Replay, Batching, Discounting
@@ -83,8 +83,8 @@ action_bounds: 1.0
 # -------------------------------------------------------------------------------
 # Logging & Checkpointing
 # -------------------------------------------------------------------------------
-project: fast_td3_mjc128
-exp_name: fasttd3_mjc128
+project: fasttd3_isaacgym
+exp_name: fasttd3_isaacgym
 use_wandb: true
 checkpoint_path: null
 eval_interval: 2000

--- a/roboverse_learn/fast_td3/configs/mjc.yaml
+++ b/roboverse_learn/fast_td3/configs/mjc.yaml
@@ -3,7 +3,7 @@
 # Environment
 # -------------------------------------------------------------------------------
 sim: mujoco
-robot: h1
+robots: [h1]
 task: humanoidbench:Stand
 decimation: 10
 train_or_eval: train

--- a/roboverse_learn/fast_td3/configs/mjx.yaml
+++ b/roboverse_learn/fast_td3/configs/mjx.yaml
@@ -3,7 +3,7 @@
 # Environment
 # -------------------------------------------------------------------------------
 sim: mjx
-robot: h1
+robots: [h1]
 task: humanoidbench:Stand
 decimation: 10
 train_or_eval: train

--- a/roboverse_learn/fast_td3/configs/mjx_fast.yaml
+++ b/roboverse_learn/fast_td3/configs/mjx_fast.yaml
@@ -3,7 +3,7 @@
 # Environment
 # -------------------------------------------------------------------------------
 sim: mjx
-robot: h1
+robots: [h1]
 task: humanoidbench:Stand
 decimation: 10
 train_or_eval: train

--- a/roboverse_learn/fast_td3/configs/mjx_pg.yaml
+++ b/roboverse_learn/fast_td3/configs/mjx_pg.yaml
@@ -3,7 +3,7 @@
 # Environment
 # -------------------------------------------------------------------------------
 sim: mjx
-robot: h1
+robots: [h1]
 task: humanoidbench:Stand
 decimation: 10
 train_or_eval: train

--- a/roboverse_learn/fast_td3/wrapper.py
+++ b/roboverse_learn/fast_td3/wrapper.py
@@ -29,7 +29,7 @@ class FastTD3EnvWrapper:
         self.env = EnvironmentClass(scenario)
 
         self.num_envs = scenario.num_envs
-        self.robot = scenario.robot
+        self.robot = scenario.robots[0]
         self.task = scenario.task
         # ----------- initial states --------------------------------------------------
         initial_states, _, _ = get_traj(self.task, self.robot, self.env.handler)

--- a/roboverse_learn/humanoidbench_rl/configs/isaacgym.yaml
+++ b/roboverse_learn/humanoidbench_rl/configs/isaacgym.yaml
@@ -2,7 +2,7 @@
 
 # Environment settings
 sim: isaacgym
-robot: h1
+robots: [h1]
 task: humanoidbench:Stand
 decimation: 4
 num_envs: 128

--- a/roboverse_learn/humanoidbench_rl/configs/isaaclab.yaml
+++ b/roboverse_learn/humanoidbench_rl/configs/isaaclab.yaml
@@ -2,7 +2,7 @@
 
 # Environment settings
 sim: isaaclab
-robot: h1
+robots: [h1]
 task: humanoidbench:Stand
 decimation: 1
 num_envs: 1024

--- a/roboverse_learn/humanoidbench_rl/configs/mjx.yaml
+++ b/roboverse_learn/humanoidbench_rl/configs/mjx.yaml
@@ -1,9 +1,9 @@
 # Environment settings
 sim: mjx
-robot: h1
+robots: [h1]
 task: humanoidbench:Stand
 decimation: 10
-num_envs: 128
+num_envs: 2048
 add_table: false
 
 # Training settings
@@ -18,15 +18,9 @@ eval_model_path: <path to eval model>
 
 # PPO parameters
 learning_rate: 0.0003
-n_steps: 256
+n_steps: 32
 num_batch: 64
 n_epochs: 4
-
-# # PPO parameters
-# learning_rate: 0.0003
-# n_steps: 32
-# num_batch: 64
-# n_epochs: 4
 
 # Learning rate schedule
 use_lr_schedule: true

--- a/roboverse_learn/humanoidbench_rl/configs/mujoco.yaml
+++ b/roboverse_learn/humanoidbench_rl/configs/mujoco.yaml
@@ -2,7 +2,7 @@
 
 # Environment settings
 sim: mujoco
-robot: h1
+robots: [h1]
 task: humanoidbench:Stand
 decimation: 10
 num_envs: 1  # MuJoCo only supports single environment

--- a/roboverse_learn/humanoidbench_rl/train_sb3.py
+++ b/roboverse_learn/humanoidbench_rl/train_sb3.py
@@ -118,7 +118,7 @@ def main():
 
     scenario = ScenarioCfg(
         task=config.get("task"),
-        robot=config.get("robot"),
+        robots=config.get("robots"),
         try_add_table=config.get("add_table", False),
         sim=config.get("sim"),
         num_envs=config.get("num_envs", 1),


### PR DESCRIPTION
This PR fixesthe RL infra bugs caused by multi-robots. The config files and wrappers for humanoidbench_rl and fast_td3 have been adjusted to account for this change. For now, only consider robots[0] in both environments to ensure training.
