### PR TITLE
Feat/Add h1 body

### DIFF
--- a/metasim/cfg/robots/h1_body_collision.py
+++ b/metasim/cfg/robots/h1_body_collision.py
@@ -6,7 +6,16 @@ from .h1_cfg import H1Cfg
 
 
 @configclass
-class H1Cfg(H1Cfg):
+class H1_Body_Collision_Cfg(H1Cfg):
+    # This configuration enables the full-body collision model for the H1 humanoid robot.
+    # 1. The corresponding MJCF model includes collision geoms for the entire body,
+    #    with simplified shapes to reduce simulation cost. However, it is still
+    #    significantly more computationally expensive than the default "feet-only" version,
+    #    especially under the MJX backend.
+    # 2. This configuration is necessary for certain tasks in HumanoidBench (e.g., "sit", "crawl")
+    #    that involve meaningful contact between limbs or torso and the environment.
+    #    Without enabling full-body collisions, such behaviors may become physically invalid
+    #    or lead to unstable simulation artifacts.
     name: str = "h1_body_collision"
     mjx_mjcf_path: str = "roboverse_data/robots/h1/mjcf/mjx_h1_body.xml"
 

--- a/metasim/cfg/robots/h1_body_collision.py
+++ b/metasim/cfg/robots/h1_body_collision.py
@@ -18,5 +18,3 @@ class H1_Body_Collision_Cfg(H1Cfg):
     #    or lead to unstable simulation artifacts.
     name: str = "h1_body_collision"
     mjx_mjcf_path: str = "roboverse_data/robots/h1/mjcf/mjx_h1_body.xml"
-
-    

--- a/metasim/cfg/robots/h1_body_collision.py
+++ b/metasim/cfg/robots/h1_body_collision.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from metasim.utils import configclass
+
+from .h1_cfg import H1Cfg
+
+
+@configclass
+class H1Cfg(H1Cfg):
+    name: str = "h1_body_collision"
+    mjx_mjcf_path: str = "roboverse_data/robots/h1/mjcf/mjx_h1_body.xml"
+
+    

--- a/metasim/cfg/tasks/humanoidbench/base_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/base_cfg.py
@@ -85,7 +85,7 @@ class HumanoidBaseReward:
     def __init__(self, robot_name="h1"):
         """Initialize the humanoid reward."""
         self.robot_name = robot_name
-        if robot_name == "h1" or robot_name == "h1_simple_hand" or robot_name == "h1_hand":
+        if robot_name == "h1" or robot_name == "h1_simple_hand" or robot_name == "h1_hand" or robot_name == "h1_body_collision":
             self._stand_height = H1_STAND_HEAD_HEIGHT
             self._stand_neck_height = H1_STAND_NECK_HEIGHT
             self._crawl_height = H1_CRAWL_HEAD_HEIGHT

--- a/metasim/cfg/tasks/humanoidbench/base_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/base_cfg.py
@@ -85,7 +85,12 @@ class HumanoidBaseReward:
     def __init__(self, robot_name="h1"):
         """Initialize the humanoid reward."""
         self.robot_name = robot_name
-        if robot_name == "h1" or robot_name == "h1_simple_hand" or robot_name == "h1_hand" or robot_name == "h1_body_collision":
+        if (
+            robot_name == "h1"
+            or robot_name == "h1_simple_hand"
+            or robot_name == "h1_hand"
+            or robot_name == "h1_body_collision"
+        ):
             self._stand_height = H1_STAND_HEAD_HEIGHT
             self._stand_neck_height = H1_STAND_NECK_HEIGHT
             self._crawl_height = H1_CRAWL_HEAD_HEIGHT
@@ -134,6 +139,7 @@ class StableReward(HumanoidBaseReward):
         small_control = (4 + small_control) / 5
         ret_rewards = small_control * stand_reward
         return ret_rewards
+
 
 class BaseLocomotionReward(HumanoidBaseReward):
     """Base class for locomotion rewards."""

--- a/metasim/cfg/tasks/humanoidbench/base_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/base_cfg.py
@@ -135,7 +135,6 @@ class StableReward(HumanoidBaseReward):
         ret_rewards = small_control * stand_reward
         return ret_rewards
 
-
 class BaseLocomotionReward(HumanoidBaseReward):
     """Base class for locomotion rewards."""
 


### PR DESCRIPTION
This configuration enables the full-body collision model for the H1 humanoid robot.
1. The corresponding MJCF model includes collision geoms for the entire body,
with simplified shapes to reduce simulation cost. However, it is still
significantly more computationally expensive than the default "feet-only" version,
especially under the MJX backend.
2. This configuration is necessary for certain tasks in HumanoidBench (e.g., "sit", "crawl")
that involve contact between limbs or torso and the environment.
