### PR TITLE
Dev/extra query

### DIFF
--- a/metasim/queries/base.py
+++ b/metasim/queries/base.py
@@ -1,0 +1,49 @@
+"""Base class for all query types."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from metasim.sim.base import BaseSimHandler
+from metasim.sim.genesis import GenesisHandler
+from metasim.sim.isaacgym import IsaacgymHandler
+from metasim.sim.isaaclab import IsaaclabHandler
+from metasim.sim.mjx import MJXHandler
+from metasim.sim.pybullet import PybulletHandler
+from metasim.sim.pyrep import PyrepHandler
+from metasim.sim.sapien import Sapien2Handler, Sapien3Handler
+
+
+class BaseQueryType() :
+    suported_handlers = []
+
+    def __init__(self, **kwargs) :
+
+        self.handler = None
+        self.query_options = kwargs
+
+    def bind_handler(self, handler: BaseSimHandler, *args: Any, **kwargs) :
+        """
+        By default, all queries will be binded to the handler at handler.launch() stage.
+        By default, the queries will be given the handler instance as the first argument.
+        For different simulation handlers, the queries may be binded at different stages.
+        For different simulation handlers, the queries may be given other optional arguments.
+        You can also pass locals() to bind_handler() to access local variables in the handler.
+        """
+        if handler.__class__ not in self.suported_handlers:
+            raise ValueError(f"Handler {handler.__class__.__name__} not supported for query {self.__class__.__name__}")
+        self.handler = handler
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        """
+        By default, the query has no arguments.
+        The query will be called in handler.get_extra() stage.
+        The query should return a specific value.
+        """
+        pass
+
+    def __str__(self) -> str:
+        return f"{self.__class__.__name__}"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}"

--- a/metasim/sim/base.py
+++ b/metasim/sim/base.py
@@ -8,14 +8,16 @@ from loguru import logger as log
 from metasim.cfg.randomization import FrictionRandomCfg
 from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
-from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, TimeOut
+from metasim.queries.base import BaseQueryType
+from metasim.types import (Action, EnvState, Extra, Obs, Reward, Success,
+                           TimeOut)
 from metasim.utils.state import TensorState, state_tensor_to_nested
 
 
 class BaseSimHandler(ABC):
     """Base class for simulation handler."""
 
-    def __init__(self, scenario: ScenarioCfg):
+    def __init__(self, scenario: ScenarioCfg, optional_queries: dict[str, BaseQueryType] = {}):
         ## Overwrite scenario with task, TODO: this should happen in scenario class post_init
         if scenario.task is not None:
             scenario.objects = scenario.task.objects
@@ -26,6 +28,7 @@ class BaseSimHandler(ABC):
         self.scenario = scenario
         self._num_envs = scenario.num_envs
         self.headless = scenario.headless
+        self.optional_queries = optional_queries
 
         ## For quick reference
         self.task = scenario.task
@@ -45,9 +48,12 @@ class BaseSimHandler(ABC):
             if callable(extra_fn):
                 self.spec = extra_fn() or {}
 
+
     def launch(self) -> None:
         """Launch the simulation."""
-        raise NotImplementedError
+        for query_name, query_type in self.optional_queries.items():
+            query_type.bind_handler(self)
+        # raise NotImplementedError
 
     ############################################################
     ## Gymnasium main methods
@@ -123,6 +129,14 @@ class BaseSimHandler(ABC):
             self._states = self._get_states(env_ids=env_ids)
             self._state_cache_expire = False
         return self._states
+
+    def get_extra(self) :
+        """Get the extra information of the environment.
+        """
+        ret_dict = {}
+        for query_name, query_type in self.optional_queries.items():
+            ret_dict[query_name] = query_type(self)
+        return ret_dict
 
     def get_vel(self, obj_name: str, env_ids: list[int] | None = None) -> torch.FloatTensor:
         if self.num_envs > 1:

--- a/metasim/sim/blender/blender.py
+++ b/metasim/sim/blender/blender.py
@@ -8,15 +8,13 @@ import torch
 from loguru import logger as log
 from mathutils import Matrix
 
-from metasim.cfg.objects import (
-    ArticulationObjCfg,
-    PrimitiveCubeCfg,
-    PrimitiveSphereCfg,
-    RigidObjCfg,
-)
+from metasim.cfg.objects import (ArticulationObjCfg, PrimitiveCubeCfg,
+                                 PrimitiveSphereCfg, RigidObjCfg)
 from metasim.cfg.scenario import ScenarioCfg
+from metasim.queries.base import BaseQueryType
 from metasim.sim import BaseSimHandler, EnvWrapper, IdentityEnvWrapper
-from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, Termination
+from metasim.types import (Action, EnvState, Extra, Obs, Reward, Success,
+                           Termination)
 from metasim.utils.camera_util import get_cam_params
 from metasim.utils.math import matrix_from_quat
 
@@ -42,8 +40,8 @@ def import_mesh(path):
 
 
 class BlenderHandler(BaseSimHandler):
-    def __init__(self, scenario: ScenarioCfg):
-        super().__init__(scenario)
+    def __init__(self, scenario: ScenarioCfg, optional_queries: dict[str, BaseQueryType] = {}):
+        super().__init__(scenario, optional_queries)
         self.context = bpy.context
         self._objs = {}
 

--- a/metasim/sim/genesis/genesis.py
+++ b/metasim/sim/genesis/genesis.py
@@ -7,11 +7,15 @@ from genesis.engine.entities.rigid_entity import RigidEntity, RigidJoint
 from genesis.vis.camera import Camera
 from loguru import logger as log
 
-from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg, _FileBasedMixin
+from metasim.cfg.objects import (ArticulationObjCfg, PrimitiveCubeCfg,
+                                 PrimitiveSphereCfg, RigidObjCfg,
+                                 _FileBasedMixin)
 from metasim.cfg.scenario import ScenarioCfg
+from metasim.queries.base import BaseQueryType
 from metasim.sim import BaseSimHandler, GymEnvWrapper
 from metasim.types import Action, EnvState
-from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
+from metasim.utils.state import (CameraState, ObjectState, RobotState,
+                                 TensorState)
 
 # Apply IGL compatibility patch
 try:
@@ -33,8 +37,8 @@ except Exception:
 
 
 class GenesisHandler(BaseSimHandler):
-    def __init__(self, scenario: ScenarioCfg):
-        super().__init__(scenario)
+    def __init__(self, scenario: ScenarioCfg, optional_queries: dict[str, BaseQueryType] = {}):
+        super().__init__(scenario, optional_queries)
         self._actions_cache: list[Action] = []
         self.object_inst_dict: dict[str, RigidEntity] = {}
         self.camera_inst_dict: dict[str, Camera] = {}

--- a/metasim/sim/isaacgym/isaacgym.py
+++ b/metasim/sim/isaacgym/isaacgym.py
@@ -7,26 +7,23 @@ import torch
 from isaacgym import gymapi, gymtorch, gymutil  # noqa: F401
 from loguru import logger as log
 
-from metasim.cfg.objects import (
-    ArticulationObjCfg,
-    BaseObjCfg,
-    PrimitiveCubeCfg,
-    PrimitiveSphereCfg,
-    RigidObjCfg,
-    _FileBasedMixin,
-)
+from metasim.cfg.objects import (ArticulationObjCfg, BaseObjCfg,
+                                 PrimitiveCubeCfg, PrimitiveSphereCfg,
+                                 RigidObjCfg, _FileBasedMixin)
 from metasim.cfg.randomization import FrictionRandomCfg, MassRandomCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import PhysicStateType
+from metasim.queries.base import BaseQueryType
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.types import Action, EnvState
 from metasim.utils.dict import class_to_dict
-from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
+from metasim.utils.state import (CameraState, ObjectState, RobotState,
+                                 TensorState)
 
 
 class IsaacgymHandler(BaseSimHandler):
-    def __init__(self, scenario: ScenarioCfg):
-        super().__init__(scenario)
+    def __init__(self, scenario: ScenarioCfg, optional_queries: dict[str, BaseQueryType] = {}):
+        super().__init__(scenario, optional_queries)
         self._actions_cache: list[Action] = []
         self._robot_names = {self.robot.name}
         self._robot_init_pos = self.robot.default_position

--- a/metasim/sim/isaaclab/isaaclab.py
+++ b/metasim/sim/isaaclab/isaaclab.py
@@ -16,6 +16,7 @@ from metasim.cfg.objects import (
 )
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import ContactForceSensorCfg
+from metasim.queries.base import BaseQueryType
 from metasim.sim import BaseSimHandler, EnvWrapper, IdentityEnvWrapper
 from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, TimeOut
 from metasim.utils.dict import deep_get
@@ -36,8 +37,8 @@ except:
 
 
 class IsaaclabHandler(BaseSimHandler):
-    def __init__(self, scenario: ScenarioCfg):
-        super().__init__(scenario)
+    def __init__(self, scenario: ScenarioCfg, optional_queries: dict[str, BaseQueryType] = {}):
+        super().__init__(scenario, optional_queries)
         self._actions_cache: list[Action] = []
 
     ############################################################

--- a/metasim/sim/mjx/mjx.py
+++ b/metasim/sim/mjx/mjx.py
@@ -23,29 +23,25 @@ from dm_control import mjcf
 from loguru import logger as log
 from mujoco import mjx
 
-from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveCylinderCfg, PrimitiveSphereCfg
+from metasim.cfg.objects import (ArticulationObjCfg, PrimitiveCubeCfg,
+                                 PrimitiveCylinderCfg, PrimitiveSphereCfg)
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import TaskType
+from metasim.queries.base import BaseQueryType
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.types import Action
-from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
+from metasim.utils.state import (CameraState, ObjectState, RobotState,
+                                 TensorState)
 
-from .mjx_helper import (
-    j2t,
-    pack_body_state,
-    pack_root_state,
-    process_entity,
-    sorted_actuator_ids,
-    sorted_body_ids,
-    sorted_joint_info,
-    t2j,
-)
+from .mjx_helper import (j2t, pack_body_state, pack_root_state, process_entity,
+                         sorted_actuator_ids, sorted_body_ids,
+                         sorted_joint_info, t2j)
 from .mjx_querier import MJXQuerier
 
 
 class MJXHandler(BaseSimHandler):
-    def __init__(self, scenario: ScenarioCfg, *, seed: int | None = None):
-        super().__init__(scenario)
+    def __init__(self, scenario: ScenarioCfg, optional_queries: dict[str, BaseQueryType] = {}, *, seed: int | None = None):
+        super().__init__(scenario, optional_queries)
 
         self._scenario = scenario
         self._seed = seed or 0

--- a/metasim/sim/mujoco/mujoco.py
+++ b/metasim/sim/mujoco/mujoco.py
@@ -7,21 +7,24 @@ import torch
 from dm_control import mjcf
 from loguru import logger as log
 
-from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveCylinderCfg, PrimitiveSphereCfg
+from metasim.cfg.objects import (ArticulationObjCfg, PrimitiveCubeCfg,
+                                 PrimitiveCylinderCfg, PrimitiveSphereCfg)
 from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import TaskType
+from metasim.queries.base import BaseQueryType
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.sim.parallel import ParallelSimWrapper
 from metasim.types import Action
-from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
+from metasim.utils.state import (CameraState, ObjectState, RobotState,
+                                 TensorState)
 
 from .mujoco_querier import MujocoQuerier
 
 
 class MujocoHandler(BaseSimHandler):
-    def __init__(self, scenario: ScenarioCfg):
-        super().__init__(scenario)
+    def __init__(self, scenario: ScenarioCfg, optional_queries: dict[str, BaseQueryType] = {}):
+        super().__init__(scenario, optional_queries)
         self._actions_cache: list[Action] = []
 
         if scenario.num_envs > 1:

--- a/metasim/sim/pybullet/pybullet.py
+++ b/metasim/sim/pybullet/pybullet.py
@@ -15,19 +15,22 @@ import pybullet as p
 import pybullet_data
 import torch
 
-from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
+from metasim.cfg.objects import (ArticulationObjCfg, PrimitiveCubeCfg,
+                                 PrimitiveSphereCfg, RigidObjCfg)
 from metasim.cfg.robots import BaseRobotCfg
 from metasim.cfg.scenario import ScenarioCfg
+from metasim.queries.base import BaseQueryType
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.types import Action, EnvState
 from metasim.utils.math import convert_quat
-from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
+from metasim.utils.state import (CameraState, ObjectState, RobotState,
+                                 TensorState)
 
 
 class SinglePybulletHandler(BaseSimHandler):
     """Pybullet Handler class."""
 
-    def __init__(self, scenario: ScenarioCfg):
+    def __init__(self, scenario: ScenarioCfg, optional_queries: dict[str, BaseQueryType] = {}):
         """Initialize the Pybullet Handler.
 
         Args:
@@ -35,7 +38,7 @@ class SinglePybulletHandler(BaseSimHandler):
             num_envs: Number of environments
             headless: Whether to run the simulation in headless mode
         """
-        super().__init__(scenario)
+        super().__init__(scenario, optional_queries)
         self._actions_cache: list[Action] = []
 
     def _build_pybullet(self):

--- a/metasim/sim/pyrep/pyrep.py
+++ b/metasim/sim/pyrep/pyrep.py
@@ -10,7 +10,8 @@ from pyrep.robots.end_effectors.panda_gripper import PandaGripper
 from rlbench.backend.robot import Robot
 
 from metasim.sim import BaseSimHandler
-from metasim.types import Action, EnvState, Extra, Obs, Reward, Success, TimeOut
+from metasim.types import (Action, EnvState, Extra, Obs, Reward, Success,
+                           TimeOut)
 from metasim.utils import to_snake_case
 
 # TODO: try best to be independent from RLBench

--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -26,6 +26,8 @@ from metasim.cfg.objects import (
     RigidObjCfg,
 )
 from metasim.cfg.robots import BaseRobotCfg
+from metasim.cfg.scenario import ScenarioCfg
+from metasim.queries.base import BaseQueryType
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.types import EnvState
 from metasim.utils.math import quat_from_euler_np
@@ -35,10 +37,10 @@ from metasim.utils.state import CameraState, ObjectState, RobotState, TensorStat
 class Sapien2Handler(BaseSimHandler):
     """Sapien2 Handler class."""
 
-    def __init__(self, scenario):
+    def __init__(self, scenario: ScenarioCfg, optional_queries: dict[str, BaseQueryType] = {}):
         assert parse_version(sapien.__version__) >= parse_version("2.0.0"), "Sapien version should be 2.0.0 or higher"
         assert parse_version(sapien.__version__) < parse_version("3.0.0a0"), "Sapien version should be lower than 3.0.0"
-        super().__init__(scenario)
+        super().__init__(scenario, optional_queries)
         self.headless = False  # XXX: no headless anyway
 
     def _build_sapien(self):

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -18,28 +18,27 @@ from loguru import logger as log
 from packaging.version import parse as parse_version
 from sapien.utils import Viewer
 
-from metasim.cfg.objects import (
-    ArticulationObjCfg,
-    NonConvexRigidObjCfg,
-    PrimitiveCubeCfg,
-    PrimitiveSphereCfg,
-    RigidObjCfg,
-)
+from metasim.cfg.objects import (ArticulationObjCfg, NonConvexRigidObjCfg,
+                                 PrimitiveCubeCfg, PrimitiveSphereCfg,
+                                 RigidObjCfg)
 from metasim.cfg.robots import BaseRobotCfg
+from metasim.cfg.scenario import ScenarioCfg
+from metasim.queries.base import BaseQueryType
 from metasim.sim import BaseSimHandler, EnvWrapper, GymEnvWrapper
 from metasim.types import Action, EnvState
 from metasim.utils.math import quat_from_euler_np
-from metasim.utils.state import CameraState, ObjectState, RobotState, TensorState
+from metasim.utils.state import (CameraState, ObjectState, RobotState,
+                                 TensorState)
 
 
 class Sapien3Handler(BaseSimHandler):
     """Sapien3 Handler class."""
 
-    def __init__(self, scenario):
+    def __init__(self, scenario: ScenarioCfg, optional_queries: dict[str, BaseQueryType] = {}):
         assert parse_version(sapien.__version__) >= parse_version("3.0.0a0"), "Sapien3 is required"
         assert parse_version(sapien.__version__) < parse_version("4.0.0"), "Sapien3 is required"
         log.warning("Sapien3 is still under development, some metasim apis yet don't have sapien3 support")
-        super().__init__(scenario)
+        super().__init__(scenario, optional_queries)
         self.headless = scenario.headless
         self._actions_cache: list[Action] = []
 

--- a/roboverse_learn/tasks/base.py
+++ b/roboverse_learn/tasks/base.py
@@ -10,8 +10,10 @@ from traitlets import Dict
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType
+from metasim.queries.base import BaseQueryType
 from metasim.sim.base import BaseSimHandler
-from metasim.types import Action, Extra, Obs, Reward, Success, Termination, TimeOut
+from metasim.types import (Action, Extra, Obs, Reward, Success, Termination,
+                           TimeOut)
 from metasim.utils.setup_util import get_sim_handler_class
 
 
@@ -29,6 +31,7 @@ class BaseTaskWrapper:
     - _time_out
     - _observation_space
     - _action_space
+    - _extra_spec
 
     And use callbacks to modify the environment. The callbacks are:
     - pre_physics_step_callback: Called before the physics step
@@ -66,7 +69,7 @@ class BaseTaskWrapper:
         """
 
         handler_class = get_sim_handler_class(SimType(scenario.sim))
-        self.env: BaseSimHandler = handler_class(scenario)
+        self.env: BaseSimHandler = handler_class(scenario, self.extra_spec)
         self.env.launch()
 
     def _prepare_callbacks(self) -> None:
@@ -90,6 +93,12 @@ class BaseTaskWrapper:
         Get the action space of the environment.
         """
         return gym.spaces.Box(low=-np.inf, high=np.inf, shape=(0,))
+
+    def _extra_spec(self) -> dict[str, BaseQueryType]:
+        """
+        Get the extra spec of the environment.
+        """
+        return {}
 
     def _observation(self, env_states: Obs) -> Obs:
         """
@@ -234,3 +243,11 @@ class BaseTaskWrapper:
         Get the action space of the environment.
         """
         return self._action_space()
+
+    @property
+    def extra_spec(self) -> dict[str, BaseQueryType]:
+        """
+        Get the extra spec of the environment.
+        Extra specs are optional queries that are used in handler.get_extra() stage.
+        """
+        return self._extra_spec()


### PR DESCRIPTION
# The implementation of new extra query mechanism

This mechanism allows developers and users to create custom queries outside of metasim framework.

Users need first define custom query types. Simulator-dependent implementations for carrying out the actual query need to be done in each query type.

At TaskWrapper() level, users need to define a dictionary of extra queries. These queries are then used by handler.get_extra() method to obtain additional information that may be (1) partially supported by different simulators, (2) optional observations that are only used by some tasks.

At launch() stage of handlers, query.bind_handler() will be called to bind to simulators.

At get_extra() stage of handlers, query.__call__() will be called to perform the actual query and return the query value.