### PR TITLE
[fix] skillblender cross-embodiment action_dim assignment

### DIFF
--- a/metasim/cfg/tasks/skillblender/base_humanoid_cfg.py
+++ b/metasim/cfg/tasks/skillblender/base_humanoid_cfg.py
@@ -117,4 +117,7 @@ class BaseHumanoidCfg(BaseLeggedTaskCfg):
     ]
 
     def __post_init__(self):
-        self.num_actions = self.robots[0].num_joints
+        super().__post_init__()
+        # set the number of actions based on the robot's joints if available
+        if self.robots is not None:
+            self.num_actions = self.robots[0].num_joints

--- a/roboverse_learn/rl/rsl_rl/rsl_rl/modules/actor_critic_hierarchical.py
+++ b/roboverse_learn/rl/rsl_rl/rsl_rl/modules/actor_critic_hierarchical.py
@@ -113,7 +113,7 @@ class ActorCriticHierarchical(nn.Module):
         [torch.nn.init.orthogonal_(module.weight, gain=scales[idx]) for idx, module in
          enumerate(mod for mod in sequential if isinstance(mod, nn.Linear))]
 
-    def _get_one_policy(self, args, device, task, experiment_name, load_run, checkpoint):
+    def _get_one_policy(self, args, num_actions, device, task, experiment_name, load_run, checkpoint):
         from rsl_rl.modules import ActorCritic
         from roboverse_learn.rl.rsl_rl.rsl_rl.utils import get_load_path
         # get skill arguments
@@ -124,7 +124,7 @@ class ActorCriticHierarchical(nn.Module):
         skill_args.load_run = load_run
         skill_args.checkpoint = checkpoint
         # retrieve config snapshot
-        skill_env_cfg, skill_train_cfg = get_cfgs(name=skill_args.task, load_run=skill_args.load_run, experiment_name=skill_args.experiment_name)
+        skill_env_cfg, skill_train_cfg = get_cfgs(name=skill_args.task, load_run=skill_args.load_run, experiment_name=skill_args.experiment_name, num_actions=num_actions)
         # load skill policy
         from metasim.utils.dict import class_to_dict
         skill_policy = ActorCritic(
@@ -157,7 +157,7 @@ class ActorCriticHierarchical(nn.Module):
         self.train_cfg_list = []
         self.low_high_list = []
         for key, value in skill_dict.items():
-            policy, env_cfg, train_cfg = self._get_one_policy(args, device, key, value['experiment_name'], value['load_run'], value['checkpoint'])
+            policy, env_cfg, train_cfg = self._get_one_policy(args, kwargs['num_dofs'], device, key, value['experiment_name'], value['load_run'], value['checkpoint'])
             self.policy_list.append(policy)
             self.env_cfg_list.append(env_cfg)
             self.train_cfg_list.append(train_cfg)

--- a/roboverse_learn/rl/rsl_rl/rsl_rl/runners/on_policy_runner.py
+++ b/roboverse_learn/rl/rsl_rl/rsl_rl/runners/on_policy_runner.py
@@ -69,6 +69,7 @@ class OnPolicyRunner:
             obs_context_len = self.env.obs_context_len
         else:
             obs_context_len = 1
+        args = kwargs['args']
         actor_critic = actor_critic_class(
             self.env.num_obs,
             num_critic_obs,
@@ -76,6 +77,7 @@ class OnPolicyRunner:
             obs_context_len=obs_context_len,
             **self.policy_cfg,
             device=self.device,
+            args=args,
         ).to(self.device)
         alg_class = eval(self.cfg["algorithm_class_name"])  # PPO
         self.alg = alg_class(actor_critic, device=self.device, **self.alg_cfg)

--- a/roboverse_learn/rl/rsl_rl/rsl_rl/utils/utils.py
+++ b/roboverse_learn/rl/rsl_rl/rsl_rl/utils/utils.py
@@ -101,7 +101,7 @@ def get_load_path(root, load_run=-1, checkpoint=-1):
     load_path = os.path.join(load_run, model)
     return load_path
 
-def retrieve_cfgs(load_run, experiment_name):
+def retrieve_cfgs(load_run, experiment_name,num_actions):
     """
     Retrieve the config files from the checkpoint directory"""
     from runpy import run_path
@@ -123,11 +123,12 @@ def retrieve_cfgs(load_run, experiment_name):
                 cfg = cfgs[key]() #Instantiate the metasim class configclass
                 if hasattr(cfg, 'task_name'):
                     env_cfg = cfg
+                    env_cfg.num_actions = num_actions
     return env_cfg, train_cfg()
 
-def get_cfgs(name, load_run=None, experiment_name=None):
+def get_cfgs(name, load_run=None, experiment_name=None, num_actions=None):
     if load_run is None and experiment_name is None:
         raise ValueError('Either load_run or experiment_name must be provided')
-    env_cfg, train_cfg = retrieve_cfgs(load_run, experiment_name)
+    env_cfg, train_cfg = retrieve_cfgs(load_run, experiment_name,num_actions )
     env_cfg.seed = train_cfg.seed
     return env_cfg, train_cfg

--- a/roboverse_learn/skillblender_rl/train.py
+++ b/roboverse_learn/skillblender_rl/train.py
@@ -57,6 +57,7 @@ def train(args):
         device=device,
         log_dir=log_dir,
         wandb=use_wandb,
+        args=args,
     )
     ppo_runner.learn(num_learning_iterations=args.learning_iterations)
 


### PR DESCRIPTION
allow all task to get `num_actions` based on robot's `num_dof`, simplified config for cross-embodiment, test with
```
python3 roboverse_learn/skillblender_rl/train.py --task "skillblender:Walking" --sim "isaacgym" --num_envs 1024 --robot "h1_wrist" --use_wandb
```