### PR TITLE
[dev] New architecture for roboverse tasks (ongoing)

### DIFF
--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -738,8 +738,6 @@ class IsaacgymHandler(BaseSimHandler):
         self.gym.refresh_jacobian_tensors(self.sim)
         self.gym.refresh_mass_matrix_tensors(self.sim)
         self.gym.refresh_net_contact_force_tensor(self.sim)
-        self.gym.step_graphics(self.sim)
-        self.gym.render_all_camera_sensors(self.sim)
         # Refresh cameras and viewer
         self._render()
 
@@ -749,13 +747,14 @@ class IsaacgymHandler(BaseSimHandler):
             for evt in self.gym.query_viewer_action_events(self.viewer):
                 if evt.action == "toggle_viewer_sync" and evt.value > 0:
                     self._enable_viewer_sync = not self._enable_viewer_sync
-            if self._enable_viewer_sync or len(self.cameras) > 0:
-                self.gym.step_graphics(self.sim)
-                if len(self.cameras) > 0:
-                    self.gym.render_all_camera_sensors(self.sim)
-                if self._enable_viewer_sync:
-                    self.gym.draw_viewer(self.viewer, self.sim, False)
-            else:
+        if self._enable_viewer_sync or len(self.cameras) > 0:
+            self.gym.step_graphics(self.sim)
+            if len(self.cameras) > 0:
+                self.gym.render_all_camera_sensors(self.sim)
+            if self._enable_viewer_sync:
+                self.gym.draw_viewer(self.viewer, self.sim, False)
+        else:
+            if not self.headless:
                 self.gym.poll_viewer_events(self.viewer)
 
     def _compute_effort(self, actions):

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -7,19 +7,16 @@ import torch
 from dm_control import mjcf
 from loguru import logger as log
 
-from metasim.cfg.objects import (
-    ArticulationObjCfg,
-    PrimitiveCubeCfg,
-    PrimitiveCylinderCfg,
-    PrimitiveSphereCfg,
-)
+from metasim.cfg.objects import (ArticulationObjCfg, PrimitiveCubeCfg,
+                                 PrimitiveCylinderCfg, PrimitiveSphereCfg)
 from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import TaskType
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.sim.parallel import ParallelSimWrapper
 from metasim.types import Action
-from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
+from metasim.utils.state import (CameraState, ObjectState, RobotState,
+                                 TensorState)
 
 
 class MujocoHandler(BaseSimHandler):
@@ -234,6 +231,9 @@ class MujocoHandler(BaseSimHandler):
             mjcf_model.worldbody.add("camera", name=f"{camera.name}_custom", **camera_params)
             camera_max_width = max(camera_max_width, camera.width)
             camera_max_height = max(camera_max_height, camera.height)
+
+        getattr(mjcf_model.visual, 'global').offwidth = camera_max_width
+        getattr(mjcf_model.visual, 'global').offheight = camera_max_height
 
         if self.scenario.try_add_table:
             mjcf_model.asset.add(

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -7,16 +7,14 @@ import torch
 from dm_control import mjcf
 from loguru import logger as log
 
-from metasim.cfg.objects import (ArticulationObjCfg, PrimitiveCubeCfg,
-                                 PrimitiveCylinderCfg, PrimitiveSphereCfg)
+from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveCylinderCfg, PrimitiveSphereCfg
 from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import TaskType
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.sim.parallel import ParallelSimWrapper
 from metasim.types import Action
-from metasim.utils.state import (CameraState, ObjectState, RobotState,
-                                 TensorState)
+from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
 
 
 class MujocoHandler(BaseSimHandler):
@@ -232,8 +230,8 @@ class MujocoHandler(BaseSimHandler):
             camera_max_width = max(camera_max_width, camera.width)
             camera_max_height = max(camera_max_height, camera.height)
 
-        getattr(mjcf_model.visual, 'global').offwidth = camera_max_width
-        getattr(mjcf_model.visual, 'global').offheight = camera_max_height
+        getattr(mjcf_model.visual, "global").offwidth = camera_max_width
+        getattr(mjcf_model.visual, "global").offheight = camera_max_height
 
         if self.scenario.try_add_table:
             mjcf_model.asset.add(

--- a/roboverse_learn/tasks/base.py
+++ b/roboverse_learn/tasks/base.py
@@ -11,10 +11,8 @@ from traitlets import Dict
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
 from metasim.sim.base import BaseSimHandler
-from metasim.types import (Action, EnvState, Extra, Obs, Reward, Success,
-                           Termination, TimeOut)
+from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, Termination, TimeOut
 from metasim.utils.setup_util import get_sim_handler_class
-from metasim.utils.state import TensorState
 
 
 class BaseTaskWrapper:
@@ -122,7 +120,7 @@ class BaseTaskWrapper:
 
         return actions_dict
 
-    def _physics_step(self, actions_dict: dict) -> tuple[EnvState, Extra]:
+    def _physics_step(self, actions_dict: dict) -> tuple[EnvState, Extra | None]:
         """
         Physics step.
         """
@@ -136,7 +134,7 @@ class BaseTaskWrapper:
 
         return self.env.get_states(), None
 
-    def _post_physics_step(self, env_states: EnvState) -> tuple[Obs, Obs, Reward, Success, TimeOut, Extra]:
+    def _post_physics_step(self, env_states: EnvState) -> tuple[Obs, Obs, Reward, Success, TimeOut, Extra | None]:
         """
         Post-physics step.
         """
@@ -153,7 +151,7 @@ class BaseTaskWrapper:
             None,
         )
 
-    def step(self, actions: Action) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
+    def step(self, actions: Action) -> tuple[Obs, Obs, Reward, Success, TimeOut, Extra | None]:
         """
         Step the environment.
 

--- a/roboverse_learn/tasks/base.py
+++ b/roboverse_learn/tasks/base.py
@@ -11,7 +11,8 @@ from traitlets import Dict
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
 from metasim.sim.base import BaseSimHandler
-from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, Termination, TimeOut
+from metasim.types import (Action, EnvState, Extra, Obs, Reward, Success,
+                           Termination, TimeOut)
 from metasim.utils.setup_util import get_sim_handler_class
 from metasim.utils.state import TensorState
 
@@ -135,7 +136,7 @@ class BaseTaskWrapper:
 
         return self.env.get_states(), None
 
-    def _post_physics_step(self, env_states: EnvState) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
+    def _post_physics_step(self, env_states: EnvState) -> tuple[Obs, Obs, Reward, Success, TimeOut, Extra]:
         """
         Post-physics step.
         """
@@ -143,7 +144,14 @@ class BaseTaskWrapper:
         for callback in self.post_physics_step_callback:
             callback(env_states)
 
-        return self.env.get_states(), self.reward(), self.terminated(), self.time_out(), None
+        return (
+            self.observation(),
+            self.privileged_observation(),
+            self.reward(),
+            self.terminated(),
+            self.time_out(),
+            None,
+        )
 
     def step(self, actions: Action) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
         """
@@ -155,18 +163,18 @@ class BaseTaskWrapper:
 
         actions_dict = self._pre_physics_step(actions)
         env_states, _ = self._physics_step(actions_dict)
-        obs, reward, terminated, time_out, _ = self._post_physics_step(env_states)
+        obs, priv_obs, reward, terminated, time_out, _ = self._post_physics_step(env_states)
 
-        return obs, reward, terminated, time_out, None
+        return obs, priv_obs, reward, terminated, time_out, None
 
-    def reset(self) -> tuple[TensorState, Extra]:
+    def reset(self) -> tuple[Obs, Obs, Extra]:
         """
         Reset the environment.
         """
         for callback in self.reset_callback:
             callback()
 
-        return self.env.get_states(), None
+        return self.observation(), self.privileged_observation(), None
 
     def close(self) -> None:
         """

--- a/roboverse_learn/tasks/base.py
+++ b/roboverse_learn/tasks/base.py
@@ -16,6 +16,32 @@ from metasim.utils.setup_util import get_sim_handler_class
 
 
 class BaseTaskWrapper:
+    """
+    A base task wrapper for roboverse.
+
+    This wrapper is used to wrap the environment to form a complete task.
+
+    To write your own task, you need to inherit this class and override the following methods:
+    - _observation
+    - _privileged_observation
+    - _reward
+    - _terminated
+    - _time_out
+    - _observation_space
+    - _action_space
+
+    And use callbacks to modify the environment. The callbacks are:
+    - pre_physics_step_callback: Called before the physics step
+    - post_physics_step_callback: Called after the physics step
+    - reset_callback: Called when the environment is reset
+    - close_callback: Called when the environment is closed
+
+    Some methods are private and usually you should not override them.
+    - __pre_physics_step
+    - __physics_step
+    - __post_physics_step
+    """
+
     def __init__(self, scenario: BaseSimHandler | ScenarioCfg) -> None:
         """
         Initialize the task wrapper.
@@ -51,16 +77,15 @@ class BaseTaskWrapper:
         self.pre_physics_step_callback: list[Callable] = []
         self.post_physics_step_callback: list[Callable] = []
         self.reset_callback: list[Callable] = []
+        self.close_callback: list[Callable] = []
 
-    @property
-    def observation_space(self) -> gym.Space:
+    def _observation_space(self) -> gym.Space:
         """
         Get the observation space of the environment.
         """
         return gym.spaces.Box(low=-np.inf, high=np.inf, shape=(0,))
 
-    @property
-    def action_space(self) -> gym.Space:
+    def _action_space(self) -> gym.Space:
         """
         Get the action space of the environment.
         """
@@ -96,13 +121,16 @@ class BaseTaskWrapper:
         """
         return [False] * self.env.num_envs
 
-    def _pre_physics_step(self, actions: Action) -> Dict():
+    def __pre_physics_step(self, actions: Action) -> Dict():
         """
         Pre-physics step, apply transforms to actions and put actions into correct dict format.
 
         Args:
             actions: The actions to take
         """
+
+        for callback in self.pre_physics_step_callback:
+            callback(actions)
 
         actions_dict = {
             "robots": {
@@ -115,12 +143,9 @@ class BaseTaskWrapper:
             }
         }
 
-        for callback in self.pre_physics_step_callback:
-            callback(actions_dict)
-
         return actions_dict
 
-    def _physics_step(self, actions_dict: dict) -> tuple[Obs, Extra | None]:
+    def __physics_step(self, actions_dict: dict) -> tuple[Obs, Extra | None]:
         """
         Physics step.
         """
@@ -134,7 +159,7 @@ class BaseTaskWrapper:
 
         return self.env.get_states(), None
 
-    def _post_physics_step(self, env_states: Obs) -> tuple[Obs, Obs, Reward, Success, TimeOut, Extra | None]:
+    def __post_physics_step(self, env_states: Obs) -> tuple[Obs, Obs, Reward, Success, TimeOut, Extra | None]:
         """
         Post-physics step.
         """
@@ -159,9 +184,9 @@ class BaseTaskWrapper:
             actions: The actions to take
         """
 
-        actions_dict = self._pre_physics_step(actions)
-        env_states, _ = self._physics_step(actions_dict)
-        obs, priv_obs, reward, terminated, time_out, _ = self._post_physics_step(env_states)
+        actions_dict = self.__pre_physics_step(actions)
+        env_states, _ = self.__physics_step(actions_dict)
+        obs, priv_obs, reward, terminated, time_out, _ = self.__post_physics_step(env_states)
 
         return obs, priv_obs, reward, terminated, time_out, None
 
@@ -191,4 +216,21 @@ class BaseTaskWrapper:
         """
         Close the environment.
         """
+        for callback in self.close_callback:
+            callback()
+
         self.env.close()
+
+    @property
+    def observation_space(self) -> gym.Space:
+        """
+        Get the observation space of the environment.
+        """
+        return self._observation_space()
+
+    @property
+    def action_space(self) -> gym.Space:
+        """
+        Get the action space of the environment.
+        """
+        return self._action_space()

--- a/roboverse_learn/tasks/base.py
+++ b/roboverse_learn/tasks/base.py
@@ -11,7 +11,7 @@ from traitlets import Dict
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
 from metasim.sim.base import BaseSimHandler
-from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, Termination, TimeOut
+from metasim.types import Action, Extra, Obs, Reward, Success, Termination, TimeOut
 from metasim.utils.setup_util import get_sim_handler_class
 
 
@@ -66,31 +66,31 @@ class BaseTaskWrapper:
         """
         return gym.spaces.Box(low=-np.inf, high=np.inf, shape=(0,))
 
-    def observation(self) -> Obs:
+    def _observation(self, env_states: Obs) -> Obs:
         """
         Get the observation of the environment.
         """
-        return self.env.get_states()
+        return env_states
 
-    def privileged_observation(self) -> Obs:
+    def _privileged_observation(self, env_states: Obs) -> Obs:
         """
         Get the privileged observation of the environment.
         """
-        return self.env.get_states()
+        return env_states
 
-    def reward(self) -> Reward:
+    def _reward(self, env_states: Obs) -> Reward:
         """
         Get the reward of the environment.
         """
         return [0.0] * self.env.num_envs
 
-    def terminated(self) -> Termination:
+    def _terminated(self, env_states: Obs) -> Termination:
         """
         Get the terminated of the environment.
         """
         return [False] * self.env.num_envs
 
-    def time_out(self) -> TimeOut:
+    def _time_out(self, env_states: Obs) -> TimeOut:
         """
         Get the time out of the environment.
         """
@@ -120,7 +120,7 @@ class BaseTaskWrapper:
 
         return actions_dict
 
-    def _physics_step(self, actions_dict: dict) -> tuple[EnvState, Extra | None]:
+    def _physics_step(self, actions_dict: dict) -> tuple[Obs, Extra | None]:
         """
         Physics step.
         """
@@ -134,7 +134,7 @@ class BaseTaskWrapper:
 
         return self.env.get_states(), None
 
-    def _post_physics_step(self, env_states: EnvState) -> tuple[Obs, Obs, Reward, Success, TimeOut, Extra | None]:
+    def _post_physics_step(self, env_states: Obs) -> tuple[Obs, Obs, Reward, Success, TimeOut, Extra | None]:
         """
         Post-physics step.
         """
@@ -143,11 +143,11 @@ class BaseTaskWrapper:
             callback(env_states)
 
         return (
-            self.observation(),
-            self.privileged_observation(),
-            self.reward(),
-            self.terminated(),
-            self.time_out(),
+            self._observation(env_states),
+            self._privileged_observation(env_states),
+            self._reward(env_states),
+            self._terminated(env_states),
+            self._time_out(env_states),
             None,
         )
 
@@ -165,14 +165,27 @@ class BaseTaskWrapper:
 
         return obs, priv_obs, reward, terminated, time_out, None
 
-    def reset(self) -> tuple[Obs, Obs, Extra]:
+    def reset(self, env_ids: list[int] | None = None) -> tuple[Obs, Obs, Extra | None]:
         """
-        Reset the environment.
-        """
-        for callback in self.reset_callback:
-            callback()
+        Reset the environment. This base implementation does not do anything.
 
-        return self.observation(), self.privileged_observation(), None
+        Args:
+            env_ids: The environment ids to reset
+
+        Returns:
+            obs: The observation
+            priv_obs: The privileged observation
+            info: The info
+        """
+        if env_ids is None:
+            env_ids = list(range(self.env.num_envs))
+
+        for callback in self.reset_callback:
+            callback(env_ids)
+
+        env_states = self.env.get_states(env_ids=env_ids)
+
+        return self._observation(env_states), self._privileged_observation(env_states), None
 
     def close(self) -> None:
         """

--- a/roboverse_learn/tasks/base.py
+++ b/roboverse_learn/tasks/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Any, Callable
 
 import gymnasium as gym
 import numpy as np
@@ -121,7 +121,7 @@ class BaseTaskWrapper:
         """
         return [False] * self.env.num_envs
 
-    def __pre_physics_step(self, actions: Action) -> Dict():
+    def __pre_physics_step(self, actions: Action) -> Dict[str, Any]:
         """
         Pre-physics step, apply transforms to actions and put actions into correct dict format.
 
@@ -145,7 +145,7 @@ class BaseTaskWrapper:
 
         return actions_dict
 
-    def __physics_step(self, actions_dict: dict) -> tuple[Obs, Extra | None]:
+    def __physics_step(self, actions_dict: Dict[str, Any]) -> tuple[Obs, Extra | None]:
         """
         Physics step.
         """

--- a/roboverse_learn/tasks/base.py
+++ b/roboverse_learn/tasks/base.py
@@ -1,0 +1,178 @@
+"""A base task wrapper for roboverse"""
+
+from __future__ import annotations
+
+from collections import deque
+from copy import deepcopy
+from typing import Callable
+
+import gymnasium as gym
+import numpy as np
+import torch
+from traitlets import Dict
+
+from metasim.cfg.scenario import ScenarioCfg
+from metasim.constants import SimType
+from metasim.sim.base import BaseSimHandler
+from metasim.types import (Action, EnvState, Extra, Obs, Reward, Success,
+                           Termination, TimeOut)
+from metasim.utils.setup_util import get_sim_handler_class
+from metasim.utils.state import TensorState
+
+
+class BaseTaskWrapper() :
+    def __init__(self, scenario: BaseSimHandler | ScenarioCfg) -> None:
+        """
+        Initialize the task wrapper.
+
+        Args:
+            scenario: The scenario configuration
+        """
+
+        if isinstance(scenario, BaseSimHandler):
+            self.env = scenario
+        else:
+            self._instantiate_env(scenario)
+
+        self._prepare_callbacks()
+
+    def _instantiate_env(self, scenario: ScenarioCfg) -> None:
+        """
+        Instantiate the environment.
+
+        Args:
+            scenario: The scenario configuration
+        """
+
+        handler_class = get_sim_handler_class(SimType(scenario.sim))
+        self.env: BaseSimHandler = handler_class(scenario)
+        self.env.launch()
+
+    def _prepare_callbacks(self) -> None:
+        """
+        Prepare the callbacks for the environment.
+        """
+
+        self.pre_physics_step_callback: list[Callable] = []
+        self.post_physics_step_callback: list[Callable] = []
+        self.reset_callback: list[Callable] = []
+
+    @property
+    def observation_space(self) -> gym.Space:
+        """
+        Get the observation space of the environment.
+        """
+        return gym.spaces.Box(low=-np.inf, high=np.inf, shape=(0,))
+
+    @property
+    def action_space(self) -> gym.Space:
+        """
+        Get the action space of the environment.
+        """
+        return gym.spaces.Box(low=-np.inf, high=np.inf, shape=(0,))
+
+    def observation(self) -> Obs:
+        """
+        Get the observation of the environment.
+        """
+        return self.env.get_states()
+
+    def privileged_observation(self) -> Obs:
+        """
+        Get the privileged observation of the environment.
+        """
+        return self.env.get_states()
+
+    def reward(self) -> Reward:
+        """
+        Get the reward of the environment.
+        """
+        return [0.0] * self.env.num_envs
+
+    def terminated(self) -> Termination:
+        """
+        Get the terminated of the environment.
+        """
+        return [False] * self.env.num_envs
+
+    def time_out(self) -> TimeOut:
+        """
+        Get the time out of the environment.
+        """
+        return [False] * self.env.num_envs
+
+    def _pre_physics_step(self, actions: Action) -> Dict():
+        """
+        Pre-physics step, apply transforms to actions and put actions into correct dict format.
+
+        Args:
+            actions: The actions to take
+        """
+
+        actions_dict = {
+            "robots": {
+                self.env.robots[0].name: {
+                    "dof_pos_target": {
+                        joint_name: action for joint_name, action in zip(self.env.get_joint_names(self.env.robots[0].name), actions)
+                    }
+                }
+            }
+        }
+
+        for callback in self.pre_physics_step_callback:
+            callback(actions_dict)
+
+        return actions_dict
+
+    def _physics_step(self, actions_dict: dict) -> tuple[EnvState, Extra]:
+        """
+        Physics step.
+        """
+        # TODO: Use set_states() in new metasim handler
+        # self.env.set_states(actions_dict)
+
+        for robot in self.env.robots:
+            self.env.set_dof_targets(robot.name, [actions_dict["robots"]])
+
+        self.env.simulate()
+
+        return self.env.get_states(), None
+
+    def _post_physics_step(self, env_states: EnvState) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
+        """
+        Post-physics step.
+        """
+
+        for callback in self.post_physics_step_callback:
+            callback(env_states)
+
+        return self.env.get_states(), self.reward(), self.terminated(), self.time_out(), None
+
+    def step(self, actions: Action) -> tuple[Obs, Reward, Success, TimeOut, Extra]:
+        """
+        Step the environment.
+
+        Args:
+            actions: The actions to take
+        """
+
+        actions_dict = self._pre_physics_step(actions)
+        env_states, _ = self._physics_step(actions_dict)
+        obs, reward, terminated, time_out, _ = self._post_physics_step(env_states)
+
+        return obs, reward, terminated, time_out, None
+
+    def reset(self) -> tuple[TensorState, Extra]:
+        """
+        Reset the environment.
+        """
+        for callback in self.reset_callback:
+            callback()
+
+        return self.env.get_states(), None
+
+    def close(self) -> None:
+        """
+        Close the environment.
+        """
+        self.env.close()

--- a/roboverse_learn/tasks/base.py
+++ b/roboverse_learn/tasks/base.py
@@ -2,25 +2,21 @@
 
 from __future__ import annotations
 
-from collections import deque
-from copy import deepcopy
 from typing import Callable
 
 import gymnasium as gym
 import numpy as np
-import torch
 from traitlets import Dict
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
 from metasim.sim.base import BaseSimHandler
-from metasim.types import (Action, EnvState, Extra, Obs, Reward, Success,
-                           Termination, TimeOut)
+from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, Termination, TimeOut
 from metasim.utils.setup_util import get_sim_handler_class
 from metasim.utils.state import TensorState
 
 
-class BaseTaskWrapper() :
+class BaseTaskWrapper:
     def __init__(self, scenario: BaseSimHandler | ScenarioCfg) -> None:
         """
         Initialize the task wrapper.
@@ -113,7 +109,8 @@ class BaseTaskWrapper() :
             "robots": {
                 self.env.robots[0].name: {
                     "dof_pos_target": {
-                        joint_name: action for joint_name, action in zip(self.env.get_joint_names(self.env.robots[0].name), actions)
+                        joint_name: action
+                        for joint_name, action in zip(self.env.get_joint_names(self.env.robots[0].name), actions)
                     }
                 }
             }

--- a/roboverse_learn/tasks/test.py
+++ b/roboverse_learn/tasks/test.py
@@ -1,14 +1,12 @@
 import numpy as np
 from base import BaseTaskWrapper
 
-from metasim.cfg.objects import (ArticulationObjCfg, PrimitiveCubeCfg,
-                                 PrimitiveSphereCfg, RigidObjCfg)
+from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg
-from metasim.constants import PhysicStateType, SimType
+from metasim.constants import PhysicStateType
 
 if __name__ == "__main__":
-
     # initialize scenario
     scenario = ScenarioCfg(
         robots=["franka"],
@@ -55,6 +53,4 @@ if __name__ == "__main__":
     task = BaseTaskWrapper(scenario)
 
     for i in range(10):
-        task.step(
-            np.zeros(9)
-        )
+        task.step(np.zeros(9))

--- a/roboverse_learn/tasks/test.py
+++ b/roboverse_learn/tasks/test.py
@@ -53,4 +53,5 @@ if __name__ == "__main__":
     task = BaseTaskWrapper(scenario)
 
     for i in range(10):
-        task.step(np.zeros(9))
+        tmp = task.step(np.zeros(9))
+        print(tmp)

--- a/roboverse_learn/tasks/test.py
+++ b/roboverse_learn/tasks/test.py
@@ -13,8 +13,8 @@ if __name__ == "__main__":
     scenario = ScenarioCfg(
         robots=["franka"],
         try_add_table=False,
-        sim="pybullet",
-        headless=False,
+        sim="mujoco",
+        headless=True,
         num_envs=1,
     )
 
@@ -39,16 +39,16 @@ if __name__ == "__main__":
             name="bbq_sauce",
             scale=(2, 2, 2),
             physics=PhysicStateType.RIGIDBODY,
-            usd_path="../get_started/example_assets/bbq_sauce/usd/bbq_sauce.usd",
-            urdf_path="../get_started/example_assets/bbq_sauce/urdf/bbq_sauce.urdf",
-            mjcf_path="../get_started/example_assets/bbq_sauce/mjcf/bbq_sauce.xml",
+            usd_path="../../get_started/example_assets/bbq_sauce/usd/bbq_sauce.usd",
+            urdf_path="../../get_started/example_assets/bbq_sauce/urdf/bbq_sauce.urdf",
+            mjcf_path="../../get_started/example_assets/bbq_sauce/mjcf/bbq_sauce.xml",
         ),
         ArticulationObjCfg(
             name="box_base",
             fix_base_link=True,
-            usd_path="../get_started/example_assets/box_base/usd/box_base.usd",
-            urdf_path="../get_started/example_assets/box_base/urdf/box_base_unique.urdf",
-            mjcf_path="../get_started/example_assets/box_base/mjcf/box_base_unique.mjcf",
+            usd_path="../../get_started/example_assets/box_base/usd/box_base.usd",
+            urdf_path="../../get_started/example_assets/box_base/urdf/box_base_unique.urdf",
+            mjcf_path="../../get_started/example_assets/box_base/mjcf/box_base_unique.mjcf",
         ),
     ]
 

--- a/roboverse_learn/tasks/test.py
+++ b/roboverse_learn/tasks/test.py
@@ -1,0 +1,60 @@
+import numpy as np
+from base import BaseTaskWrapper
+
+from metasim.cfg.objects import (ArticulationObjCfg, PrimitiveCubeCfg,
+                                 PrimitiveSphereCfg, RigidObjCfg)
+from metasim.cfg.scenario import ScenarioCfg
+from metasim.cfg.sensors import PinholeCameraCfg
+from metasim.constants import PhysicStateType, SimType
+
+if __name__ == "__main__":
+
+    # initialize scenario
+    scenario = ScenarioCfg(
+        robots=["franka"],
+        try_add_table=False,
+        sim="pybullet",
+        headless=False,
+        num_envs=1,
+    )
+
+    # add cameras
+    scenario.cameras = [PinholeCameraCfg(width=1024, height=1024, pos=(1.5, -1.5, 1.5), look_at=(0.0, 0.0, 0.0))]
+
+    # add objects
+    scenario.objects = [
+        PrimitiveCubeCfg(
+            name="cube",
+            size=(0.1, 0.1, 0.1),
+            color=[1.0, 0.0, 0.0],
+            physics=PhysicStateType.RIGIDBODY,
+        ),
+        PrimitiveSphereCfg(
+            name="sphere",
+            radius=0.1,
+            color=[0.0, 0.0, 1.0],
+            physics=PhysicStateType.RIGIDBODY,
+        ),
+        RigidObjCfg(
+            name="bbq_sauce",
+            scale=(2, 2, 2),
+            physics=PhysicStateType.RIGIDBODY,
+            usd_path="../get_started/example_assets/bbq_sauce/usd/bbq_sauce.usd",
+            urdf_path="../get_started/example_assets/bbq_sauce/urdf/bbq_sauce.urdf",
+            mjcf_path="../get_started/example_assets/bbq_sauce/mjcf/bbq_sauce.xml",
+        ),
+        ArticulationObjCfg(
+            name="box_base",
+            fix_base_link=True,
+            usd_path="../get_started/example_assets/box_base/usd/box_base.usd",
+            urdf_path="../get_started/example_assets/box_base/urdf/box_base_unique.urdf",
+            mjcf_path="../get_started/example_assets/box_base/mjcf/box_base_unique.mjcf",
+        ),
+    ]
+
+    task = BaseTaskWrapper(scenario)
+
+    for i in range(10):
+        task.step(
+            np.zeros(9)
+        )


### PR DESCRIPTION
## Purpose of This PR

As discussed with @charlietcheng @MurphyZhao04, we are now re-designing roboverse-learn architecture.

The first step is to design a base task class. 
Then rapidly we need to re-design cfg system and metasim APIs, which requires more discussions and development.

Our goal is to separate the simulation job of metasim apart from task-related jobs. This will allow easier repurposing of metasim as simply a simulator, easier task migration, and easier new task implementation.

## Short Tutorial on How to Use

To migrate a task, you just need to provide step(), reset(), observation_space(), action_space() methods in the same format of this base class.

To write your own task, you need to inherit this base class and override the following methods:
    - _observation
    - _privileged_observation
    - _reward
    - _terminated
    - _time_out
    - _observation_space
    - _action_space

  And use callbacks to modify the environment. The callbacks are:
    - pre_physics_step_callback: Called before the physics step
    - post_physics_step_callback: Called after the physics step
    - reset_callback: Called when the environment is reset
    - close_callback: Called when the environment is closed

  Some methods are private and usually you should not override them.
    - __pre_physics_step
    - __physics_step
    - __post_physics_step