### PR TITLE
fix/StandReward

### DIFF
--- a/metasim/cfg/tasks/humanoidbench/base_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/base_cfg.py
@@ -154,7 +154,7 @@ class BaseLocomotionReward(HumanoidBaseReward):
         stable_rewards = StableReward(self.robot_name)(states)
         if self._move_speed == 0:
             horizontal_velocity = robot_velocity_tensor(states, self.robot_name)[:, [0, 1]]
-            dont_move = humanoid_reward_util.tolerance_tensor(horizontal_velocity, margin=2).mean()
+            dont_move = humanoid_reward_util.tolerance_tensor(horizontal_velocity, margin=2).mean(dim=-1)
             moving_reward = dont_move
         else:
             com_x_velocity = robot_local_velocity_tensor(states, self.robot_name)[:, 0]


### PR DESCRIPTION
When we ported HumanoidBench to RoboVerse, the original code called .mean() without dim, assuming a single-env tensor.
With batched tensors the call now collapses both the (x,y) velocity axis and the num_env axis, causing every environment to share one “dont move” reward term.

The patch specifies mean(dim=-1) so we only average the two lateral velocity components while keeping the batch dimension intact.
Each environment now receives an independent reward signal.