### PR TITLE
[feat] add env_spacing to ScenarioCfg

### DIFF
--- a/docs/source/metasim/user_guide/support_matrix.rst
+++ b/docs/source/metasim/user_guide/support_matrix.rst
@@ -49,6 +49,15 @@ Simulation Configuration
      -
      -
      -
+   * - ``env_spacing``
+     - 
+     - ✓
+     -
+     - ✓
+     -
+     -
+
+
 
 Robot Configuration
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/source/roboverse_learn/index.md
+++ b/docs/source/roboverse_learn/index.md
@@ -19,6 +19,7 @@ reinforcement_learning/ppo.md
 reinforcement_learning/sac.md
 reinforcement_learning/dreamer.md
 reinforcement_learning/humanoidbench_rl.md
+reinforcement_learning/skillblender_rl.md
 ```
 
 ```{toctree}

--- a/metasim/cfg/scenario.py
+++ b/metasim/cfg/scenario.py
@@ -54,6 +54,8 @@ class ScenarioCfg:
     object_states: bool = False
     split: Literal["train", "val", "test", "all"] = "all"
     headless: bool = False
+    """environment spacing for parallel environments"""
+    env_spacing: float = 1.0
 
     def __post_init__(self):
         """Post-initialization configuration."""
@@ -84,5 +86,7 @@ class ScenarioCfg:
         self.sim_params = self.task.sim_params if self.task is not None else self.sim_params
         ### Control parameters  overvide by task
         self.control = self.task.control if self.task is not None else self.control
+        ### spacing of parallel environments
+        self.env_spacing = self.task.env_spacing if self.task is not None else self.env_spacing
 
         FileDownloader(self).do_it()

--- a/metasim/cfg/tasks/base_task_cfg.py
+++ b/metasim/cfg/tasks/base_task_cfg.py
@@ -32,6 +32,7 @@ class BaseTaskCfg:
         reward_functions: The list of reward functions.
         reward_weights: The list of reward weights.
         sim_params: The simulation params.
+        env_spacing: The spacing of parrelal environment.
     """
 
     decimation: int = 3
@@ -46,6 +47,7 @@ class BaseTaskCfg:
     reward_weights: list[float] = MISSING
     sim_params: SimParamCfg = SimParamCfg()
     control: ControlCfg = ControlCfg()
+    env_spacing: float = 1.0
 
 
 @configclass

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -90,7 +90,9 @@ class GenesisHandler(BaseSimHandler):
             )
             self.camera_inst_dict[camera.name] = camera_inst
 
-        self.scene_inst.build(n_envs=self.scenario.num_envs, env_spacing=(2, 2))
+        self.scene_inst.build(
+            n_envs=self.scenario.num_envs, env_spacing=(self.scenario.env_spacing, self.scenario.env_spacing)
+        )
 
     def _get_states(self, env_ids: list[int] | None = None) -> list[EnvState]:
         if env_ids is None:

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -345,7 +345,7 @@ class IsaacgymHandler(BaseSimHandler):
     ) -> None:
         # configure env grid
         num_per_row = int(math.sqrt(self.num_envs))
-        spacing = 1.0
+        spacing = self.scenario.env_spacing
         env_lower = gymapi.Vec3(-spacing, -spacing, 0.0)
         env_upper = gymapi.Vec3(spacing, spacing, spacing)
         log.info("Creating %d environments" % self.num_envs)

--- a/roboverse_learn/skillblender_rl/train_skillblender.py
+++ b/roboverse_learn/skillblender_rl/train_skillblender.py
@@ -100,7 +100,7 @@ def get_args(test=False):
             "name": "--num_envs",
             "type": int,
             "default": 128,
-            "help": "number of parrallel environments.",
+            "help": "number of parallel environments.",
         },
         {
             "name": "--sim",


### PR DESCRIPTION
1. I will integrate some training tasks which require larger `env_spacing`, so adding this API in ScenarioCfg is necessary. And it should be overrided by `env_spacing` in task if specified.
2. fixed mistaken delete when refactored docs before