### PR TITLE
Added fix to getstarted scripts0 for sapien envs

### DIFF
--- a/get_started/0_static_scene.py
+++ b/get_started/0_static_scene.py
@@ -157,6 +157,8 @@ if __name__ == "__main__":
         }
     ]
     handler.set_states(init_states)
+    if args.sim in ["sapien2", "sapien3"]:
+        handler.simulate()  # need step once to update the kinematics in sapien
     obs_tensor = handler.get_states(mode="tensor")  # get states as a tensor
 
     os.makedirs("get_started/output", exist_ok=True)


### PR DESCRIPTION
Sapien simulator requires step() to be called before accessing states.

```python
if args.sim in ["sapien2", "sapien3"]:
        handler.simulate()  # need step once to update the kinematics in sapien
```

is added to allow the physics to update.