### PR TITLE
[fix] jax installation for mujoco env and user override bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM nvidia/cuda:11.8.0-runtime-ubuntu22.04
 
-ARG DOCKER_UID=1000
-ARG DOCKER_GID=1000
-ARG DOCKER_USER=user
+ARG DOCKER_UID
+ARG DOCKER_GID
+ARG DOCKER_USER
 ARG HOME=/home/${DOCKER_USER}
 
 RUN groupadd -g $DOCKER_GID $DOCKER_USER \
@@ -90,6 +90,7 @@ RUN cd ${HOME}/RoboVerse \
     && eval "$(mamba shell hook --shell bash)" \
     && mamba activate metasim \
     && uv pip install -e ".[isaaclab,mujoco,sapien3,pybullet]" \
+    && pip install --upgrade "jax[cuda11_pip]" -f https://storage.googleapis.com/jax-releases/jax_cuda_releases.html \
     && uv cache clean
 
 # Test proxy connection


### PR DESCRIPTION
# Description

<!--
Thank you for your interest in sending a pull request. Please make sure to check the contribution guidelines.

Link: https://roboverse.wiki/metasim/developer_guide/precommit_hooks
-->

1. support jax in docker
2. fix `USER` hardcoding in dockerfile



<!-- As a practice, it is recommended to open an issue to have discussions on the proposed pull request.
This makes it easier for the community to keep track of what is being developed or added, and if a given feature
is demanded by more than one party. -->

## Type of change

<!-- As you go through the list, delete the ones that are not applicable. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## How to test
after build the docker image and run the container
```
conda activate metasim
python get_started/0_static_scene.py  --sim mujoco
```
test on nvidia 4080 super


## Screenshots / Videos


<img width="1220" height="725" alt="image" src="https://github.com/user-attachments/assets/0d2c184c-c63e-48d6-84df-d27c4662e894" />

