### PR TITLE
[fix]: mujoco handler fix headless offscreen size error

### DIFF
--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -121,6 +121,18 @@ class MujocoHandler(BaseSimHandler):
 
         self._robot_default_dof_pos = np.array(default_dof_pos)
 
+    def _set_framebuffer_size(self, mjcf_model, width, height):
+        visual_elem = mjcf_model.visual
+        global_elem = None
+        for child in visual_elem._children:
+            if child.tag == "global":
+                global_elem = child
+                break
+        if global_elem is None:
+            global_elem = visual_elem.add("global")
+        global_elem.offwidth = width
+        global_elem.offheight = height
+
     def _create_primitive_xml(self, obj):
         if isinstance(obj, PrimitiveCubeCfg):
             size_str = f"{obj.half_size[0]} {obj.half_size[1]} {obj.half_size[2]}"
@@ -174,11 +186,13 @@ class MujocoHandler(BaseSimHandler):
                 "mode": "fixed",
                 "fovy": camera.vertical_fov,
                 "xyaxes": f"{right[0]} {right[1]} {right[2]} {up[0]} {up[1]} {up[2]}",
-                "resolution": f"{camera.width} {camera.height}",
             }
             mjcf_model.worldbody.add("camera", name=f"{camera.name}_custom", **camera_params)
             camera_max_width = max(camera_max_width, camera.width)
             camera_max_height = max(camera_max_height, camera.height)
+
+        if camera_max_width > 640 or camera_max_height > 480:
+            self._set_framebuffer_size(mjcf_model, camera_max_width, camera_max_height)
 
         if self.scenario.try_add_table:
             mjcf_model.asset.add(


### PR DESCRIPTION
title: all get-started script wasn't running on clusters due to an offscreen size error