### PR TITLE
fix bug: collect_demo example script in docs

### DIFF
--- a/docs/source/metasim/user_guide/collect_demo_tutorial.md
+++ b/docs/source/metasim/user_guide/collect_demo_tutorial.md
@@ -21,7 +21,7 @@ python collect_demo.py \
   --robot franka \
   --sim isaaclab \
   --num_envs 2 \
-  --headless True \
+  --headless \
   --run_unfinished
 ```
 


### PR DESCRIPTION
The guide documents how to use the `collect_demo.py` script to collect demonstrations in METASIM-based environments.

# Fixes

A minor correction is also made in the example command:  
The `--headless` flag no longer requires a value (`True`), as it is a boolean flag.

### Before:
```bash
python collect_demo.py \
  --task pick_cube \
  --robot franka \
  --sim isaaclab \
  --num_envs 2 \
  --headless True \
  --run_unfinished
```

### After:
```bash
python collect_demo.py \
  --task pick_cube \
  --robot franka \
  --sim isaaclab \
  --num_envs 2 \
  --headless \
  --run_unfinished
```
