### PR TITLE
[feat]get_extras query (NOT FINISHED)

### DIFF
--- a/metasim/cfg/query_type.py
+++ b/metasim/cfg/query_type.py
@@ -1,0 +1,12 @@
+from dataclasses import dataclass
+
+@dataclass
+class SitePos:
+    """Return world‑frame (x, y, z) position of a given site."""
+    site: str
+
+
+@dataclass
+class ContactForce:
+    """Return 6‑D contact force/torque measured by a named sensor."""
+    sensor_name: str

--- a/metasim/cfg/tasks/humanoidbench/crawl_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/crawl_cfg.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import torch
-
+from metasim.cfg.query import SitePos
 from metasim.cfg.checkers import _CrawlChecker
 from metasim.cfg.objects import RigidObjCfg
+from metasim.cfg.query_type import SitePos, ContactForce
 from metasim.constants import PhysicStateType
 from metasim.utils import configclass
 from metasim.utils.humanoid_reward_util import tolerance_tensor
@@ -101,3 +102,9 @@ class CrawlCfg(HumanoidTaskCfg):
     checker = _CrawlChecker()
     reward_weights = [1.0]
     reward_functions = [CrawlReward]
+    def extra_obs_spec(self):
+        """Declare extra observations needed by CrawlReward."""
+        return {
+            "imu_pos": SitePos(f"{self.robot_name}/imu"),
+            "head_pos": SitePos(f"{self.robot_name}/head"),
+        }

--- a/metasim/sim/mjx/mjx.py
+++ b/metasim/sim/mjx/mjx.py
@@ -31,7 +31,6 @@ from metasim.types import Action
 from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
 
 from .mjx_helper import (
-    get_extras,
     j2t,
     pack_body_state,
     pack_root_state,
@@ -41,7 +40,7 @@ from .mjx_helper import (
     sorted_joint_info,
     t2j,
 )
-
+from .mjx_querier import MJXQuerier
 
 class MJXHandler(BaseSimHandler):
     def __init__(self, scenario: ScenarioCfg, *, seed: int | None = None):
@@ -204,8 +203,11 @@ class MJXHandler(BaseSimHandler):
             # Convert JAX → PyTorch; result shape (batch, dim)
             sensors[name] = j2t(sens_batch[:, sl])
 
-        extras = get_extras(self._data, self._mj_model, env_ids)
-        return TensorState(objects=objects, robots=robots, cameras=camera_states, sensors=sensors, extras=extras)
+        return TensorState(objects=objects, robots=robots, cameras=camera_states, sensors=sensors)
+
+
+    def get_extra(self, spec):
+        return {k: MJXQuerier.query(v, self) for k, v in spec.items()}
 
     def _set_states(
         self,

--- a/metasim/sim/mjx/mjx_helper.py
+++ b/metasim/sim/mjx/mjx_helper.py
@@ -181,7 +181,8 @@ def process_entity(
     return qpos, qvel, ctrl
 
 
-_KIND_META = {  # (size-field, adr-field) for each name-pool category
+_KIND_META = {
+    # (size-field, adr-field) for each name-pool category
     "joint": ("njnt", "name_jntadr"),
     "actuator": ("nu", "name_actuatoradr"),
     "body": ("nbody", "name_bodyadr"),

--- a/metasim/sim/mjx/mjx_querier.py
+++ b/metasim/sim/mjx/mjx_querier.py
@@ -1,0 +1,64 @@
+# mjx_query_helper.py
+import mujoco, functools
+import jax.numpy as jnp
+from metasim.cfg.query_type import SitePos, ContactForce
+import jax
+
+class MJXQuerier:
+    """
+    Add new Query types by inserting into QUERY_MAP.
+    """
+    _site_cache = {}
+    _body_cache = {}
+
+    QUERY_MAP = {
+        SitePos:        "site_pos",
+        ContactForce:   "contact_force",
+        # add here
+    }
+
+    # public entry ------------------------------------------------------------
+    @classmethod
+    def query(cls, q, handler):
+        fn_name = cls.QUERY_MAP[type(q)]
+        return getattr(cls, f"_{fn_name}")(q, handler)
+
+    # query func collection ---------------------------------------------------
+    @classmethod
+    def _site_pos(cls, q: SitePos, handler):
+        """Return (N_env, 3) site position."""
+        key = id(handler._mj_model)
+        cache = cls._site_cache.setdefault(key, {})
+        if not cache:
+            cache.update(
+                {
+                    mujoco.mj_id2name(handler._mj_model, mujoco.mjtObj.mjOBJ_SITE, i): i
+                    for i in range(handler._mj_model.nsite)
+                    if mujoco.mj_id2name(handler._mj_model, mujoco.mjtObj.mjOBJ_SITE, i)
+                }
+            )
+        sid = cache[q.site]
+        return handler._data.site_xpos[:, sid]
+
+    @classmethod
+    def _contact_force(cls, q: ContactForce, handler):
+        """Return (N_env, 6) force‑torque of one body."""
+        key = id(handler._mj_model)
+        cache = cls._body_cache.setdefault(key, {})
+        if not cache:
+            cache.update(
+                {
+                    mujoco.mj_id2name(handler._mj_model, mujoco.mjtObj.mjOBJ_BODY, i): i
+                    for i in range(handler._mj_model.nbody)
+                    if mujoco.mj_id2name(handler._mj_model, mujoco.mjtObj.mjOBJ_BODY, i)
+                }
+            )
+        bid = cache[q.sensor_name]
+
+        contact_force = handler._data.cfrc_ext[:, jnp.asarray([bid], jnp.int32)]
+        return contact_force[:, 0, :]                         # (N_env, 6)
+
+# -----------------------------------------------------------------------------
+# usage in handler
+# -----------------------------------------------------------------------------
+# value = MJXQuerier.query(query_obj, handler)

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -20,7 +20,7 @@ from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.sim.parallel import ParallelSimWrapper
 from metasim.types import Action
 from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
-
+from .mujoco_querier import MujocoQuerier
 
 class MujocoHandler(BaseSimHandler):
     def __init__(self, scenario: ScenarioCfg):
@@ -467,6 +467,9 @@ class MujocoHandler(BaseSimHandler):
             self._set_root_state(obj_name, obj_state, zero_vel)
             self._set_joint_state(obj_name, obj_state, zero_vel)
         self.physics.forward()
+
+    def get_extra(self, spec):
+        return {k: MujocoQuerier.query(v, self) for k, v in spec.items()}
 
     def _disable_robotgravity(self):
         gravity_vec = np.array([0.0, 0.0, -9.81])

--- a/metasim/sim/mujoco/mujoco_querier.py
+++ b/metasim/sim/mujoco/mujoco_querier.py
@@ -1,0 +1,64 @@
+# mjx_query_helper.py
+import mujoco, functools
+import jax.numpy as jnp
+from metasim.cfg.query_type import SitePos, ContactForce
+import jax
+
+class MujocoQuerier:
+    """
+    Add new Query types by inserting into QUERY_MAP.
+    """
+    _site_cache = {}
+    _body_cache = {}
+
+    QUERY_MAP = {
+        SitePos:        "site_pos",
+        ContactForce:   "contact_force",
+        # add here
+    }
+
+    # public entry ------------------------------------------------------------
+    @classmethod
+    def query(cls, q, handler):
+        fn_name = cls.QUERY_MAP[type(q)]
+        return getattr(cls, f"_{fn_name}")(q, handler)
+
+    # query func collection ------------------------------------------------------------
+    @classmethod
+    def _site_pos(cls, q: SitePos, handler):
+        """Return (N_env, 3) site position."""
+        key = id(handler._mj_model)
+        cache = cls._site_cache.setdefault(key, {})
+        if not cache:
+            cache.update(
+                {
+                    mujoco.mj_id2name(handler._mj_model, mujoco.mjtObj.mjOBJ_SITE, i): i
+                    for i in range(handler._mj_model.nsite)
+                    if mujoco.mj_id2name(handler._mj_model, mujoco.mjtObj.mjOBJ_SITE, i)
+                }
+            )
+        sid = cache[q.site]
+        return handler._data.site_xpos[:, sid]
+
+    @classmethod
+    def _contact_force(cls, q: ContactForce, handler):
+        """Return (N_env, 6) force‑torque of one body."""
+        key = id(handler._mj_model)
+        cache = cls._body_cache.setdefault(key, {})
+        if not cache:
+            cache.update(
+                {
+                    mujoco.mj_id2name(handler._mj_model, mujoco.mjtObj.mjOBJ_BODY, i): i
+                    for i in range(handler._mj_model.nbody)
+                    if mujoco.mj_id2name(handler._mj_model, mujoco.mjtObj.mjOBJ_BODY, i)
+                }
+            )
+        bid = cache[q.sensor_name]
+
+        contact_force = handler._data.cfrc_ext[:, jnp.asarray([bid], jnp.int32)]
+        return contact_force[:, 0, :]                         # (N_env, 6)
+
+# -----------------------------------------------------------------------------
+# usage in handler
+# -----------------------------------------------------------------------------
+# value = MujocoQuerier.query(query_obj, handler)


### PR DESCRIPTION
The base state is still returned by get_states(). Extra observations are now defined in each task through extra_obs_spec(), where each entry is a query object like SitePos(["h1/imu"]) or ContactForce(["h1/foot_left"]). A class called Querier handles these query objects and returns the requested data from the simulator. Each query type maps to a fixed function that extracts the corresponding quantity. This query system is only used inside the roboverse/learn training wrapper and does not change any existing behavior.