### PR TITLE
fix mean(dim=-1)

### DIFF
--- a/metasim/cfg/tasks/humanoidbench/base_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/base_cfg.py
@@ -130,7 +130,7 @@ class StableReward(HumanoidBaseReward):
             margin=10,
             value_at_margin=0,
             sigmoid="quadratic",
-        ).mean()
+        ).mean(dim=-1)
         small_control = (4 + small_control) / 5
         ret_rewards = small_control * stand_reward
         return ret_rewards

--- a/metasim/cfg/tasks/humanoidbench/crawl_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/crawl_cfg.py
@@ -71,7 +71,7 @@ class CrawlReward(HumanoidBaseReward):
                 margin=10,
                 value_at_margin=0,
                 sigmoid="quadratic",
-            ).mean()
+            ).mean(dim=-1)
             small_control = (4 + small_control) / 5
 
             # R = tunnel × (0.1·e + 0.25·min(heightcrawl,heightIMU) + 0.25·orientation + 0.4·speed)

--- a/metasim/cfg/tasks/humanoidbench/sit_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/sit_cfg.py
@@ -81,7 +81,7 @@ class SitReward(HumanoidBaseReward):
                 margin=10,
                 value_at_margin=0,
                 sigmoid="quadratic",
-            ).mean()
+            ).mean(dim=-1)
             small_control = (4 + small_control) / 5
 
             # Calculate combined reward

--- a/metasim/cfg/tasks/humanoidbench/slide_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/slide_cfg.py
@@ -41,7 +41,7 @@ class SlideReward(HumanoidBaseReward):
                 margin=10,
                 value_at_margin=0,
                 sigmoid="quadratic",
-            ).mean()
+            ).mean(dim=-1)
             small_control = (4 + small_control) / 5
 
             # Reward for sliding motion - encourage horizontal velocity

--- a/metasim/cfg/tasks/humanoidbench/stair_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/stair_cfg.py
@@ -41,7 +41,7 @@ class StairReward(HumanoidBaseReward):
                 margin=10,
                 value_at_margin=0,
                 sigmoid="quadratic",
-            ).mean()
+            ).mean(dim=-1)
             small_control = (4 + small_control) / 5
 
             # Reward for sliding motion - encourage horizontal velocity


### PR DESCRIPTION
Same problem mentioned in PR#295
When we ported HumanoidBench to RoboVerse, the original code called .mean() without dim, assuming a single-env tensor.
With batched tensors the call now collapses both the (x,y) velocity axis and the num_env axis, causing every environment to share one “dont move” reward term.

The patch specifies mean(dim=-1) so we only average the two lateral velocity components while keeping the batch dimension intact.
Each environment now receives an independent reward signal.