### PR TITLE
[bugfix] scenario randomization cfg terms missing to none

### DIFF
--- a/metasim/cfg/randomization.py
+++ b/metasim/cfg/randomization.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from dataclasses import MISSING
 from typing import Callable, Literal
 
 from metasim.utils.configclass import configclass
@@ -16,9 +15,9 @@ class FrictionRandomCfg:
     """Whether to randomize friction"""
     range: tuple[float, float] = (0.0, 0.0)
     """Friction sampling range"""
-    num_buckets: int = MISSING
+    num_buckets: int | None = None
     """Distribution buckets"""
-    dist_fn: Callable = MISSING
+    dist_fn: Callable | None = None
     """Distribution function, usually uniform or normal"""
 
 
@@ -30,7 +29,7 @@ class MassRandomCfg:
     """Whether to randomize mass"""
     range: tuple[float, float] = (0.0, 0.0)
     """Mass sampling range"""
-    dist_fn: Callable = MISSING
+    dist_fn: Callable | None = None
     """Distribution sampling function for all env, usually uniform or normal"""
 
 


### PR DESCRIPTION
When running basic replay demo script
```
python metasim/scripts/replay_demo.py --task=close_box --sim=mujoco       
```
I got error
```
/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_parsers.py:347: UserWarning: The field `random.friction.num-buckets` is annotated with type `<class 'int'>`, but the default value `<dataclasses._MISSING_TYPE object at 0x709339bbe5f0>` has type `<class 'dataclasses._MISSING_TYPE'>`. We'll try to handle this gracefully, but it may cause unexpected behavior.
  warnings.warn(message)
/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_parsers.py:347: UserWarning: The field `random.friction.dist-fn` is annotated with type `typing.Callable`, but the default value `<dataclasses._MISSING_TYPE object at 0x709339bbda50>` has type `<class 'dataclasses._MISSING_TYPE'>`. We'll try to handle this gracefully, but it may cause unexpected behavior.
  warnings.warn(message)
Traceback (most recent call last):
  File "/home/fs/cod/RoboVerse/metasim/scripts/replay_demo.py", line 66, in <module>
    args = tyro.cli(Args)
  File "/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_cli.py", line 197, in cli
    output = _cli_impl(
  File "/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_cli.py", line 411, in _cli_impl
    parser_spec = _parsers.ParserSpecification.from_callable_or_type(
  File "/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_parsers.py", line 121, in from_callable_or_type
    field_out = handle_field(
  File "/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_parsers.py", line 392, in handle_field
    return ParserSpecification.from_callable_or_type(
  File "/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_parsers.py", line 121, in from_callable_or_type
    field_out = handle_field(
  File "/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_parsers.py", line 392, in handle_field
    return ParserSpecification.from_callable_or_type(
  File "/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_parsers.py", line 121, in from_callable_or_type
    field_out = handle_field(
  File "/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_parsers.py", line 363, in handle_field
    subparsers_attempt = SubparsersSpecification.from_field(
  File "/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_parsers.py", line 587, in from_field
    subparser = ParserSpecification.from_callable_or_type(
  File "/home/fs/miniforge3/envs/metasim/lib/python3.10/site-packages/tyro/_parsers.py", line 108, in from_callable_or_type
    assert not isinstance(out, UnsupportedStructTypeMessage)
AssertionError
```
fixing with this PR solve the issue