### PR TITLE
Change Zarr 2 API to Zarr 3

### DIFF
--- a/roboverse_learn/il/data2zarr_dp.py
+++ b/roboverse_learn/il/data2zarr_dp.py
@@ -8,6 +8,7 @@ import imageio.v2 as iio
 import numpy as np
 import torch
 import zarr
+from zarr.codecs import BloscCodec, BloscShuffle
 from tqdm import tqdm
 
 try:
@@ -86,7 +87,7 @@ def main():
     zarr_meta = zarr_root.create_group("meta")
 
     # ZARR datasets will be created dynamically during the first batch write
-    compressor = zarr.Blosc(cname="zstd", clevel=3, shuffle=1)
+    compressor = BloscCodec(cname="zstd", clevel=3, shuffle="shuffle")
 
     # Batch processing settings
     batch_size = 100


### PR DESCRIPTION
New zarr has no attribute blosc, needs to be changed to use zarr 3 style.