### PR TITLE
add libero90 kitchen scene1 and scene2 tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ view_mjcf.py
 /tools_libero
 /tools_libero/
 logdir/
+/libero_util
+/libero_traj_output
+libero_dataset
 
 # Old Repos
 UniRobo

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
     -   id: check-yaml
     -   id: check-toml
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.13.2
+    rev: v0.14.2
     hooks:
     -   id: ruff
         args: [ --fix ]

--- a/get_started/object_layout.py
+++ b/get_started/object_layout.py
@@ -1,0 +1,582 @@
+"""Keyboard object control - Real-time object manipulation with keyboard"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+import pygame
+import rootutils
+import torch
+import tyro
+
+rootutils.setup_root(__file__, pythonpath=True)
+
+from loguru import logger as log
+
+# Keep only the necessary metasim imports
+from metasim.scenario.cameras import PinholeCameraCfg
+from metasim.utils import configclass
+from metasim.utils.math import matrix_from_euler, quat_from_matrix, quat_mul
+from metasim.utils.setup_util import get_handler
+
+
+def save_poses_to_file(states, objects, robots, filename="saved_poses.py"):
+    """Save current poses of all objects and robots to a Python file"""
+    import datetime
+
+    timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    filename = filename.replace(".py", f"_{timestamp}.py")
+
+    with open(filename, "w") as f:
+        f.write('"""Saved poses from keyboard control"""\n\n')
+        f.write("import torch\n\n")
+        f.write("# Saved at: " + datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S") + "\n\n")
+        f.write("poses = {\n")
+        f.write('    "objects": {\n')
+
+        # Save objects
+        for obj in objects:
+            obj_name = obj.name
+            if obj_name in states[0]["objects"]:
+                obj_state = states[0]["objects"][obj_name]
+                pos = obj_state["pos"]
+                rot = obj_state["rot"]
+                f.write(f'        "{obj_name}": {{\n')
+                f.write(f'            "pos": torch.tensor([{pos[0]:.6f}, {pos[1]:.6f}, {pos[2]:.6f}]),\n')
+                f.write(f'            "rot": torch.tensor([{rot[0]:.6f}, {rot[1]:.6f}, {rot[2]:.6f}, {rot[3]:.6f}]),\n')
+                if obj_state.get("dof_pos"):
+                    f.write(f'            "dof_pos": {obj_state["dof_pos"]},\n')
+                f.write("        },\n")
+
+        f.write("    },\n")
+        f.write('    "robots": {\n')
+
+        # Save robots
+        for robot in robots:
+            robot_name = robot.name
+            if robot_name in states[0]["robots"]:
+                robot_state = states[0]["robots"][robot_name]
+                pos = robot_state["pos"]
+                rot = robot_state["rot"]
+                f.write(f'        "{robot_name}": {{\n')
+                f.write(f'            "pos": torch.tensor([{pos[0]:.6f}, {pos[1]:.6f}, {pos[2]:.6f}]),\n')
+                f.write(f'            "rot": torch.tensor([{rot[0]:.6f}, {rot[1]:.6f}, {rot[2]:.6f}, {rot[3]:.6f}]),\n')
+                if "dof_pos" in robot_state:
+                    f.write('            "dof_pos": {\n')
+                    for joint_name, joint_val in robot_state["dof_pos"].items():
+                        f.write(f'                "{joint_name}": {joint_val:.6f},\n')
+                    f.write("            },\n")
+                f.write("        },\n")
+
+        f.write("    },\n")
+        f.write("}\n")
+
+    return filename
+
+
+class ObjectKeyboardClient:
+    """Keyboard client for object and robot control"""
+
+    def __init__(
+        self,
+        entity_names: list[str],
+        entity_types: list[str],
+        entity_joints: dict[str, list[str]],  # entity_name -> list of joint names
+        width: int = 550,
+        height: int = 650,
+        title: str = "Object/Robot Control",
+    ):
+        pygame.init()
+        self.screen = pygame.display.set_mode((width, height))
+        pygame.display.set_caption(title)
+        self.clock = pygame.time.Clock()
+        self.font = pygame.font.Font(None, 28)
+        self.small_font = pygame.font.Font(None, 22)
+        self.tiny_font = pygame.font.Font(None, 18)
+
+        self.entity_names = entity_names  # All entities (objects + robots)
+        self.entity_types = entity_types  # 'object' or 'robot'
+        self.entity_joints = entity_joints  # joint names for each entity
+        self.selected_idx = 0
+
+        # Joint control mode
+        self.joint_mode = False
+        self.selected_joint_idx = 0
+
+        self.instructions = [
+            "=== Object/Robot Control ===",
+            "",
+            "   Movement:",
+            "     UP    - Move +X",
+            "     DOWN  - Move -X",
+            "     LEFT  - Move +Y",
+            "     RIGHT - Move -Y",
+            "     e     - Move +Z",
+            "     d     - Move -Z",
+            "",
+            "   Rotation:",
+            "     q     - Roll +",
+            "     w     - Roll -",
+            "     a     - Pitch +",
+            "     s     - Pitch -",
+            "     z     - Yaw +",
+            "     x     - Yaw -",
+            "",
+            "   Joint Control (when in joint mode):",
+            "     UP    - Increase angle",
+            "     DOWN  - Decrease angle",
+            "     LEFT  - Previous joint",
+            "     RIGHT - Next joint",
+            "",
+            "   Control:",
+            "     TAB   - Switch entity",
+            "     j     - Toggle joint mode",
+            "     c     - Save poses",
+            "     ESC   - Quit",
+        ]
+
+    def update(self) -> bool:
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                return False
+        return True
+
+    def get_selected_entity(self) -> tuple[str, str]:
+        """Returns (entity_name, entity_type)"""
+        return self.entity_names[self.selected_idx], self.entity_types[self.selected_idx]
+
+    def switch_entity(self):
+        """Switch to next entity (TAB key)"""
+        self.selected_idx = (self.selected_idx + 1) % len(self.entity_names)
+        name, etype = self.get_selected_entity()
+        self.selected_joint_idx = 0  # Reset joint selection
+
+        # Auto-exit joint mode if new entity has no joints
+        joints = self.entity_joints.get(name, [])
+        if self.joint_mode and not joints:
+            self.joint_mode = False
+            log.info(f"Auto-exited joint mode: {name} has no controllable joints")
+
+        etype_tag = "[R]" if etype == "robot" else "[O]"
+        joints = self.entity_joints.get(name, [])
+        joint_count = len(joints)
+
+        if joint_count > 0:
+            log.info(
+                f"Selected: {etype_tag} {name} ({self.selected_idx + 1}/{len(self.entity_names)}) - {joint_count} joints available"
+            )
+        else:
+            log.info(
+                f"Selected: {etype_tag} {name} ({self.selected_idx + 1}/{len(self.entity_names)}) - No controllable joints"
+            )
+
+    def toggle_joint_mode(self):
+        """Toggle joint control mode (J key)"""
+        name, _ = self.get_selected_entity()
+        joints = self.entity_joints.get(name, [])
+
+        if not joints:
+            log.warning(f"{name} has no controllable joints")
+            return
+
+        self.joint_mode = not self.joint_mode
+        self.selected_joint_idx = 0
+
+        if self.joint_mode:
+            log.info(f"Joint mode ENABLED for {name} ({len(joints)} joints)")
+        else:
+            log.info("Joint mode DISABLED")
+
+    def get_selected_joint(self) -> str | None:
+        """Get currently selected joint name"""
+        name, _ = self.get_selected_entity()
+        joints = self.entity_joints.get(name, [])
+        if joints and 0 <= self.selected_joint_idx < len(joints):
+            return joints[self.selected_joint_idx]
+        return None
+
+    def next_joint(self):
+        """Select next joint"""
+        name, _ = self.get_selected_entity()
+        joints = self.entity_joints.get(name, [])
+        if joints:
+            self.selected_joint_idx = (self.selected_joint_idx + 1) % len(joints)
+            log.info(f"Selected joint: {joints[self.selected_joint_idx]} ({self.selected_joint_idx + 1}/{len(joints)})")
+
+    def prev_joint(self):
+        """Select previous joint"""
+        name, _ = self.get_selected_entity()
+        joints = self.entity_joints.get(name, [])
+        if joints:
+            self.selected_joint_idx = (self.selected_joint_idx - 1) % len(joints)
+            log.info(f"Selected joint: {joints[self.selected_joint_idx]} ({self.selected_joint_idx + 1}/{len(joints)})")
+
+    def draw_instructions(self):
+        self.screen.fill((30, 30, 30))
+        y = 25
+
+        # Use unified instruction set
+        instructions = self.instructions
+
+        for instruction in instructions:
+            if not instruction:
+                y += 12
+                continue
+            color = (100, 200, 255) if "===" in instruction else (200, 200, 200)
+            font = self.font if "===" in instruction else self.small_font
+            text = font.render(instruction, True, color)
+            self.screen.blit(text, (25, y))
+            y += 30 if "===" in instruction else 24
+
+        y += 20
+
+        # Show joint info if in joint mode (static info only)
+        if self.joint_mode:
+            y += 35
+            joint_name = self.get_selected_joint()
+            name, _ = self.get_selected_entity()
+            joints = self.entity_joints.get(name, [])
+
+            if joint_name:
+                joint_text = f"Joint: {joint_name} ({self.selected_joint_idx + 1}/{len(joints)})"
+                text = self.small_font.render(joint_text, True, (255, 255, 100))
+                self.screen.blit(text, (25, y))
+
+        pygame.display.flip()
+        self.clock.tick(60)
+
+    def close(self):
+        pygame.quit()
+
+
+def process_input(dpos: float = 0.01, drot: float = 0.05, dangle: float = 0.02, joint_mode: bool = False):
+    """Process keyboard input - returns delta position, delta rotation, joint angle delta, and control flags"""
+    keys = pygame.key.get_pressed()
+
+    # Initialize persistent state
+    if not hasattr(process_input, "tab_pressed"):
+        process_input.tab_pressed = False
+        process_input.c_pressed = False
+        process_input.j_pressed = False
+        process_input.left_pressed = False
+        process_input.right_pressed = False
+
+    # In joint mode, arrow keys control joints
+    if joint_mode:
+        # UP/DOWN for angle adjustment
+        dangle_val = dangle * (keys[pygame.K_UP] - keys[pygame.K_DOWN])
+
+        # LEFT/RIGHT for joint selection (single press)
+        prev_joint = False
+        if keys[pygame.K_LEFT] and not process_input.left_pressed:
+            prev_joint = True
+            process_input.left_pressed = True
+        elif not keys[pygame.K_LEFT]:
+            process_input.left_pressed = False
+
+        next_joint = False
+        if keys[pygame.K_RIGHT] and not process_input.right_pressed:
+            next_joint = True
+            process_input.right_pressed = True
+        elif not keys[pygame.K_RIGHT]:
+            process_input.right_pressed = False
+
+        return None, None, dangle_val, False, False, True, prev_joint, next_joint
+
+    else:
+        # Normal mode: position and rotation control
+        # Movement (follow teleop convention)
+        dx = dpos * (keys[pygame.K_UP] - keys[pygame.K_DOWN])  # UP/DOWN for X
+        dy = dpos * (keys[pygame.K_LEFT] - keys[pygame.K_RIGHT])  # LEFT/RIGHT for Y
+        dz = dpos * (keys[pygame.K_e] - keys[pygame.K_d])  # e/d for Z
+
+        # Rotation (euler angles: roll, pitch, yaw)
+        droll = drot * (keys[pygame.K_q] - keys[pygame.K_w])  # q/w for roll
+        dpitch = drot * (keys[pygame.K_a] - keys[pygame.K_s])  # a/s for pitch
+        dyaw = drot * (keys[pygame.K_z] - keys[pygame.K_x])  # z/x for yaw
+
+        return [dx, dy, dz], [droll, dpitch, dyaw], 0.0, False, False, False, False, False
+
+    # Common controls (always checked after mode-specific logic)
+
+
+def process_common_input():
+    """Process common input (TAB, J, C, ESC) - separate function"""
+    keys = pygame.key.get_pressed()
+
+    if not hasattr(process_common_input, "tab_pressed"):
+        process_common_input.tab_pressed = False
+        process_common_input.c_pressed = False
+        process_common_input.j_pressed = False
+
+    switch = False
+    if keys[pygame.K_TAB] and not process_common_input.tab_pressed:
+        switch = True
+        process_common_input.tab_pressed = True
+    elif not keys[pygame.K_TAB]:
+        process_common_input.tab_pressed = False
+
+    save_poses = False
+    if keys[pygame.K_c] and not process_common_input.c_pressed:
+        save_poses = True
+        process_common_input.c_pressed = True
+    elif not keys[pygame.K_c]:
+        process_common_input.c_pressed = False
+
+    toggle_joint = False
+    if keys[pygame.K_j] and not process_common_input.j_pressed:
+        toggle_joint = True
+        process_common_input.j_pressed = True
+    elif not keys[pygame.K_j]:
+        process_common_input.j_pressed = False
+
+    return switch, save_poses, toggle_joint
+
+
+if __name__ == "__main__":
+
+    @configclass
+    class Args:
+        robot: str = "franka"
+        sim: Literal["isaacsim", "isaacgym", "genesis", "pybullet", "sapien2", "sapien3", "mujoco", "mjx"] = "mujoco"
+        num_envs: int = 1
+        headless: bool = False
+        step_size: float = 0.01
+        rot_size: float = 0.05
+        angle_size: float = 0.02  # Joint angle adjustment step size
+        print_interval: int = 50
+
+        def __post_init__(self):
+            log.info(f"Args: {self}")
+
+    args = tyro.cli(Args)
+
+    # Replace ad-hoc scenario with task scenario
+    from roboverse_pack.tasks.libero_90.libero_kitchen_scene1_open_drawer_put_bowl import (
+        LiberoKitchenOpenDrawerPutBowlTask as _Task,
+    )
+
+    scenario = _Task.scenario.update(
+        robots=[args.robot],
+        headless=args.headless,
+        num_envs=args.num_envs,
+        simulator=args.sim,
+        cameras=[PinholeCameraCfg(width=1024, height=1024, pos=(1.5, -1.5, 1.5), look_at=(0.0, 0.0, 0.0))],
+    )
+
+    log.info(f"Using simulator: {args.sim}")
+    handler = get_handler(scenario)
+
+    init_states = [
+        {
+            "objects": {
+                "wooden_cabinet": {
+                    "pos": torch.tensor([0.009487758146743611, -0.30807493267210423, 0.905]),
+                    "rot": torch.tensor([6.123233995736766e-17, 0.0, 0.0, 1.0]),
+                    "dof_pos": {
+                        "top_level": 0.0,
+                        "middle_level": 0.0,
+                        "bottom_level": 0.0,
+                    },
+                },
+                "akita_black_bowl": {
+                    "pos": torch.tensor([0.012230005405043189, 0.011573901059802013, 0.8981585151399347]),
+                    "rot": torch.tensor([
+                        0.7071067776242912,
+                        -1.0724537191719106e-05,
+                        -1.4310617004710356e-06,
+                        0.7071067846660275,
+                    ]),
+                },
+                "plate": {
+                    "pos": torch.tensor([-0.021242529331592822, 0.23429697944573386, 0.9023145976636144]),
+                    "rot": torch.tensor([
+                        0.7071068944202988,
+                        -1.013777001383946e-05,
+                        2.0046027443782938e-05,
+                        0.7071066675959596,
+                    ]),
+                },
+            },
+            "robots": {
+                "franka": {
+                    "pos": torch.tensor([-0.66, 0.0, 0.912]),
+                    "rot": torch.tensor([1.0, 0.0, 0.0, 0.0]),
+                    "dof_pos": {
+                        "panda_joint1": 0.01600639,
+                        "panda_joint2": -0.14575404,
+                        "panda_joint3": -0.02947152,
+                        "panda_joint4": -2.42612482,
+                        "panda_joint5": 0.02332437,
+                        "panda_joint6": 2.2185957,
+                        "panda_joint7": 0.77954786,
+                        "panda_finger_joint1": 0.03407744,
+                        "panda_finger_joint2": -0.03403489,
+                    },
+                },
+            },
+        }
+    ]
+    handler.set_states(init_states * scenario.num_envs)
+
+    # Build entity list: objects first, then robots
+    entity_names = [obj.name for obj in scenario.objects] + [robot.name for robot in scenario.robots]
+    entity_types = ["object"] * len(scenario.objects) + ["robot"] * len(scenario.robots)
+
+    # Get joint information for each entity
+    entity_joints = {}
+
+    # Get joints from objects (articulated objects)
+    for obj in scenario.objects:
+        if hasattr(obj, "actuators") and obj.actuators:
+            entity_joints[obj.name] = list(obj.actuators.keys())
+        else:
+            # Try to get from init states
+            obj_state = init_states[0]["objects"].get(obj.name)
+            if obj_state:
+                dof_pos = obj_state.get("dof_pos")
+                if dof_pos:
+                    entity_joints[obj.name] = list(dof_pos.keys())
+                else:
+                    entity_joints[obj.name] = []
+            else:
+                entity_joints[obj.name] = []
+
+    # Get joints from robots
+    for robot in scenario.robots:
+        if hasattr(robot, "actuators") and robot.actuators:
+            entity_joints[robot.name] = list(robot.actuators.keys())
+        else:
+            # Try to get from init states
+            robot_state = init_states[0]["robots"].get(robot.name)
+            if robot_state:
+                dof_pos = robot_state.get("dof_pos")
+                if dof_pos:
+                    entity_joints[robot.name] = list(dof_pos.keys())
+                else:
+                    entity_joints[robot.name] = []
+            else:
+                entity_joints[robot.name] = []
+
+    keyboard_client = ObjectKeyboardClient(entity_names, entity_types, entity_joints)
+
+    log.info("Keyboard Object/Robot Control")
+    log.info("Use Arrow keys + e/d for position, q/w/a/s/z/x for rotation")
+    log.info("Press J to enter joint control mode")
+    log.info("TAB to switch entity, C to save poses, ESC to quit\n")
+
+    os.makedirs("get_started/output", exist_ok=True)
+
+    step = 0
+    running = True
+
+    while running:
+        running = keyboard_client.update()
+        if not running or (keyboard_client.update() and pygame.key.get_pressed()[pygame.K_ESCAPE]):
+            break
+
+        # Process common input (TAB, J, C)
+        switch, save_poses, toggle_joint = process_common_input()
+
+        if switch:
+            keyboard_client.switch_entity()
+
+        if toggle_joint:
+            keyboard_client.toggle_joint_mode()
+
+        # Save poses when C is pressed
+        if save_poses:
+            current_states = handler.get_states(mode="dict")
+            saved_file = save_poses_to_file(
+                current_states, scenario.objects, scenario.robots, filename="get_started/output/saved_poses.py"
+            )
+            log.info(f"Poses saved to: {saved_file}")
+
+        # Process mode-specific input
+        delta_pos, delta_rot, delta_angle, _, _, in_joint_mode, prev_joint, next_joint = process_input(
+            dpos=args.step_size, drot=args.rot_size, dangle=args.angle_size, joint_mode=keyboard_client.joint_mode
+        )
+
+        # Handle joint selection
+        if prev_joint:
+            keyboard_client.prev_joint()
+        if next_joint:
+            keyboard_client.next_joint()
+
+        # Get current selection for control logic
+        selected_name, selected_type = keyboard_client.get_selected_entity()
+
+        keyboard_client.draw_instructions()
+
+        # Handle joint mode updates
+        if keyboard_client.joint_mode and abs(delta_angle) > 1e-6:
+            joint_name = keyboard_client.get_selected_joint()
+            if joint_name:
+                states = handler.get_states(mode="dict")
+                for env_idx in range(scenario.num_envs):
+                    if selected_type == "object" and selected_name in states[env_idx]["objects"]:
+                        if "dof_pos" in states[env_idx]["objects"][selected_name]:
+                            if joint_name in states[env_idx]["objects"][selected_name]["dof_pos"]:
+                                states[env_idx]["objects"][selected_name]["dof_pos"][joint_name] += delta_angle
+
+                    elif selected_type == "robot" and selected_name in states[env_idx]["robots"]:
+                        if "dof_pos" in states[env_idx]["robots"][selected_name]:
+                            if joint_name in states[env_idx]["robots"][selected_name]["dof_pos"]:
+                                states[env_idx]["robots"][selected_name]["dof_pos"][joint_name] += delta_angle
+
+                handler.set_states(states)
+
+        # Handle normal mode updates (position/rotation)
+        elif not keyboard_client.joint_mode and delta_pos is not None and delta_rot is not None:
+            delta_pos_tensor = torch.tensor(delta_pos)
+            delta_rot_tensor = torch.tensor(delta_rot)
+
+            has_input = delta_pos_tensor.abs().sum() > 0 or delta_rot_tensor.abs().sum() > 0
+
+            if has_input:
+                states = handler.get_states(mode="dict")
+                for env_idx in range(scenario.num_envs):
+                    # Check if it's an object or robot
+                    if selected_type == "object" and selected_name in states[env_idx]["objects"]:
+                        # Update position
+                        if delta_pos_tensor.abs().sum() > 0:
+                            pos = states[env_idx]["objects"][selected_name]["pos"]
+                            new_pos = pos + delta_pos_tensor
+                            states[env_idx]["objects"][selected_name]["pos"] = new_pos
+
+                        # Update rotation
+                        if delta_rot_tensor.abs().sum() > 0:
+                            current_rot = states[env_idx]["objects"][selected_name]["rot"]
+                            delta_rot_mat = matrix_from_euler(delta_rot_tensor.unsqueeze(0), "XYZ")
+                            delta_quat = quat_from_matrix(delta_rot_mat)[0]
+                            new_rot = quat_mul(current_rot.unsqueeze(0), delta_quat.unsqueeze(0))[0]
+                            states[env_idx]["objects"][selected_name]["rot"] = new_rot
+
+                    elif selected_type == "robot" and selected_name in states[env_idx]["robots"]:
+                        # Update position
+                        if delta_pos_tensor.abs().sum() > 0:
+                            pos = states[env_idx]["robots"][selected_name]["pos"]
+                            new_pos = pos + delta_pos_tensor
+                            states[env_idx]["robots"][selected_name]["pos"] = new_pos
+
+                        # Update rotation
+                        if delta_rot_tensor.abs().sum() > 0:
+                            current_rot = states[env_idx]["robots"][selected_name]["rot"]
+                            delta_rot_mat = matrix_from_euler(delta_rot_tensor.unsqueeze(0), "XYZ")
+                            delta_quat = quat_from_matrix(delta_rot_mat)[0]
+                            new_rot = quat_mul(current_rot.unsqueeze(0), delta_quat.unsqueeze(0))[0]
+                            states[env_idx]["robots"][selected_name]["rot"] = new_rot
+
+                handler.set_states(states)
+
+        handler.simulate()
+
+        if step % 10 == 0:
+            handler.refresh_render()
+        step += 1
+
+    keyboard_client.close()
+    handler.close()
+
+    log.info(f"Done (steps: {step})")

--- a/metasim/utils/hf_util.py
+++ b/metasim/utils/hf_util.py
@@ -165,7 +165,8 @@ class FileDownloader:
             self._add(obj.mjx_mjcf_path)
 
     def _add(self, filepath: str):
-        self.files_to_download.append(filepath)
+        if filepath is not None:
+            self.files_to_download.append(filepath)
 
     def do_it(self):
         """Download the files specified in the scenario."""

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene1_open_bottom_drawer.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene1_open_bottom_drawer.py
@@ -12,7 +12,7 @@ from metasim.task.registry import register_task
 from .libero_90_base import Libero90BaseTask
 
 
-@register_task("libero_90.kitchen_open_bottom_drawer", "kitchen_open_bottom_drawer")
+@register_task("libero_90.kitchen_scene1_open_bottom_drawer", "kitchen_open_bottom_drawer")
 class LiberoKitchenOpenBottomDrawerTask(Libero90BaseTask):
     """Configuration for the Libero kitchen open bottom drawer task.
 
@@ -24,7 +24,7 @@ class LiberoKitchenOpenBottomDrawerTask(Libero90BaseTask):
 
     This is a manipulation task that requires:
     1. Grasping and manipulating the cabinet drawer (articulated object)
-    2. Opening the bottom drawer to the required position
+    2. Opening the bottom drawer to the required positionw2
 
     Objects from BDDL:
     - wooden_cabinet_1 (fixture): The cabinet with drawers
@@ -39,23 +39,23 @@ class LiberoKitchenOpenBottomDrawerTask(Libero90BaseTask):
             # Movable objects (from BDDL :objects section)
             RigidObjCfg(
                 name="akita_black_bowl",
-                physics=PhysicStateType.RIGIDBODY,
                 usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
             ),
             RigidObjCfg(
                 name="plate",
-                physics=PhysicStateType.RIGIDBODY,
                 usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+                physics=PhysicStateType.RIGIDBODY,
             ),
             # Fixed fixtures (from BDDL :fixtures section)
             # Note: kitchen_table is handled by the scene/arena
             ArticulationObjCfg(
                 name="wooden_cabinet",
-                fix_base_link= True,
+                fix_base_link=True,
                 usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
                 urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
@@ -65,7 +65,7 @@ class LiberoKitchenOpenBottomDrawerTask(Libero90BaseTask):
         # Scene configuration (from BDDL problem domain)
         scene=SceneCfg(
             name="libero_kitchen_tabletop",
-            mjcf_path="roboverse_data/LIBERO/libero/libero/assets/scenes/libero_kitchen_tabletop_base_style.xml",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
         ),
     )
 
@@ -88,4 +88,15 @@ class LiberoKitchenOpenBottomDrawerTask(Libero90BaseTask):
     )
 
     # Trajectory file path
-    traj_filepath = "libero_traj_output/libero_90_kitchen_scene1_traj_v2.pkl"
+    traj_filepath = "roboverse_data/trajs/libero90/libero_90_kitchen_scene1_traj_v2.pkl"
+
+    # # rewrite terminate
+    # def _terminated(self, states: TensorState) -> torch.Tensor:
+    #     """No terminate condition yet. Will terminate when time is up."""
+    #     return torch.tensor([False])
+
+    # # rewrite checker
+    # def reset(self, states=None, env_ids=None):
+    #     """Skip checker reset."""
+    #     states = super(Libero90BaseTask, self).reset(states, env_ids)
+    #     return states

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene1_open_drawer_put_bowl.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene1_open_drawer_put_bowl.py
@@ -1,0 +1,141 @@
+"""Configuration for the Libero kitchen open drawer and put bowl task."""
+
+from __future__ import annotations
+
+import torch
+
+from metasim.constants import PhysicStateType
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+from metasim.types import TensorState
+from metasim.utils.math import matrix_from_quat
+
+from .libero_90_base import Libero90BaseTask
+
+
+def pose_to_mat(pos: torch.Tensor, quat: torch.Tensor | None = None) -> torch.Tensor:
+    """Build homogeneous transforms (N,4,4) from batched pos (N,3) and optional quat (N,4).
+
+    If quat is None, rotation is identity for all N.
+    """
+    assert pos.dim() == 2 and pos.shape[-1] == 3, "pos must be (N,3)"
+    N = pos.shape[0]
+    T = torch.eye(4, dtype=pos.dtype, device=pos.device).unsqueeze(0).repeat(N, 1, 1)
+    if quat is None:
+        R = torch.eye(3, dtype=pos.dtype, device=pos.device).unsqueeze(0).repeat(N, 1, 1)
+    else:
+        assert quat.shape == (N, 4), "quat must be (N,4)"
+        R = matrix_from_quat(quat)  # (N,3,3)
+    T[:, :3, :3] = R
+    T[:, :3, 3] = pos
+    return T
+
+
+@register_task("libero_90.kitchen_scene1_open_drawer_put_bowl", "kitchen_open_drawer_put_bowl")
+class LiberoKitchenOpenDrawerPutBowlTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen open drawer and put bowl task.
+
+    This task is transferred from:
+    KITCHEN_SCENE1_open_the_top_drawer_of_the_cabinet_and_put_the_bowl_in_it.bddl
+
+    Task Description:
+    - Open the top drawer of the wooden cabinet
+    - Put the akita black bowl into the top drawer
+
+    This is a complex manipulation task that requires:
+    1. Grasping and manipulating the cabinet drawer (articulated object)
+    2. Opening the top drawer to the required position
+    3. Picking up the bowl from the table
+    4. Placing the bowl inside the opened drawer
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1 (object): Bowl to be placed in the drawer
+    - plate_1 (object): Plate on the table (distractor)
+
+    Goal: (And (Open wooden_cabinet_1_top_region) (In akita_black_bowl_1 wooden_cabinet_1_top_region))
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            # Movable objects (from BDDL :objects section)
+            RigidObjCfg(
+                name="akita_black_bowl",  # 碗的位置似乎不对，在libero里换角度观察
+                physics=PhysicStateType.RIGIDBODY,
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+            ),
+            RigidObjCfg(
+                name="plate",
+                physics=PhysicStateType.RIGIDBODY,
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+            ),
+            # Fixed fixtures (from BDDL :fixtures section)
+            # Note: kitchen_table is handled by the scene/arena
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        # Scene configuration (from BDDL problem domain)
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    # Task parameters
+    max_episode_steps = 500  # Complex task requiring two subtasks
+    task_desc = "Open the top drawer of the cabinet and put the bowl in it"
+
+    # Workspace configuration (from BDDL regions)
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.91),)  # kitchen_table_offset
+    workspace_size = ((1.0, 1.2, 0.05),)  # kitchen_table_full_size
+
+    traj_filepath = "roboverse_data/trajs/libero90/libero_90_kitchen_scene1_open_the_top_drawer_of_the_cabinet_and_put_the_bowl_in_it_traj_v2.pkl"
+
+    # env.handler.get_states[0]['objects']['wooden_cabinet']['dof_pos']["top_level"] 获取top
+    def _terminated(self, states: TensorState) -> torch.Tensor:  # 需要仔细检查一下
+        """Task success checker."""
+        # get bowl/cabinet poses
+        bowl_pos = states.objects["akita_black_bowl"].root_state[:, :3]  # (N,3)
+        cabinet_pos = states.objects["wooden_cabinet"].root_state[:, :3]  # (N,3)
+        cabinet_quat = states.objects["wooden_cabinet"].root_state[:, 3:7]  # (N,4)
+        top_idx = self.handler.get_joint_names("wooden_cabinet").index("top_level")
+        bbox_displacement = self.handler.get_states(mode="tensor").objects["wooden_cabinet"].joint_pos[:, top_idx]
+        # Build homogeneous transforms (N,4,4)
+        # bowl_T = pose_to_mat(bowl_pos, None)              # identity rotation
+        cabinet_T = pose_to_mat(cabinet_pos, cabinet_quat)
+        # get top drawer T
+        bbox_relative_pos = torch.tensor(
+            [0.00328, 0.01128 + bbox_displacement, 0.18563], device=bowl_pos.device
+        )  # relative to cabinet frame
+        bbox_relative_quat = torch.tensor([0.70711, 0.00000, 0.70711, 0.00000], device=bowl_pos.device)
+        bbox_relative_T = pose_to_mat(bbox_relative_pos.unsqueeze(0), bbox_relative_quat.unsqueeze(0))  # (1,4,4)
+        bbox_half_size = torch.tensor([0.02993, 0.07561, 0.10224], device=bowl_pos.device)  # (3,) 需要进一步确认
+        # Compose with cabinet_T to get bbox transform in world coordinates (N,4,4)
+        bbox_T_world = torch.matmul(cabinet_T, bbox_relative_T)
+        # Transform bowl position into bbox local frame and test inclusion
+        R = bbox_T_world[:, :3, :3]  # (N,3,3)
+        t = bbox_T_world[:, :3, 3]  # (N,3)
+        bowl_local = torch.matmul(R.transpose(1, 2), (bowl_pos - t).unsqueeze(-1)).squeeze(-1)  # (N,3)
+        eps = 1e-6
+        inside = (bowl_local.abs() <= (bbox_half_size.unsqueeze(0) + eps)).all(dim=-1)  # (N,)
+
+        return inside
+
+    # rewrite checker
+    def reset(self, states=None, env_ids=None):
+        """Skip checker reset."""
+        states = super(Libero90BaseTask, self).reset(states, env_ids)
+        return states

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene1_open_top_drawer.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene1_open_top_drawer.py
@@ -1,0 +1,93 @@
+"""Configuration for the Libero kitchen open top drawer task."""
+
+from __future__ import annotations
+
+from metasim.constants import PhysicStateType
+from metasim.example.example_pack.tasks.checkers import JointPosChecker
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+
+from .libero_90_base import Libero90BaseTask
+
+
+@register_task("libero_90.kitchen_scene1_open_top_drawer", "kitchen_open_top_drawer")
+class LiberoKitchenOpenTopDrawerTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen open top drawer task.
+
+    This task is transferred from:
+    KITCHEN_SCENE1_open_the_top_drawer_of_the_cabinet_demo.bddl
+
+    Task Description:
+    - Open the top drawer of the wooden cabinet
+
+    This is a manipulation task that requires:
+    1. Grasping and manipulating the cabinet drawer (articulated object)
+    2. Opening the top drawer to the required position
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1 (object): Bowl on the table
+    - plate_1 (object): Plate on the table
+
+    Goal: (Open wooden_cabinet_1_top_region)
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            # Movable objects (from BDDL :objects section)
+            RigidObjCfg(
+                name="akita_black_bowl",
+                physics=PhysicStateType.RIGIDBODY,
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+            ),
+            RigidObjCfg(
+                name="plate",
+                physics=PhysicStateType.RIGIDBODY,
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+            ),
+            # Fixed fixtures (from BDDL :fixtures section)
+            # Note: kitchen_table is handled by the scene/arena
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        # Scene configuration (from BDDL problem domain)
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    # Task parameters
+    max_episode_steps = 300  # Moderate complexity task
+    task_desc = "Open the top drawer of the cabinet"
+
+    # Workspace configuration (from BDDL regions)
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.91),)  # kitchen_table_offset
+    workspace_size = ((1.0, 1.2, 0.05),)  # kitchen_table_full_size
+
+    # Checker: top drawer must be open
+    # Use JointPosChecker to check if the drawer joint position exceeds threshold
+    checker = JointPosChecker(
+        obj_name="wooden_cabinet",
+        joint_name="top_level",  # Assuming this is the joint name for the top drawer
+        mode="le",  # greater than or equal to
+        radian_threshold=-0.1,  # Minimum opening distance (in radians)
+    )
+
+    # Trajectory file path
+    traj_filepath = (
+        "roboverse_data/trajs/libero90/libero_90_kitchen_scene1_open_the_top_drawer_of_the_cabinet_traj_v2.pkl"
+    )

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene1_put_the_black_bowl_on_the_plate.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene1_put_the_black_bowl_on_the_plate.py
@@ -1,0 +1,132 @@
+"""Configuration for the Libero kitchen put the black bowl on the plate task."""
+
+from __future__ import annotations
+
+import torch
+
+from metasim.constants import PhysicStateType
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+from metasim.types import TensorState
+
+from .libero_90_base import Libero90BaseTask
+
+
+@register_task(
+    "libero_90.kitchen_scene1_put_the_black_bowl_on_the_plate", "kitchen_scene1_put_the_black_bowl_on_the_plate"
+)
+class LiberoKitchen1PutBowlOnPlateTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen put the black bowl on the plate task.
+
+    This task is transferred from:
+    KITCHEN_SCENE1_put_the_black_bowl_on_the_plate.bddl
+
+    Task Description:
+    - Put the akita black bowl on the plate
+
+    This is a manipulation task that requires:
+    1. Grasping the akita black bowl
+    2. Placing it on top of the plate
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1 (object): Bowl to be placed on the plate
+    - plate_1 (object): Target plate
+
+    Goal: (On akita_black_bowl_1 plate_1)
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            # Movable objects (from BDDL :objects section)
+            RigidObjCfg(
+                name="akita_black_bowl",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="plate",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            # Fixed fixtures (from BDDL :fixtures section)
+            # Note: kitchen_table is handled by the scene/arena
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        # Scene configuration (from BDDL problem domain)
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    # Task parameters
+    max_episode_steps = 300  # Moderate complexity task
+    task_desc = "Put the black bowl on the plate"
+
+    # Workspace configuration (from BDDL regions)
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.90),)  # kitchen_table_offset
+    workspace_size = ((1.0, 1.2, 0.05),)  # kitchen_table_full_size
+
+    # Checker: bowl must be on the plate (within detection region above plate)
+    # checker = DetectedChecker(
+    #     obj_name="akita_black_bowl",
+    #     detector=RelativeBboxDetector(
+    #         base_obj_name="plate",
+    #         relative_pos=(0.0, 0.0, 0.05),  # Slightly above the plate center
+    #         relative_quat=(1.0, 0.0, 0.0, 0.0),  # Identity rotation
+    #         checker_lower=(-0.1, -0.1, -0.02),  # Detection region half-size
+    #         checker_upper=(0.1, 0.1, 0.1),
+    #         ignore_base_ori=True,
+    #         debug_vis=False,
+    #         name="plate_region",
+    #         fixed=True,
+    #     ),
+    # )
+
+    # Trajectory file path
+    traj_filepath = "roboverse_data/trajs/libero90/libero_90_kitchen_scene1_put_the_black_bowl_on_the_plate_traj_v2.pkl"
+
+    # env.handler.get_states[0]['objects']['wooden_cabinet']['dof_pos']["top_level"] 获取top
+    def _terminated(self, states: TensorState) -> torch.Tensor:
+        """Task success checker."""
+        bowl_pos = states.objects["akita_black_bowl"].root_state[:, :3]  # (N,3)
+        plate_pos = states.objects["plate"].root_state[:, :3]  # (N,3)
+        # Check if bowl is within a small region above the plate
+        range_threshold = 0.06  # Radius of the range in xy plane
+        height_threshold = 0.03  # Height threshold above the plate
+
+        # Calculate xy distance between bowl and plate
+        xy_distance = torch.norm(bowl_pos[:, :2] - plate_pos[:, :2], dim=-1)  # (N,)
+        # Calculate height difference (bowl z - plate z)
+        height_diff = bowl_pos[:, 2] - plate_pos[:, 2]  # (N,)
+        # Check both conditions: xy distance < range AND 0 < height_diff < height_threshold
+        xy_close = xy_distance < range_threshold  # (N,)
+        height_valid = (height_diff > 0) & (height_diff < height_threshold)  # (N,)
+
+        is_on_plate = xy_close & height_valid  # (N,)
+
+        # print('xy_distance:', xy_distance)
+        # print('height_diff:', height_diff)
+        # print('is_on_plate:', is_on_plate)
+        return is_on_plate
+
+    # rewrite checker
+    def reset(self, states=None, env_ids=None):
+        """Skip checker reset."""
+        states = super(Libero90BaseTask, self).reset(states, env_ids)
+        return states

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene1_put_the_black_bowl_on_top_of_the_cabinet.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene1_put_the_black_bowl_on_top_of_the_cabinet.py
@@ -1,0 +1,131 @@
+"""Configuration for the Libero kitchen put the black bowl on top of the cabinet task."""
+
+from __future__ import annotations
+
+import torch
+
+from metasim.constants import PhysicStateType
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+from metasim.types import TensorState
+from metasim.utils.math import matrix_from_quat
+
+from .libero_90_base import Libero90BaseTask
+
+
+def pose_to_mat(pos: torch.Tensor, quat: torch.Tensor | None = None) -> torch.Tensor:
+    """Build homogeneous transforms (N,4,4) from batched pos (N,3) and optional quat (N,4).
+
+    If quat is None, rotation is identity for all N.
+    """
+    assert pos.dim() == 2 and pos.shape[-1] == 3, "pos must be (N,3)"
+    N = pos.shape[0]
+    T = torch.eye(4, dtype=pos.dtype, device=pos.device).unsqueeze(0).repeat(N, 1, 1)
+    if quat is None:
+        R = torch.eye(3, dtype=pos.dtype, device=pos.device).unsqueeze(0).repeat(N, 1, 1)
+    else:
+        assert quat.shape == (N, 4), "quat must be (N,4)"
+        R = matrix_from_quat(quat)  # (N,3,3)
+    T[:, :3, :3] = R
+    T[:, :3, 3] = pos
+    return T
+
+
+@register_task(
+    "libero_90.kitchen_scene1_put_the_black_bowl_on_top_of_the_cabinet",
+    "kitchen_scene1_put_the_black_bowl_on_top_of_the_cabinet",
+)
+class LiberoKitchen1PutBowlOnCabinetTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen put the black bowl on top of the cabinet task.
+
+    This task is transferred from:
+    KITCHEN_SCENE1_put_the_black_bowl_on_top_of_the_cabinet.bddl
+
+    Task Description:
+    - Put the akita black bowl on top of the cabinet
+
+    This is a manipulation task that requires:
+    1. Grasping the akita black bowl
+    2. Placing it on top of the cabinet
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1 (object): Bowl to be placed on the cabinet
+    - plate_1 (object): Distractor plate
+
+    Goal: (On akita_black_bowl_1 wooden_cabinet_1_top_surface)
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            RigidObjCfg(
+                name="akita_black_bowl",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="plate",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    max_episode_steps = 300
+    task_desc = "Put the black bowl on top of the cabinet"
+
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.90),)
+    workspace_size = ((1.0, 1.2, 0.05),)
+
+    traj_filepath = (
+        "roboverse_data/trajs/libero90/libero_90_kitchen_scene1_put_the_black_bowl_on_top_of_the_cabinet_traj_v2.pkl"
+    )
+
+    def _terminated(self, states: TensorState) -> torch.Tensor:
+        """Task success checker."""
+        bowl_pos = states.objects["akita_black_bowl"].root_state[:, :3]  # (N,3)
+        cabinet_pos = states.objects["wooden_cabinet"].root_state[:, :3]  # (N,3)
+        cabinet_quat = states.objects["wooden_cabinet"].root_state[:, 3:7]  # (N,4)
+        # cabinet_T = pose_to_mat(cabinet_pos, cabinet_quat)
+        # manually set bbox lower/upper bound (cabinet local coordinate system)
+        bbox_lower = torch.tensor([-0.12, -0.076, 0.22], device=bowl_pos.device)  # x-, y-, z-
+        bbox_upper = torch.tensor([0.13, 0.11, 0.22 + 0.05], device=bowl_pos.device)  # x+, y+, z+
+        # cabinet rotation matrix
+        R = matrix_from_quat(cabinet_quat)  # (N,3,3)
+        # bowl in cabinet local coordinate system
+        bowl_local = torch.matmul(R.transpose(1, 2), (bowl_pos - cabinet_pos).unsqueeze(-1)).squeeze(-1)  # (N,3)
+        # check each direction within lower/upper bound
+        ge_lower = bowl_local >= bbox_lower  # (N,3)
+        le_upper = bowl_local <= bbox_upper  # (N,3)
+        inside = (ge_lower & le_upper).all(dim=-1)
+
+        # print('bowl_local >= bbox_lower:', ge_lower)
+        # print('bowl_local <= bbox_upper:', le_upper)
+        # print('Bowl local position:', bowl_local)
+        # print('bbox center', cabinet_pos + torch.tensor([0, 0, 0.25], device=cabinet_pos.device))
+        # print('Bowl on top of the cabinet:', inside)
+        return inside
+
+    def reset(self, states=None, env_ids=None):
+        """Skip checker reset."""
+        states = super(Libero90BaseTask, self).reset(states, env_ids)
+        return states

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_open_the_top_drawer_of_the_cabinet.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_open_the_top_drawer_of_the_cabinet.py
@@ -1,0 +1,99 @@
+"""Configuration for the Libero kitchen scene2 open the top drawer of the cabinet task."""
+
+from __future__ import annotations
+
+from metasim.constants import PhysicStateType
+from metasim.example.example_pack.tasks.checkers import JointPosChecker
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+
+from .libero_90_base import Libero90BaseTask
+
+
+@register_task(
+    "libero_90.kitchen_scene2_open_the_top_drawer_of_the_cabinet", "kitchen_scene2_open_the_top_drawer_of_the_cabinet"
+)
+class LiberoKitchenScene2OpenTopDrawerTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen scene2 open the top drawer of the cabinet task.
+
+    This task is transferred from:
+    KITCHEN_SCENE2_open_the_top_drawer_of_the_cabinet.bddl
+
+    Task Description:
+    - Open the top drawer of the wooden cabinet (scene2)
+
+    This is a manipulation task that requires:
+    1. Grasping and manipulating the cabinet drawer (articulated object)
+    2. Opening the top drawer to the required position
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1/2/3 (object): Three bowls on the table
+
+    Goal: (Open wooden_cabinet_1_top_region)
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            RigidObjCfg(
+                name="akita_black_bowl_1",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_2",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_3",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="plate",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    max_episode_steps = 300
+    task_desc = "Open the top drawer of the cabinet (scene2)"
+
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.90),)
+    workspace_size = ((1.0, 1.2, 0.05),)
+
+    checker = JointPosChecker(
+        obj_name="wooden_cabinet",
+        joint_name="top_level",
+        mode="le",
+        radian_threshold=-0.1,
+    )
+
+    traj_filepath = (
+        "roboverse_data/trajs/libero90/libero_90_kitchen_scene2_open_the_top_drawer_of_the_cabinet_traj_v2.pkl"
+    )

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_put_the_black_bowl_at_the_back_on_the_plate.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_put_the_black_bowl_at_the_back_on_the_plate.py
@@ -1,0 +1,114 @@
+"""Configuration for the Libero kitchen scene2 put the black bowl at the back on the plate task."""
+
+from __future__ import annotations
+
+import torch
+
+from metasim.constants import PhysicStateType
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+from metasim.types import TensorState
+
+from .libero_90_base import Libero90BaseTask
+
+
+@register_task(
+    "libero_90.kitchen_scene2_put_the_black_bowl_at_the_back_on_the_plate",
+    "kitchen_scene2_put_the_black_bowl_at_the_back_on_the_plate",
+)
+class LiberoKitchenScene2PutBowlAtBackOnPlateTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen scene2 put the black bowl at the back on the plate task.
+
+    This task is transferred from:
+    KITCHEN_SCENE2_put_the_black_bowl_at_the_back_on_the_plate.bddl
+
+    Task Description:
+    - Put the akita black bowl at the back (bowl_3) on the plate
+
+    This is a manipulation task that requires:
+    1. Grasping akita_black_bowl_3
+    2. Placing it on top of the plate
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1/2/3 (object): Three bowls on the table
+    - plate_1 (object): Target plate
+
+    Goal: (On akita_black_bowl_3 plate_1)
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            RigidObjCfg(
+                name="akita_black_bowl_1",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_2",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_3",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="plate",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    max_episode_steps = 300
+    task_desc = "Put the black bowl at the back (bowl_3) on the plate (scene2)"
+
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.90),)
+    workspace_size = ((1.0, 1.2, 0.05),)
+
+    traj_filepath = (
+        "roboverse_data/trajs/libero90/libero_90_kitchen_scene2_put_the_black_bowl_at_the_back_on_the_plate_traj_v2.pkl"
+    )
+
+    def _terminated(self, states: TensorState) -> torch.Tensor:
+        """Task success checker."""
+        bowl_pos = states.objects["akita_black_bowl_3"].root_state[:, :3]  # (N,3)
+        plate_pos = states.objects["plate"].root_state[:, :3]  # (N,3)
+        range_threshold = 0.06  # Radius of the range in xy plane
+        height_threshold = 0.03  # Height threshold above the plate
+        xy_distance = torch.norm(bowl_pos[:, :2] - plate_pos[:, :2], dim=-1)  # (N,)
+        height_diff = bowl_pos[:, 2] - plate_pos[:, 2]  # (N,)
+        xy_close = xy_distance < range_threshold  # (N,)
+        height_valid = (height_diff > 0) & (height_diff < height_threshold)  # (N,)
+        is_on_plate = xy_close & height_valid  # (N,)
+        return is_on_plate
+
+    def reset(self, states=None, env_ids=None):
+        """Skip checker reset."""
+        states = super(Libero90BaseTask, self).reset(states, env_ids)
+        return states

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_put_the_black_bowl_at_the_front_on_the_plate.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_put_the_black_bowl_at_the_front_on_the_plate.py
@@ -1,0 +1,112 @@
+"""Configuration for the Libero kitchen scene2 put the black bowl at the back on the plate task."""
+
+from __future__ import annotations
+
+import torch
+
+from metasim.constants import PhysicStateType
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+from metasim.types import TensorState
+
+from .libero_90_base import Libero90BaseTask
+
+
+@register_task(
+    "libero_90.kitchen_scene2_put_the_black_bowl_at_the_front_on_the_plate",
+    "kitchen_scene2_put_the_black_bowl_at_the_front_on_the_plate",
+)
+class LiberoKitchenScene2PutBowlAtFrontOnPlateTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen scene2 put the black bowl at the front on the plate task.
+
+    This task is transferred from:
+    KITCHEN_SCENE2_put_the_black_bowl_at_the_front_on_the_plate.bddl
+
+    Task Description:
+    - Put the akita black bowl at the front (bowl_1) on the plate
+
+    This is a manipulation task that requires:
+    1. Grasping akita_black_bowl_1
+    2. Placing it on top of the plate
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1/2/3 (object): Three bowls on the table
+    - plate_1 (object): Target plate
+
+    Goal: (On akita_black_bowl_1 plate_1)
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            RigidObjCfg(
+                name="akita_black_bowl_1",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_2",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_3",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="plate",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    max_episode_steps = 300
+    task_desc = "Put the black bowl at the front (bowl_1) on the plate (scene2)"
+
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.90),)
+    workspace_size = ((1.0, 1.2, 0.05),)
+
+    traj_filepath = "roboverse_data/trajs/libero90/libero_90_kitchen_scene2_put_the_black_bowl_at_the_front_on_the_plate_traj_v2.pkl"
+
+    def _terminated(self, states: TensorState) -> torch.Tensor:
+        """Task success checker."""
+        bowl_pos = states.objects["akita_black_bowl_1"].root_state[:, :3]  # (N,3)
+        plate_pos = states.objects["plate"].root_state[:, :3]  # (N,3)
+        range_threshold = 0.06  # Radius of the range in xy plane
+        height_threshold = 0.03  # Height threshold above the plate
+        xy_distance = torch.norm(bowl_pos[:, :2] - plate_pos[:, :2], dim=-1)  # (N,)
+        height_diff = bowl_pos[:, 2] - plate_pos[:, 2]  # (N,)
+        xy_close = xy_distance < range_threshold  # (N,)
+        height_valid = (height_diff > 0) & (height_diff < height_threshold)  # (N,)
+        is_on_plate = xy_close & height_valid  # (N,)
+        return is_on_plate
+
+    def reset(self, states=None, env_ids=None):
+        """Skip checker reset."""
+        states = super(Libero90BaseTask, self).reset(states, env_ids)
+        return states

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_put_the_black_bowl_in_the_middle_on_the_plate.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_put_the_black_bowl_in_the_middle_on_the_plate.py
@@ -1,0 +1,112 @@
+"""Configuration for the Libero kitchen scene2 put the black bowl in the middle on the plate task."""
+
+from __future__ import annotations
+
+import torch
+
+from metasim.constants import PhysicStateType
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+from metasim.types import TensorState
+
+from .libero_90_base import Libero90BaseTask
+
+
+@register_task(
+    "libero_90.kitchen_scene2_put_the_black_bowl_in_the_middle_on_the_plate",
+    "kitchen_scene2_put_the_black_bowl_in_the_middle_on_the_plate",
+)
+class LiberoKitchenScene2PutBowlInMiddleOnPlateTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen scene2 put the black bowl in the middle on the plate task.
+
+    This task is transferred from:
+    KITCHEN_SCENE2_put_the_black_bowl_in_the_middle_on_the_plate.bddl
+
+    Task Description:
+    - Put the akita black bowl in the middle (bowl_2) on the plate
+
+    This is a manipulation task that requires:
+    1. Grasping akita_black_bowl_2
+    2. Placing it on top of the plate
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1/2/3 (object): Three bowls on the table
+    - plate_1 (object): Target plate
+
+    Goal: (On akita_black_bowl_2 plate_1)
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            RigidObjCfg(
+                name="akita_black_bowl_1",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_2",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_3",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="plate",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    max_episode_steps = 300
+    task_desc = "Put the black bowl in the middle (bowl_2) on the plate (scene2)"
+
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.90),)
+    workspace_size = ((1.0, 1.2, 0.05),)
+
+    traj_filepath = "roboverse_data/trajs/libero90/libero_90_kitchen_scene2_put_the_black_bowl_in_the_middle_on_the_plate_traj_v2.pkl"
+
+    def _terminated(self, states: TensorState) -> torch.Tensor:
+        """Task success checker."""
+        bowl_pos = states.objects["akita_black_bowl_2"].root_state[:, :3]  # (N,3)
+        plate_pos = states.objects["plate"].root_state[:, :3]  # (N,3)
+        range_threshold = 0.06  # Radius of the range in xy plane
+        height_threshold = 0.03  # Height threshold above the plate
+        xy_distance = torch.norm(bowl_pos[:, :2] - plate_pos[:, :2], dim=-1)  # (N,)
+        height_diff = bowl_pos[:, 2] - plate_pos[:, 2]  # (N,)
+        xy_close = xy_distance < range_threshold  # (N,)
+        height_valid = (height_diff > 0) & (height_diff < height_threshold)  # (N,)
+        is_on_plate = xy_close & height_valid  # (N,)
+        return is_on_plate
+
+    def reset(self, states=None, env_ids=None):
+        """Skip checker reset."""
+        states = super(Libero90BaseTask, self).reset(states, env_ids)
+        return states

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_put_the_middle_black_bowl_on_top_of_the_cabinet.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_put_the_middle_black_bowl_on_top_of_the_cabinet.py
@@ -1,0 +1,132 @@
+"""Configuration for the Libero kitchen scene2 put the middle black bowl on top of the cabinet task."""
+
+from __future__ import annotations
+
+import torch
+
+from metasim.constants import PhysicStateType
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+from metasim.types import TensorState
+from metasim.utils.math import matrix_from_quat
+
+from .libero_90_base import Libero90BaseTask
+
+
+def pose_to_mat(pos: torch.Tensor, quat: torch.Tensor | None = None) -> torch.Tensor:
+    """Build homogeneous transforms (N,4,4) from batched pos (N,3) and optional quat (N,4).
+
+    If quat is None, rotation is identity for all N.
+    """
+    assert pos.dim() == 2 and pos.shape[-1] == 3, "pos must be (N,3)"
+    N = pos.shape[0]
+    T = torch.eye(4, dtype=pos.dtype, device=pos.device).unsqueeze(0).repeat(N, 1, 1)
+    if quat is None:
+        R = torch.eye(3, dtype=pos.dtype, device=pos.device).unsqueeze(0).repeat(N, 1, 1)
+    else:
+        assert quat.shape == (N, 4), "quat must be (N,4)"
+        R = matrix_from_quat(quat)  # (N,3,3)
+    T[:, :3, :3] = R
+    T[:, :3, 3] = pos
+    return T
+
+
+@register_task(
+    "libero_90.kitchen_scene2_put_the_middle_black_bowl_on_top_of_the_cabinet",
+    "kitchen_scene2_put_the_middle_black_bowl_on_top_of_the_cabinet",
+)
+class LiberoKitchenScene2PutMiddleBowlOnCabinetTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen scene2 put the middle black bowl on top of the cabinet task.
+
+    This task is transferred from:
+    KITCHEN_SCENE2_put_the_middle_black_bowl_on_top_of_the_cabinet.bddl
+
+    Task Description:
+    - Put the akita black bowl in the middle (bowl_2) on top of the cabinet
+
+    This is a manipulation task that requires:
+    1. Grasping akita_black_bowl_2
+    2. Placing it on top of the cabinet
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1/2/3 (object): Three bowls on the table
+    - plate_1 (object): Distractor plate
+
+    Goal: (On akita_black_bowl_2 wooden_cabinet_1_top_surface)
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            RigidObjCfg(
+                name="akita_black_bowl_1",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_2",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_3",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="plate",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    max_episode_steps = 300
+    task_desc = "Put the middle black bowl (bowl_2) on top of the cabinet (scene2)"
+
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.90),)
+    workspace_size = ((1.0, 1.2, 0.05),)
+
+    traj_filepath = "roboverse_data/trajs/libero90/libero_90_kitchen_scene2_put_the_middle_black_bowl_on_top_of_the_cabinet_traj_v2.pkl"
+
+    def _terminated(self, states: TensorState) -> torch.Tensor:
+        """Task success checker."""
+        bowl_pos = states.objects["akita_black_bowl_2"].root_state[:, :3]  # (N,3)
+        cabinet_pos = states.objects["wooden_cabinet"].root_state[:, :3]  # (N,3)
+        cabinet_quat = states.objects["wooden_cabinet"].root_state[:, 3:7]  # (N,4)
+        bbox_lower = torch.tensor([-0.12, -0.076, 0.22], device=bowl_pos.device)  # x-, y-, z-
+        bbox_upper = torch.tensor([0.13, 0.11, 0.22 + 0.05], device=bowl_pos.device)  # x+, y+, z+
+        R = matrix_from_quat(cabinet_quat)  # (N,3,3)
+        bowl_local = torch.matmul(R.transpose(1, 2), (bowl_pos - cabinet_pos).unsqueeze(-1)).squeeze(-1)  # (N,3)
+        ge_lower = bowl_local >= bbox_lower  # (N,3)
+        le_upper = bowl_local <= bbox_upper  # (N,3)
+        inside = (ge_lower & le_upper).all(dim=-1)
+        return inside
+
+    def reset(self, states=None, env_ids=None):
+        """Skip checker reset."""
+        states = super(Libero90BaseTask, self).reset(states, env_ids)
+        return states

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_stack_the_black_bowl_at_the_front_on_the_black_bowl_in_the_middle.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_stack_the_black_bowl_at_the_front_on_the_black_bowl_in_the_middle.py
@@ -1,0 +1,112 @@
+"""Configuration for the Libero kitchen scene2 stack the black bowl at the front on the black bowl in the middle task."""
+
+from __future__ import annotations
+
+import torch
+
+from metasim.constants import PhysicStateType
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+from metasim.types import TensorState
+
+from .libero_90_base import Libero90BaseTask
+
+
+@register_task(
+    "libero_90.kitchen_scene2_stack_the_black_bowl_at_the_front_on_the_black_bowl_in_the_middle",
+    "kitchen_scene2_stack_the_black_bowl_at_the_front_on_the_black_bowl_in_the_middle",
+)
+class LiberoKitchenScene2StackBowlFrontOnMiddleTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen scene2 stack the black bowl at the front on the black bowl in the middle task.
+
+    This task is transferred from:
+    KITCHEN_SCENE2_stack_the_black_bowl_at_the_front_on_the_black_bowl_in_the_middle.bddl
+
+    Task Description:
+    - Stack akita_black_bowl_1 (front) on top of akita_black_bowl_2 (middle)
+
+    This is a manipulation task that requires:
+    1. Grasping akita_black_bowl_1
+    2. Placing it on top of akita_black_bowl_2
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1/2/3 (object): Three bowls on the table
+    - plate_1 (object): Distractor plate
+
+    Goal: (On akita_black_bowl_1 akita_black_bowl_2)
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            RigidObjCfg(
+                name="akita_black_bowl_1",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_2",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_3",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="plate",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    max_episode_steps = 300
+    task_desc = "Stack the black bowl at the front (bowl_1) on the black bowl in the middle (bowl_2) (scene2)"
+
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.90),)
+    workspace_size = ((1.0, 1.2, 0.05),)
+
+    traj_filepath = "roboverse_data/trajs/libero90/libero_90_kitchen_scene2_stack_the_black_bowl_at_the_front_on_the_black_bowl_in_the_middle_traj_v2.pkl"
+
+    def _terminated(self, states: TensorState) -> torch.Tensor:
+        """Task success checker."""
+        bowl1_pos = states.objects["akita_black_bowl_1"].root_state[:, :3]  # (N,3)
+        bowl2_pos = states.objects["akita_black_bowl_2"].root_state[:, :3]  # (N,3)
+        range_threshold = 0.06  # Radius of the range in xy plane
+        height_threshold = 0.05  # Height threshold above bowl_2
+        xy_distance = torch.norm(bowl1_pos[:, :2] - bowl2_pos[:, :2], dim=-1)  # (N,)
+        height_diff = bowl1_pos[:, 2] - bowl2_pos[:, 2]  # (N,)
+        xy_close = xy_distance < range_threshold  # (N,)
+        height_valid = (height_diff > 0) & (height_diff < height_threshold)  # (N,)
+        is_stacked = xy_close & height_valid  # (N,)
+        return is_stacked
+
+    def reset(self, states=None, env_ids=None):
+        """Skip checker reset."""
+        states = super(Libero90BaseTask, self).reset(states, env_ids)
+        return states

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_stack_the_middle_black_bowl_on_the_back_black_bowl.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene2_stack_the_middle_black_bowl_on_the_back_black_bowl.py
@@ -1,0 +1,112 @@
+"""Configuration for the Libero kitchen scene2 stack the middle black bowl on the back black bowl task."""
+
+from __future__ import annotations
+
+import torch
+
+from metasim.constants import PhysicStateType
+from metasim.scenario.objects import ArticulationObjCfg, RigidObjCfg
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.scenario.scene import SceneCfg
+from metasim.task.registry import register_task
+from metasim.types import TensorState
+
+from .libero_90_base import Libero90BaseTask
+
+
+@register_task(
+    "libero_90.kitchen_scene2_stack_the_middle_black_bowl_on_the_back_black_bowl",
+    "kitchen_scene2_stack_the_middle_black_bowl_on_the_back_black_bowl",
+)
+class LiberoKitchenScene2StackMiddleBowlOnBackBowlTask(Libero90BaseTask):
+    """Configuration for the Libero kitchen scene2 stack the middle black bowl on the back black bowl task.
+
+    This task is transferred from:
+    KITCHEN_SCENE2_stack_the_middle_black_bowl_on_the_back_black_bowl.bddl
+
+    Task Description:
+    - Stack akita_black_bowl_2 (middle) on top of akita_black_bowl_3 (back)
+
+    This is a manipulation task that requires:
+    1. Grasping akita_black_bowl_2
+    2. Placing it on top of akita_black_bowl_3
+
+    Objects from BDDL:
+    - wooden_cabinet_1 (fixture): The cabinet with drawers
+    - akita_black_bowl_1/2/3 (object): Three bowls on the table
+    - plate_1 (object): Distractor plate
+
+    Goal: (On akita_black_bowl_2 akita_black_bowl_3)
+    """
+
+    scenario = ScenarioCfg(
+        objects=[
+            RigidObjCfg(
+                name="akita_black_bowl_1",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_2",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="akita_black_bowl_3",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/usd/akita_black_bowl.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/urdf/akita_black_bowl.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/akita_black_bowl/mjcf/akita_black_bowl.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            RigidObjCfg(
+                name="plate",
+                usd_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/usd/plate.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/urdf/plate.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_scanned_objects/plate/mjcf/plate.xml",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+            ArticulationObjCfg(
+                name="wooden_cabinet",
+                fix_base_link=True,
+                usd_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/usd/wooden_cabinet.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/urdf/wooden_cabinet.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/articulated_objects/wooden_cabinet/mjcf/wooden_cabinet.xml",
+            ),
+        ],
+        robots=["franka"],
+        scene=SceneCfg(
+            name="libero_kitchen_tabletop",
+            mjcf_path="roboverse_data/assets/libero/scenes/libero_tabletop_base_style.xml",
+        ),
+    )
+
+    max_episode_steps = 300
+    task_desc = "Stack the middle black bowl (bowl_2) on the back black bowl (bowl_3) (scene2)"
+
+    workspace_name = ("kitchen_table",)
+    workspace_offset = ((0.0, 0, 0.90),)
+    workspace_size = ((1.0, 1.2, 0.05),)
+
+    traj_filepath = "roboverse_data/trajs/libero90/libero_90_kitchen_scene2_stack_the_middle_black_bowl_on_the_back_black_bowl_traj_v2.pkl"
+
+    def _terminated(self, states: TensorState) -> torch.Tensor:
+        """Task success checker."""
+        bowl2_pos = states.objects["akita_black_bowl_2"].root_state[:, :3]  # (N,3)
+        bowl3_pos = states.objects["akita_black_bowl_3"].root_state[:, :3]  # (N,3)
+        range_threshold = 0.06  # Radius of the range in xy plane
+        height_threshold = 0.03  # Height threshold above bowl_3
+        xy_distance = torch.norm(bowl2_pos[:, :2] - bowl3_pos[:, :2], dim=-1)  # (N,)
+        height_diff = bowl2_pos[:, 2] - bowl3_pos[:, 2]  # (N,)
+        xy_close = xy_distance < range_threshold  # (N,)
+        height_valid = (height_diff > 0) & (height_diff < height_threshold)  # (N,)
+        is_stacked = xy_close & height_valid  # (N,)
+        return is_stacked
+
+    def reset(self, states=None, env_ids=None):
+        """Skip checker reset."""
+        states = super(Libero90BaseTask, self).reset(states, env_ids)
+        return states

--- a/run_tasks.sh
+++ b/run_tasks.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# kitchen_scene1_open_bottom_drawer
+# kitchen_scene1_open_drawer_put_bowl
+# kitchen_scene1_open_top_drawer
+# kitchen_scene1_put_the_black_bowl_on_the_plate
+# kitchen_scene1_put_the_black_bowl_on_top_of_the_cabinet
+# kitchen_scene2_open_the_top_drawer_of_the_cabinet
+# kitchen_scene2_put_the_black_bowl_at_the_back_on_the_plate
+# kitchen_scene2_put_the_black_bowl_at_the_front_on_the_plate
+# kitchen_scene2_put_the_black_bowl_in_the_middle_on_the_plate
+# kitchen_scene2_put_the_middle_black_bowl_on_top_of_the_cabinet
+# kitchen_scene2_stack_the_black_bowl_at_the_front_on_the_black_bowl_in_the_middle
+# kitchen_scene2_stack_the_middle_black_bowl_on_the_back_black_bowl
+# mujoco isaacsim
+for task in kitchen_scene2_stack_the_middle_black_bowl_on_the_back_black_bowl; do
+    python scripts/advanced/collect_demo.py --sim=mujoco --task=libero_90.$task --num_envs=1 --max_demo_idx=1 # --render.mode pathtracing  --cust_name new_render_256_pathtracing_0
+done


### PR DESCRIPTION
# Description

add new libero tasks:
- kitchen_scene1_open_drawer_put_bowl
- kitchen_scene1_open_top_drawer
- kitchen_scene1_put_the_black_bowl_on_the_plate
- kitchen_scene1_put_the_black_bowl_on_top_of_the_cabinet
- kitchen_scene2_open_the_top_drawer_of_the_cabinet
- kitchen_scene2_put_the_black_bowl_at_the_back_on_the_plate
- kitchen_scene2_put_the_black_bowl_at_the_front_on_the_plate
- kitchen_scene2_put_the_black_bowl_in_the_middle_on_the_plate
- kitchen_scene2_put_the_middle_black_bowl_on_top_of_the_cabinet
- kitchen_scene2_stack_the_black_bowl_at_the_front_on_the_black_bowl_in_the_middle
- kitchen_scene2_stack_the_middle_black_bowl_on_the_back_black_bowl

## Type of change

- New feature (non-breaking change which adds functionality)

## How to test

`bash run_tasks.sh`


## Screenshots / Videos
example tasks: put_the_black_bowl_on_top_of_the_cabinet

https://github.com/user-attachments/assets/123bdc59-0a3a-4eb6-a0de-6a272ad0a9ed






