### PR TITLE
fix: add pynput to examples dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ examples = [
     "imageio[ffmpeg]",
     "opencv-python",
     "pygame",
+    "pynput",
     "rich",
     "rootutils",
     "stable-baselines3",


### PR DESCRIPTION
`pynput` is used by `scripts/advanced/teleop_keyboard.py` but was not included in the `examples` optional dependencies. This adds it alongside `pygame` which was already listed.

Closes #664