### PR TITLE
[fix] isaacgym video all black in headless mode

### DIFF
--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -689,6 +689,10 @@ class IsaacgymHandler(BaseSimHandler):
         for _ in range(self.scenario.decimation):
             self._simulate_one_physics_step(self.actions)
 
+        if self.headless:
+            self.gym.step_graphics(self.sim)
+            self.gym.render_all_camera_sensors(self.sim)
+
         # Refresh tensors
         if not self._manual_pd_on:
             self.gym.refresh_dof_state_tensor(self.sim)


### PR DESCRIPTION
In headless mode, the camera tensors were not being updated every simulate() step, resulting in all black visualizations. Now, users should see get_started/0_static_scene.py and get_started/3_parallel_envs.py  produce an image and video respectively.