### PR TITLE
Adds methods in XrClient for hand, body, and motion tracker tracking

### DIFF
--- a/metasim/utils/teleop_utils.py
+++ b/metasim/utils/teleop_utils.py
@@ -432,6 +432,77 @@ class XrClient:
         """Returns the current timestamp in nanoseconds (int)."""
         return xrt.get_time_stamp_ns()
 
+    def get_hand_tracking_state(self, hand: str) -> np.ndarray | None:
+        """Returns the hand tracking state for the specified hand.
+        Valid hands: "left", "right".
+        State is a 27 x 7 numpy array, where each row is [x, y, z, qx, qy, qz, qw] for each joint.
+        Returns None if hand tracking is inactive (low quality).
+        """
+        if hand.lower() == "left":
+            if not xrt.get_left_hand_is_active():
+                return None
+            return xrt.get_left_hand_tracking_state()
+        elif hand.lower() == "right":
+            if not xrt.get_right_hand_is_active():
+                return None
+            return xrt.get_right_hand_tracking_state()
+        else:
+            raise ValueError(f"Invalid hand: {hand}. Valid hands are: 'left', 'right'.")
+
+    def get_joystick_state(self, controller: str) -> list[float]:
+        """Returns the joystick state for the specified controller.
+        Valid controllers: "left", "right".
+        State is a list with shape (2) representing [x, y] for each joystick.
+        """
+        if controller.lower() == "left":
+            return xrt.get_left_axis()
+        elif controller.lower() == "right":
+            return xrt.get_right_axis()
+        else:
+            raise ValueError(f"Invalid controller: {controller}. Valid controllers are: 'left', 'right'.")
+
+    def get_motion_tracker_data(self) -> dict:
+        """Returns a dictionary of motion tracker data, where the keys are the tracker serial numbers.
+        Each value is a dictionary containing the pose, velocity, and acceleration of the tracker.
+        """
+        num_motion_data = xrt.num_motion_data_available()
+        if num_motion_data == 0:
+            return {}
+
+        poses = xrt.get_motion_tracker_pose()
+        velocities = xrt.get_motion_tracker_velocity()
+        accelerations = xrt.get_motion_tracker_acceleration()
+        serial_numbers = xrt.get_motion_tracker_serial_numbers()
+
+        tracker_data = {}
+        for i in range(num_motion_data):
+            serial = serial_numbers[i]
+            tracker_data[serial] = {
+                "pose": poses[i],
+                "velocity": velocities[i],
+                "acceleration": accelerations[i],
+            }
+
+        return tracker_data
+
+    def get_body_tracking_data(self) -> dict | None:
+        """Returns complete body tracking data or None if unavailable.
+
+        Returns:
+            Dict with keys: 'poses', 'velocities', 'accelerations', 'imu_timestamps', 'body_timestamp'
+            - poses: (24, 7) array [x,y,z,qx,qy,qz,qw] for each joint
+            - velocities: (24, 6) array [vx,vy,vz,wx,wy,wz] for each joint
+            - accelerations: (24, 6) array [ax,ay,az,wax,way,waz] for each joint
+        """
+        if not xrt.is_body_data_available():
+            return None
+
+        return {
+            "poses": xrt.get_body_joints_pose(),
+            "velocities": xrt.get_body_joints_velocity(),
+            "accelerations": xrt.get_body_joints_acceleration(),
+        }
+
     def close(self):
         xrt.close()
 


### PR DESCRIPTION
Expands the `XrClient` to expose more data from the underlying teleop system.

New methods provide access to:
- Hand tracking joint states
- Controller joystick axes
- Generic motion tracker data (pose, velocity, acceleration)
- Full-body tracking information

# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://roboverse.wiki/metasim/developer_guide/precommit_hooks
-->

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

Fixes # (issue)

<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How to test

Please describe how to test the change if applicable.


## Screenshots / Videos

Please attach before and after screenshots or videos of the change if applicable.

<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |

To upload images to a PR -- simply drag and drop an image while in edit mode and it should upload the image directly. You can then paste that source into the above before/after sections.
-->

## Checklist

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --color=always --all-files`
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added my name to the `CONTRIBUTORS.md` or my name already exists there

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
