### PR TITLE
fix/handler_import_error

### DIFF
--- a/dashboard/run_test.py
+++ b/dashboard/run_test.py
@@ -9,7 +9,11 @@ from dataclasses import dataclass
 import tyro
 import yaml
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 

--- a/dashboard/run_test_data.py
+++ b/dashboard/run_test_data.py
@@ -10,7 +10,11 @@ from dataclasses import dataclass
 import tyro
 import yaml
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 

--- a/get_started/0_static_scene.py
+++ b/get_started/0_static_scene.py
@@ -16,7 +16,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/get_started/1_control_robot.py
+++ b/get_started/1_control_robot.py
@@ -15,7 +15,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/get_started/2_add_new_robot.py
+++ b/get_started/2_add_new_robot.py
@@ -15,7 +15,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/get_started/3_parallel_envs.py
+++ b/get_started/3_parallel_envs.py
@@ -15,7 +15,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/get_started/4_motion_planning.py
+++ b/get_started/4_motion_planning.py
@@ -16,7 +16,11 @@ import torch
 import tyro
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/get_started/5_hybrid_sim.py
+++ b/get_started/5_hybrid_sim.py
@@ -15,7 +15,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/get_started/6_advanced_rendering.py
+++ b/get_started/6_advanced_rendering.py
@@ -16,7 +16,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/get_started/7_multiple_robots.py
+++ b/get_started/7_multiple_robots.py
@@ -10,7 +10,11 @@ from dataclasses import dataclass
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.robots import FrankaCfg, H1Cfg
 from metasim.cfg.scenario import ScenarioCfg

--- a/get_started/8_mount_camera.py
+++ b/get_started/8_mount_camera.py
@@ -15,7 +15,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/get_started/motion_planning/0_franka_planning.py
+++ b/get_started/motion_planning/0_franka_planning.py
@@ -18,7 +18,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
@@ -26,7 +30,11 @@ log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 import rootutils
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/get_started/motion_planning/1_object_grasping.py
+++ b/get_started/motion_planning/1_object_grasping.py
@@ -19,7 +19,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
@@ -28,7 +32,11 @@ import open3d as o3d
 import rootutils
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from get_started.utils import convert_to_ply
 

--- a/get_started/motion_planning/2_water_pouring.py
+++ b/get_started/motion_planning/2_water_pouring.py
@@ -19,7 +19,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
@@ -27,7 +31,11 @@ log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 import rootutils
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from get_started.utils import convert_to_ply
 

--- a/get_started/multiple_cameras.py
+++ b/get_started/multiple_cameras.py
@@ -17,7 +17,11 @@ import rootutils
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/get_started/rl/0_ppo_reaching.py
+++ b/get_started/rl/0_ppo_reaching.py
@@ -18,7 +18,11 @@ import tyro
 from gymnasium import spaces
 from gymnasium.vector import VectorEnv
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import VecEnv
 

--- a/get_started/rl/0_ppo_reaching_new.py
+++ b/get_started/rl/0_ppo_reaching_new.py
@@ -18,7 +18,11 @@ import tyro
 from gymnasium import spaces
 from loguru import logger as log
 from packaging.version import Version
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import VecEnv
 

--- a/metasim/cfg/tasks/humanoidbench/base_cfg.py
+++ b/metasim/cfg/tasks/humanoidbench/base_cfg.py
@@ -7,7 +7,11 @@ import logging
 import numpy as np
 import torch
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.control import ControlCfg
 from metasim.cfg.tasks.base_task_cfg import BaseRLTaskCfg, SimParamCfg

--- a/metasim/queries/site.py
+++ b/metasim/queries/site.py
@@ -6,8 +6,16 @@ import mujoco
 import torch
 
 from metasim.queries.base import BaseQueryType
-from metasim.sim.mjx import MJXHandler
-from metasim.sim.mujoco import MujocoHandler
+
+try:
+    from metasim.sim.mjx import MJXHandler
+except ImportError:
+    MJXHandler = None
+try:
+    from metasim.sim.mujoco import MujocoHandler
+except ImportError:
+    MujocoHandler = None
+
 
 # ------------------------ util cache ------------------------
 _site_cache = {}

--- a/metasim/scripts/collect_demo.py
+++ b/metasim/scripts/collect_demo.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 ## Setup logging
 #########################################
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 

--- a/metasim/scripts/motion_planning.py
+++ b/metasim/scripts/motion_planning.py
@@ -12,7 +12,11 @@ import time
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType

--- a/metasim/scripts/motion_planning_gapartnet.py
+++ b/metasim/scripts/motion_planning_gapartnet.py
@@ -14,7 +14,11 @@ import numpy as np
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg

--- a/metasim/scripts/random_action.py
+++ b/metasim/scripts/random_action.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 ## Setup logging
 #########################################
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 

--- a/metasim/scripts/random_action_ee.py
+++ b/metasim/scripts/random_action_ee.py
@@ -26,7 +26,11 @@ except ImportError:
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg

--- a/metasim/scripts/random_action_pure.py
+++ b/metasim/scripts/random_action_pure.py
@@ -10,7 +10,11 @@ except ImportError:
 
 import torch
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType

--- a/metasim/scripts/random_action_really_pure.py
+++ b/metasim/scripts/random_action_really_pure.py
@@ -10,7 +10,11 @@ from dataclasses import dataclass
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.constants import SimType

--- a/metasim/scripts/replay_demo.py
+++ b/metasim/scripts/replay_demo.py
@@ -15,7 +15,11 @@ import numpy as np
 import tyro
 from loguru import logger as log
 from numpy.typing import NDArray
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 from torchvision.utils import make_grid, save_image
 from tyro import MISSING
 

--- a/metasim/scripts/retarget_demo.py
+++ b/metasim/scripts/retarget_demo.py
@@ -45,7 +45,11 @@ import numpy as np
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 from tqdm.rich import tqdm, trange
 
 from metasim.utils.demo_util.loader import load_traj_file, save_traj_file

--- a/metasim/scripts/teleop_keyboard.py
+++ b/metasim/scripts/teleop_keyboard.py
@@ -14,7 +14,11 @@ import pygame
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg

--- a/metasim/scripts/teleop_phone.py
+++ b/metasim/scripts/teleop_phone.py
@@ -14,7 +14,11 @@ import numpy as np
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg

--- a/metasim/scripts/teleop_xr.py
+++ b/metasim/scripts/teleop_xr.py
@@ -9,7 +9,11 @@ import numpy as np
 import torch
 from curobo.types.math import Pose
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.scenario import ScenarioCfg
 from metasim.cfg.sensors import PinholeCameraCfg

--- a/metasim/scripts/train_ppo.py
+++ b/metasim/scripts/train_ppo.py
@@ -3,7 +3,11 @@ import numpy as np
 import torch
 from gymnasium import spaces
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import DummyVecEnv
 

--- a/metasim/scripts/train_ppo_vec.py
+++ b/metasim/scripts/train_ppo_vec.py
@@ -15,7 +15,11 @@ import tyro
 from gymnasium import spaces
 from loguru import logger as log
 from packaging.version import Version
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 from stable_baselines3 import PPO
 from stable_baselines3.common.vec_env import VecEnv
 

--- a/metasim/test/state_consistency.py
+++ b/metasim/test/state_consistency.py
@@ -14,7 +14,11 @@ except ImportError:
 import torch
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from metasim.cfg.objects import ArticulationObjCfg, PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
 from metasim.cfg.scenario import ScenarioCfg

--- a/roboverse_learn/eval.py
+++ b/roboverse_learn/eval.py
@@ -16,7 +16,11 @@ import numpy as np
 import rootutils
 import tyro
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/roboverse_learn/eval_act.py
+++ b/roboverse_learn/eval_act.py
@@ -10,7 +10,11 @@ import rootutils
 import torch
 from loguru import logger as log
 from PIL import Image
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/roboverse_learn/eval_rdt.py
+++ b/roboverse_learn/eval_rdt.py
@@ -10,7 +10,11 @@ import rootutils
 import torch
 from loguru import logger as log
 from PIL import Image
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/roboverse_learn/eval_test_demo.py
+++ b/roboverse_learn/eval_test_demo.py
@@ -9,7 +9,11 @@ import numpy as np
 import rootutils
 from loguru import logger as log
 from PIL import Image
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/roboverse_learn/humanoidbench_rl/train_sb3.py
+++ b/roboverse_learn/humanoidbench_rl/train_sb3.py
@@ -11,7 +11,11 @@ import rootutils
 import wandb
 import yaml
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/roboverse_learn/rl/eval_rl.py
+++ b/roboverse_learn/rl/eval_rl.py
@@ -7,7 +7,11 @@ import imageio
 import numpy as np
 import rootutils
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 from roboverse_learn.rl.env import RLEnvWrapper
 

--- a/roboverse_learn/rl/train_rl.py
+++ b/roboverse_learn/rl/train_rl.py
@@ -5,7 +5,11 @@ import time
 
 import rootutils
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/roboverse_learn/train.py
+++ b/roboverse_learn/train.py
@@ -6,7 +6,11 @@ import time
 
 import rootutils
 from loguru import logger as log
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])

--- a/scripts/test_usd.py
+++ b/scripts/test_usd.py
@@ -59,7 +59,11 @@ from omni.isaac.lab.assets import (
     RigidObjectCfg,
 )
 from pxr import PhysxSchema
-from rich.logging import RichHandler
+
+try:
+    from rich.logging import RichHandler
+except ImportError:
+    RichHandler = None
 
 try:
     import omni.isaac.core.utils.prims as prim_utils


### PR DESCRIPTION
A handler (or any module) should not import all dependencies at the top level—especially optional or backend-specific ones. Instead, such imports should be deferred until they are needed, or wrapped in a try/except block to avoid unnecessary errors and dependency issues.