### PR TITLE
perf/tensorize-robot-local-velocity

### DIFF
--- a/metasim/utils/humanoid_robot_util.py
+++ b/metasim/utils/humanoid_robot_util.py
@@ -5,11 +5,8 @@ from __future__ import annotations
 import torch
 
 from metasim.utils.math import (
-    axis_angle_from_quat,
     euler_xyz_from_quat,
     matrix_from_quat,
-    quat_from_angle_axis,
-    quat_mul,
 )
 
 
@@ -136,67 +133,40 @@ def last_robot_velocity_tensor(envstate, robot_name: str):
     return envstate.robots[robot_name].extra["last_robot_velocity"]
 
 
-def robot_local_velocity_tensor(envstate, robot_name: str):
-    """Returns the local linear velocity of the robot in its local frame.
+def robot_local_velocity_tensor(envstate, robot_name: str) -> torch.Tensor:
+    """Batched (B,) → (B,2) conversion from world-frame XY velocity to robot-frame XY velocity.
 
     Args:
-        envstate: Environment state object with batched robot states.
-        robot_name (str): Name of the robot.
+    ----
+    envstate :  your batched simulation state object
+    robot_name : str
+        Name of the queried robot.
 
     Returns:
-        torch.Tensor: Local velocities, shape=(batch_size, 2), where columns correspond to forward (x) and lateral (y) velocities.
+    -------
+    torch.Tensor [B, 2]
+        v_x_fwd  (column 0) and v_y_lat (column 1) in *robot* coordinates.
     """
-    world_velocity = robot_velocity_tensor(envstate, robot_name)
-    world_rotation = robot_rotation_tensor(envstate, robot_name)
+    # (B,3)  – only XY are used here, but keep Z so downstream code can stay unchanged.
+    v_world = robot_velocity_tensor(envstate, robot_name)
 
-    # Extract yaw (rotation around z-axis) from the full rotation matrices
-    # TODO check if this is inefficiency
-    def decompose_rotation_with_zaxis(rot_quat):
-        """Decompose a rotation quaternion into a z angle and a xy rotation. R = Rz * Rxy.
+    # (B,4)  quaternion.  ***Assumed layout = (w, x, y, z).***
+    # If your codebase stores (x,y,z,w) just swap the last two lines of the unbind.
+    q = robot_rotation_tensor(envstate, robot_name)
+    w, x, y, z = q.unbind(-1)
 
-        Args:
-            rot_quat: The rotation quaternion. Shape is (batch_size, 4).
+    # Closed-form yaw   (cf. Shoemake 1985)
+    # yaw = atan2( 2(w z + x y), 1 – 2(y² + z²) )
+    yaw = torch.atan2(2.0 * (w * z + x * y), 1.0 - 2.0 * (y * y + z * z))  # (B,)
 
-        Returns:
-            z_angle: The z angle. Shape is (batch_size,).
-        """
-        rot_matrix = matrix_from_quat(rot_quat)  # Compute rotation matrix
-        batch_size = rot_matrix.shape[0]
-        Rz_angle = torch.zeros(batch_size, device=rot_matrix.device)
-        for i in range(batch_size):
-            z_new = rot_matrix[i] @ torch.tensor(
-                [0.0, 0.0, 1.0], dtype=torch.float, device=rot_matrix.device
-            )  # Compute z-axis rotation direction
-            z_ori = torch.tensor(
-                [0.0, 0.0, 1.0], dtype=torch.float, device=rot_matrix.device
-            )  # z-axis original direction
-            theta_z = torch.arccos(
-                torch.dot(z_new, z_ori) / (torch.norm(z_new) * torch.norm(z_ori))
-            )  # Compute z-axis rotation angle
-            rot_axis_z = torch.cross(z_new, z_ori, dim=0) / torch.norm(
-                torch.cross(z_new, z_ori, dim=0)
-            )  # Compute z-axis rotation axis
-            Rz_quat = quat_mul(
-                quat_from_angle_axis(theta_z, rot_axis_z)[None, :], rot_quat[i][None, :]
-            )  # Compute z-axis rotation quaternion
-            Rz_rotvec = axis_angle_from_quat(Rz_quat)  # Compute z-axis rotation vector
-            # print(f"Rz_rotvec: {Rz_rotvec/torch.norm(Rz_rotvec, dim=-1)}")
-            # from metasim.utils.math import quat_inv
-            # Rz_quat_inv = quat_inv(Rz_quat)
-            # Rxy_quat = quat_mul(Rz_quat_inv, rot_quat)
-            # Rxy_rotvec = axis_angle_from_quat(Rxy_quat)
-            # print(f"Rxy_rotvec: {Rxy_rotvec/torch.norm(Rxy_rotvec, dim=-1)}")
-            # exit()
-            Rz_angle[i] = torch.norm(Rz_rotvec, dim=-1)  # Compute z-axis rotation angle
-        return Rz_angle
+    cos_y = torch.cos(yaw)
+    sin_y = torch.sin(yaw)
 
-    yaws = decompose_rotation_with_zaxis(world_rotation)
-    cos_z = torch.cos(yaws)
-    sin_z = torch.sin(yaws)
-    local_xy_velocity = torch.zeros((world_velocity.shape[0], 2), device=world_velocity.device)
-    local_xy_velocity[:, 0] = world_velocity[:, 0] * cos_z + world_velocity[:, 1] * sin_z
-    local_xy_velocity[:, 1] = -world_velocity[:, 0] * sin_z + world_velocity[:, 1] * cos_z
-    return local_xy_velocity
+    # Rotate world-frame XY into robot frame:
+    v_x_local = v_world[:, 0] * cos_y + v_world[:, 1] * sin_y
+    v_y_local = -v_world[:, 0] * sin_y + v_world[:, 1] * cos_y
+
+    return torch.stack((v_x_local, v_y_local), dim=-1)
 
 
 def default_dof_pos_tensor(envstates, robot_name: str):


### PR DESCRIPTION
Optimized `robot_local_velocity_tensor` by eliminating the for-loop and using torch tensor operations instead, removing this part of the bottleneck in RL training.
