### PR TITLE
fix bug: collect_demo example script in docs

### DIFF
--- a/docs/source/metasim/user_guide/collect_demo_tutorial.md
+++ b/docs/source/metasim/user_guide/collect_demo_tutorial.md
@@ -21,7 +21,7 @@ python collect_demo.py \
   --robot franka \
   --sim isaaclab \
   --num_envs 2 \
-  --headless True \
+  --headless \
   --run_unfinished
 ```
 


### PR DESCRIPTION
The guide documents how to use the `collect_demo.py` script to collect demonstrations in METASIM-based environments.

# Description

This pull request adds the initial version of the user guide under `docs/source/metasim/user_guide/collect_demo_tutorial.md`.

# Fixes:

From:
```bash
python collect_demo.py \
  --task pick_cube \
  --robot franka \
  --sim isaaclab \
  --num_envs 2 \
  --headless True \
  --run_unfinished
```

To:
```bash
python collect_demo.py \
  --task pick_cube \
  --robot franka \
  --sim isaaclab \
  --num_envs 2 \
  --headless \
  --run_unfinished
``` 
