### PR TITLE
[performance/isaacgym] tensorize set_state

### DIFF
--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -756,12 +756,15 @@ class IsaacgymHandler(BaseSimHandler):
             assert len(states) == self.num_envs, (
                 f"The length of the state list ({len(states)}) must match the length of num_envs ({self.num_envs})."
             )
-            # Prepare state data for specified env_ids
+
             pos_list = []
             rot_list = []
             q_list = []
             states_flat = [{**states[i]["objects"], **states[i]["robots"]} for i in env_ids]
+
+            # Prepare state data for specified env_ids
             env_indices = {env_id: i for i, env_id in enumerate(env_ids)}
+
             for i in range(self.num_envs):
                 if i not in env_indices:
                     continue

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -512,8 +512,12 @@ class IsaacgymHandler(BaseSimHandler):
             self.gym.viewer_camera_look_at(self.viewer, middle_env, cam_pos, cam_target)
         ################################
 
-    def _reorder_quat_xyzw_to_wxyz(self, state: torch.Tensor) -> torch.Tensor:
-        return state[..., [0, 1, 2, 6, 3, 4, 5, 7, 8, 9, 10, 11, 12]]
+    def _reorder_quat_xyzw_to_wxyz(self, state: torch.Tensor, reverse: bool = False) -> torch.Tensor:
+        return (
+            state[..., [0, 1, 2, 4, 5, 6, 3, 7, 8, 9, 10, 11, 12]]
+            if reverse
+            else state[..., [0, 1, 2, 6, 3, 4, 5, 7, 8, 9, 10, 11, 12]]
+        )
 
     def _get_states(self, env_ids: list[int] | None = None) -> list[EnvState]:
         if env_ids is None:
@@ -747,69 +751,108 @@ class IsaacgymHandler(BaseSimHandler):
         if env_ids is None:
             env_ids = list(range(self.num_envs))
 
-        assert len(states) == self.num_envs, (
-            f"The length of the state list ({len(states)}) must match the length of num_envs ({self.num_envs})."
-        )
+        # if states is list[EnvState], iterate over it and set state
+        if isinstance(states, list):
+            assert len(states) == self.num_envs, (
+                f"The length of the state list ({len(states)}) must match the length of num_envs ({self.num_envs})."
+            )
+            # Prepare state data for specified env_ids
+            pos_list = []
+            rot_list = []
+            q_list = []
+            states_flat = [{**states[i]["objects"], **states[i]["robots"]} for i in env_ids]
+            env_indices = {env_id: i for i, env_id in enumerate(env_ids)}
+            for i in range(self.num_envs):
+                if i not in env_indices:
+                    continue
 
-        pos_list = []
-        rot_list = []
-        q_list = []
-        states_flat = [{**states[i]["objects"], **states[i]["robots"]} for i in env_ids]
+                state_idx = env_indices[i]
+                state = states_flat[state_idx]
 
-        # Prepare state data for specified env_ids
-        env_indices = {env_id: i for i, env_id in enumerate(env_ids)}
+                pos_list_i = []
+                rot_list_i = []
+                q_list_i = []
+                for obj in self.objects:
+                    obj_name = obj.name
+                    pos = np.array(state[obj_name].get("pos", [0.0, 0.0, 0.0]))
+                    rot = np.array(state[obj_name].get("rot", [1.0, 0.0, 0.0, 0.0]))
+                    obj_quat = [rot[1], rot[2], rot[3], rot[0]]  # IsaacGym convention
 
-        for i in range(self.num_envs):
-            if i not in env_indices:
-                continue
+                    pos_list_i.append(pos)
+                    rot_list_i.append(obj_quat)
+                    if isinstance(obj, ArticulationObjCfg):
+                        obj_joint_q = np.zeros(len(self._articulated_joint_dict_dict[obj_name]))
+                        articulated_joint_dict = self._articulated_joint_dict_dict[obj_name]
+                        for joint_name, joint_idx in articulated_joint_dict.items():
+                            if "dof_pos" in state[obj_name]:
+                                obj_joint_q[joint_idx] = state[obj_name]["dof_pos"][joint_name]
+                            else:
+                                log.warning(f"No dof_pos for {joint_name} in {obj_name}")
+                                obj_joint_q[joint_idx] = 0.0
+                        q_list_i.append(obj_joint_q)
 
-            state_idx = env_indices[i]
-            state = states_flat[state_idx]
+                pos_list_i.append(np.array(state[self.robot.name].get("pos", [0.0, 0.0, 0.0])))
+                rot = np.array(state[self.robot.name].get("rot", [1.0, 0.0, 0.0, 0.0]))
+                robot_quat = [rot[1], rot[2], rot[3], rot[0]]
+                rot_list_i.append(robot_quat)
 
-            pos_list_i = []
-            rot_list_i = []
-            q_list_i = []
-            for obj in self.objects:
-                obj_name = obj.name
-                pos = np.array(state[obj_name].get("pos", [0.0, 0.0, 0.0]))
-                rot = np.array(state[obj_name].get("rot", [1.0, 0.0, 0.0, 0.0]))
-                obj_quat = [rot[1], rot[2], rot[3], rot[0]]  # IsaacGym convention
+                robot_dof_state_i = np.zeros(len(self._robot_joint_dict))
+                if "dof_pos" in state[self.robot.name]:
+                    for joint_name, joint_idx in self._robot_joint_dict.items():
+                        robot_dof_state_i[joint_idx] = state[self.robot.name]["dof_pos"][joint_name]
+                else:
+                    for joint_name, joint_idx in self._robot_joint_dict.items():
+                        robot_dof_state_i[joint_idx] = (
+                            self.robot.joint_limits[joint_name][0] + self.robot.joint_limits[joint_name][1]
+                        ) / 2
 
-                pos_list_i.append(pos)
-                rot_list_i.append(obj_quat)
+                q_list_i.append(robot_dof_state_i)
+                pos_list.append(pos_list_i)
+                rot_list.append(rot_list_i)
+                q_list.append(q_list_i)
+
+            self._set_actor_root_state(pos_list, rot_list, env_ids)
+            self._set_actor_joint_state(q_list, env_ids)
+
+        # if states is TensorState, reindex the tensors and set state
+        elif isinstance(states, TensorState):
+            new_root_states = self._root_states.view(self.num_envs, -1, 13)
+            new_dof_states = self._dof_states.view(self.num_envs, -1, 2)
+            for idx, obj in enumerate(self.objects):
+                obj_state = states.objects[obj.name]
+                roo_state = self._reorder_quat_xyzw_to_wxyz(obj_state.root_state, reverse=True)
+                new_root_states[env_ids, idx, :] = roo_state[env_ids, :]
                 if isinstance(obj, ArticulationObjCfg):
-                    obj_joint_q = np.zeros(len(self._articulated_joint_dict_dict[obj_name]))
-                    articulated_joint_dict = self._articulated_joint_dict_dict[obj_name]
-                    for joint_name, joint_idx in articulated_joint_dict.items():
-                        if "dof_pos" in state[obj_name]:
-                            obj_joint_q[joint_idx] = state[obj_name]["dof_pos"][joint_name]
-                        else:
-                            log.warning(f"No dof_pos for {joint_name} in {obj_name}")
-                            obj_joint_q[joint_idx] = 0.0
-                    q_list_i.append(obj_joint_q)
+                    joint_pos = obj_state.joint_pos
+                    joint_vel = obj_state.joint_vel
+                    joint_ids_reindex = self.get_joint_reindex(obj.name, inverse=True)
+                    new_dof_states[env_ids, :, 0] = joint_pos[env_ids, :][:, joint_ids_reindex]
+                    new_dof_states[env_ids, :, 1] = joint_vel[env_ids, :][:, joint_ids_reindex]
+            for idx, robot in enumerate(self.robots):
+                robot_state = states.robots[robot.name]
+                root_state = self._reorder_quat_xyzw_to_wxyz(robot_state.root_state, reverse=True)
+                new_root_states[env_ids, len(self.objects) + idx, :] = root_state[env_ids, :]
+                joint_pos = robot_state.joint_pos
+                joint_vel = robot_state.joint_vel
+                joint_ids_reindex = self.get_joint_reindex(robot.name, inverse=True)
+                new_dof_states[env_ids, :, 0] = joint_pos[env_ids, :][:, joint_ids_reindex]
+                new_dof_states[env_ids, :, 1] = joint_vel[env_ids, :][:, joint_ids_reindex]
 
-            pos_list_i.append(np.array(state[self.robot.name].get("pos", [0.0, 0.0, 0.0])))
-            rot = np.array(state[self.robot.name].get("rot", [1.0, 0.0, 0.0, 0.0]))
-            robot_quat = [rot[1], rot[2], rot[3], rot[0]]
-            rot_list_i.append(robot_quat)
-
-            robot_dof_state_i = np.zeros(len(self._robot_joint_dict))
-            if "dof_pos" in state[self.robot.name]:
-                for joint_name, joint_idx in self._robot_joint_dict.items():
-                    robot_dof_state_i[joint_idx] = state[self.robot.name]["dof_pos"][joint_name]
-            else:
-                for joint_name, joint_idx in self._robot_joint_dict.items():
-                    robot_dof_state_i[joint_idx] = (
-                        self.robot.joint_limits[joint_name][0] + self.robot.joint_limits[joint_name][1]
-                    ) / 2
-
-            q_list_i.append(robot_dof_state_i)
-            pos_list.append(pos_list_i)
-            rot_list.append(rot_list_i)
-            q_list.append(q_list_i)
-
-        self._set_actor_root_state(pos_list, rot_list, env_ids)
-        self._set_actor_joint_state(q_list, env_ids)
+            env_ids_int32_tensor = torch.tensor(env_ids, dtype=torch.int32, device=self.device)
+            self.gym.set_actor_root_state_tensor_indexed(
+                self.sim,
+                gymtorch.unwrap_tensor(new_root_states),
+                gymtorch.unwrap_tensor(env_ids_int32_tensor),
+                len(env_ids),
+            )
+            self.gym.set_dof_state_tensor_indexed(
+                self.sim,
+                gymtorch.unwrap_tensor(new_dof_states),
+                gymtorch.unwrap_tensor(env_ids_int32_tensor),
+                len(env_ids),
+            )
+        else:
+            raise Exception("Unsupported state type, must be EnvState or TensorState")
 
         # Refresh tensors
         self.gym.refresh_rigid_body_state_tensor(self.sim)

--- a/roboverse_learn/rl/rsl_rl/rsl_rl_wrapper.py
+++ b/roboverse_learn/rl/rsl_rl/rsl_rl_wrapper.py
@@ -11,7 +11,7 @@ from metasim.constants import SimType
 from metasim.sim.env_wrapper import EnvWrapper
 from metasim.utils.demo_util import get_traj
 from metasim.utils.setup_util import get_sim_env_class
-
+from metasim.utils.state import list_state_to_tensor
 
 class RslRlWrapper(VecEnv):
     """
@@ -54,14 +54,18 @@ class RslRlWrapper(VecEnv):
         self.train_cfg = rsl_rl_class_to_dict(scenario.task.ppo_cfg)
 
     def _get_init_states(self, scenario):
-        self.init_states, _, _ = get_traj(scenario.task, scenario.robot, self.env.handler)
-        if len(self.init_states) < self.num_envs:
-            self.init_states = (
-                self.init_states * (self.num_envs // len(self.init_states))
-                + self.init_states[: self.num_envs % len(self.init_states)]
+        """"""
+        init_states_list, _, _ = get_traj(scenario.task, scenario.robots[0], self.env.handler)
+        if len(init_states_list) < self.num_envs:
+            init_states_list = (
+                init_states_list * (self.num_envs // len(init_states_list))
+                + init_states_list[: self.num_envs % len(init_states_list)]
             )
         else:
-            self.init_states = self.init_states[: self.num_envs]
+            init_states_list = init_states_list[: self.num_envs]
+        #tensorize the initial states as TensorState
+        self.init_states = list_state_to_tensor(self.env.handler, init_states_list, device=self.device)
+
 
     def get_observations(self):
         """design from config"""

--- a/roboverse_learn/skillblender_rl/env_wrappers/base/humanoid_base_wrapper.py
+++ b/roboverse_learn/skillblender_rl/env_wrappers/base/humanoid_base_wrapper.py
@@ -19,7 +19,6 @@ except ImportError:
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.tasks.skillblender.base_legged_cfg import BaseLeggedTaskCfg
-from metasim.utils.demo_util import get_traj
 from metasim.utils.humanoid_robot_util import *
 from roboverse_learn.rl.rsl_rl.rsl_rl_wrapper import RslRlWrapper
 
@@ -77,17 +76,6 @@ class HumanoidBaseWrapper(RslRlWrapper):
         super()._parse_cfg(scenario)
         self.dt = scenario.decimation * scenario.sim_params.dt
         self.num_commands = scenario.task.command_dim
-
-    def _get_init_states(self, scenario):
-        """Get initial states from handler."""
-        self.init_states, _, _ = get_traj(scenario.task, scenario.robots[0], self.env.handler)
-        if len(self.init_states) < self.num_envs:
-            self.init_states = (
-                self.init_states * (self.num_envs // len(self.init_states))
-                + self.init_states[: self.num_envs % len(self.init_states)]
-            )
-        else:
-            self.init_states = self.init_states[: self.num_envs]
 
     def _get_cfg_from_handler(self):
         """


### PR DESCRIPTION
To increase training fps, add option to used tensorized `init_state` for `set_state` in isaacgym. which increases the fps of training to be consistent with the original repo. Test with
```
 python3 roboverse_learn/skillblender_rl/train_skillblender.py --task "skillblender:Reaching" --sim "isaacgym" --num_envs 1024 --robot "h1_wrist"  
```
Here is the FPS comparision:
![image](https://github.com/user-attachments/assets/62042277-205b-499e-bf4c-cecce9fbd420)

Test on ubuntu 22.04 Docker Container, 4080 super, Intel(R) Core(TM) i7-14700KF
