### PR TITLE
[fix] fixed sapien2/3 get body state order error

### DIFF
--- a/metasim/sim/sapien/sapien2.py
+++ b/metasim/sim/sapien/sapien2.py
@@ -395,6 +395,12 @@ class Sapien2Handler(BaseSimHandler):
             link_name_list.append(link.get_name())
             link_state_list.append(link_state)
         link_state_tensor = torch.cat(link_state_list, dim=0)
+
+        # sort the links by name
+        sorted_indices = sorted(range(len(link_name_list)), key=lambda i: link_name_list[i])
+        link_name_list = [link_name_list[i] for i in sorted_indices]
+        link_state_tensor = link_state_tensor[sorted_indices]
+
         return link_name_list, link_state_tensor
 
     def _get_states(self, env_ids=None) -> list[DictEnvState]:

--- a/metasim/sim/sapien/sapien3.py
+++ b/metasim/sim/sapien/sapien3.py
@@ -487,6 +487,12 @@ class Sapien3Handler(BaseSimHandler):
             link_name_list.append(link.get_name())
             link_state_list.append(link_state)
         link_state_tensor = torch.cat(link_state_list, dim=0)
+
+        # sort the links by name
+        sorted_indices = sorted(range(len(link_name_list)), key=lambda i: link_name_list[i])
+        link_name_list = [link_name_list[i] for i in sorted_indices]
+        link_state_tensor = link_state_tensor[sorted_indices]
+
         return link_name_list, link_state_tensor
 
     def _get_states(self, env_ids=None) -> list[DictEnvState]:


### PR DESCRIPTION
Previously the body order returned by sapien2/3 are not in lexicographical order. Now fixed 