### PR TITLE
[codex] Add Blender USD material overlay benchmarking support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,11 @@ public/
 artifacts/
 nohup/
 .omx/
+
+# Blender USD material overlay artifacts
+*.blender_materials.usda
+*.blender_root.usda
+roboverse_data/material_cache/
+reports/*_material_audit.json
+reports/*_conversion_report.json
+reports/*_conversion_report.md

--- a/roboverse_pack/blender/__init__.py
+++ b/roboverse_pack/blender/__init__.py
@@ -1,0 +1,2 @@
+"""Blender integration helpers for RoboVerse."""
+

--- a/roboverse_pack/blender/usd/__init__.py
+++ b/roboverse_pack/blender/usd/__init__.py
@@ -1,0 +1,2 @@
+"""USD overlay helpers for Blender material conversion."""
+

--- a/roboverse_pack/blender/usd/audit.py
+++ b/roboverse_pack/blender/usd/audit.py
@@ -1,0 +1,70 @@
+"""Audit USD material bindings for Blender overlay conversion."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _asset_path_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    return getattr(value, "path", str(value))
+
+
+def audit_usd_materials(input_path: str | Path) -> dict[str, Any]:
+    from pxr import Usd, UsdShade
+
+    path = Path(input_path)
+    stage = Usd.Stage.Open(str(path))
+    if stage is None:
+        raise ValueError(f"Unable to open USD stage: {path}")
+
+    materials = []
+    for prim in stage.Traverse():
+        if not prim.IsA(UsdShade.Material):
+            continue
+        shader_ids = []
+        mdl_source_asset = None
+        for descendant in Usd.PrimRange(prim):
+            if descendant.GetPath() == prim.GetPath() or not descendant.IsA(UsdShade.Shader):
+                continue
+            shader = UsdShade.Shader(descendant)
+            shader_id = shader.GetIdAttr().Get()
+            if shader_id:
+                shader_ids.append(str(shader_id))
+            source_input = shader.GetInput("mdl:sourceAsset")
+            if source_input and mdl_source_asset is None:
+                mdl_source_asset = _asset_path_string(source_input.Get())
+        materials.append(
+            {
+                "material_path": str(prim.GetPath()),
+                "shader_ids": shader_ids,
+                "mdl_source_asset": mdl_source_asset,
+            }
+        )
+
+    return {
+        "input_path": str(path),
+        "materials_total": len(materials),
+        "materials": materials,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Audit USD materials for Blender overlay conversion.")
+    parser.add_argument("--input", required=True, help="Input USD stage.")
+    parser.add_argument("--output", required=True, help="Output JSON report path.")
+    args = parser.parse_args(argv)
+
+    report = audit_usd_materials(args.input)
+    output = Path(args.output)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/roboverse_pack/blender/usd/compat.py
+++ b/roboverse_pack/blender/usd/compat.py
@@ -1,0 +1,137 @@
+"""Pure-Python compatibility helpers for Blender USD material overlays."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .overlay import generate_blender_overlay
+
+SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class BlenderOverlayPaths:
+    source: Path
+    overlay: Path
+    root: Path
+    cache: Path
+    manifest: Path
+
+
+def _cache_parent_for_source(source: Path) -> Path:
+    parent = source.parent
+    if str(parent) in ("", "."):
+        return Path("roboverse_data/material_cache")
+    parts = parent.parts[1:] if parent.is_absolute() else parent.parts
+    return Path("roboverse_data/material_cache").joinpath(*parts)
+
+
+def blender_overlay_paths(source: str | Path) -> BlenderOverlayPaths:
+    source_path = Path(source)
+    overlay_path = source_path.with_suffix(".blender_materials.usda")
+    root_path = source_path.with_suffix(".blender_root.usda")
+    cache_path = _cache_parent_for_source(source_path)
+    manifest_path = cache_path / f"{source_path.stem}.blender_overlay_manifest.json"
+    return BlenderOverlayPaths(
+        source=source_path,
+        overlay=overlay_path,
+        root=root_path,
+        cache=cache_path,
+        manifest=manifest_path,
+    )
+
+
+def file_sha256(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def is_overlay_current(
+    source: str | Path,
+    overlay: str | Path,
+    root: str | Path,
+    manifest: str | Path,
+    *,
+    converter_settings: dict[str, Any] | None = None,
+) -> bool:
+    source_path = Path(source)
+    overlay_path = Path(overlay)
+    root_path = Path(root)
+    manifest_path = Path(manifest)
+    if not source_path.exists() or not overlay_path.exists() or not root_path.exists() or not manifest_path.exists():
+        return False
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if data.get("schema_version") != SCHEMA_VERSION or data.get("source_sha256") != file_sha256(source_path):
+        return False
+    if converter_settings is not None and data.get("converter_settings", {}) != converter_settings:
+        return False
+    return True
+
+
+def write_manifest(
+    manifest: str | Path,
+    *,
+    source: str | Path,
+    overlay: str | Path,
+    root: str | Path,
+    converter_settings: dict[str, Any] | None = None,
+) -> None:
+    manifest_path = Path(manifest)
+    source_path = Path(source)
+    data = {
+        "schema_version": SCHEMA_VERSION,
+        "source": str(source_path),
+        "overlay": str(Path(overlay)),
+        "root": str(Path(root)),
+        "source_sha256": file_sha256(source_path),
+        "converter_settings": converter_settings or {},
+    }
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def ensure_blender_material_overlay(
+    usd_path: str | Path,
+    *,
+    force: bool = False,
+    resolution: int = 2048,
+    samples: int = 16,
+) -> Path:
+    paths = blender_overlay_paths(usd_path)
+    converter_settings = {"resolution": resolution, "samples": samples}
+    if not force and is_overlay_current(
+        paths.source,
+        paths.overlay,
+        paths.root,
+        paths.manifest,
+        converter_settings=converter_settings,
+    ):
+        return paths.root
+
+    paths.cache.mkdir(parents=True, exist_ok=True)
+    generate_blender_overlay(
+        paths.source,
+        paths.overlay,
+        paths.root,
+        paths.cache,
+        resolution=resolution,
+        samples=samples,
+    )
+    write_manifest(
+        paths.manifest,
+        source=paths.source,
+        overlay=paths.overlay,
+        root=paths.root,
+        converter_settings=converter_settings,
+    )
+    return paths.root

--- a/roboverse_pack/blender/usd/compat.py
+++ b/roboverse_pack/blender/usd/compat.py
@@ -8,9 +8,13 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from .material_graph.texture_paths import find_texture_file_candidates
 from .overlay import generate_blender_overlay
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
+CONVERTER_SCHEMA_VERSION = "material_graph_v1"
+BLENDER_TARGET = "4.x"
+_DEPENDENCY_GROUPS = ("sublayers", "references", "textures", "mdl")
 
 
 @dataclass(frozen=True)
@@ -53,12 +57,124 @@ def file_sha256(path: str | Path) -> str:
     return digest.hexdigest()
 
 
+def _effective_settings(
+    settings: dict[str, Any] | None,
+    converter_settings: dict[str, Any] | None,
+) -> dict[str, Any]:
+    if settings is not None:
+        return dict(settings)
+    if converter_settings is not None:
+        return dict(converter_settings)
+    return {}
+
+
+def _default_converter(converter: dict[str, Any] | None = None) -> dict[str, Any]:
+    data = {
+        "schema_version": CONVERTER_SCHEMA_VERSION,
+        "pxr_version": None,
+        "kit_version": None,
+        "blender_target": BLENDER_TARGET,
+    }
+    if converter:
+        data.update(converter)
+    return data
+
+
+def _dependency_entry(path: str | Path) -> dict[str, Any]:
+    dependency_path = Path(path)
+    stat = dependency_path.stat()
+    return {
+        "path": str(dependency_path),
+        "sha256": file_sha256(dependency_path),
+        "size": stat.st_size,
+        "mtime_ns": stat.st_mtime_ns,
+    }
+
+
+def _normalize_dependencies(dependencies: dict[str, Any] | None) -> dict[str, Any]:
+    normalized: dict[str, Any] = {group: [] for group in _DEPENDENCY_GROUPS}
+    if not dependencies:
+        return normalized
+
+    for group in _DEPENDENCY_GROUPS:
+        for item in dependencies.get(group, []) or []:
+            if isinstance(item, dict):
+                path = item.get("path")
+                if path is not None and Path(path).exists():
+                    entry = _dependency_entry(path)
+                    for key, value in item.items():
+                        if key not in entry:
+                            entry[key] = value
+                    normalized[group].append(entry)
+                else:
+                    normalized[group].append(dict(item))
+            elif Path(item).exists():
+                normalized[group].append(_dependency_entry(item))
+
+    missing_textures = dependencies.get("missing_textures")
+    if missing_textures:
+        normalized["missing_textures"] = [str(path) for path in missing_textures]
+    return normalized
+
+
+def _dependency_is_current(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    path = entry.get("path")
+    if not path:
+        return False
+    dependency_path = Path(path)
+    if not dependency_path.exists():
+        return False
+    try:
+        stat = dependency_path.stat()
+        if entry.get("size") != stat.st_size or entry.get("mtime_ns") != stat.st_mtime_ns:
+            return False
+        return entry.get("sha256") == file_sha256(dependency_path)
+    except OSError:
+        return False
+
+
+def _missing_texture_still_missing(raw: str, source_parent: Path) -> bool:
+    return not find_texture_file_candidates(raw, source_parent)
+
+
+def _texture_dependencies_from_report(report: dict[str, Any], source_parent: Path) -> dict[str, list[Any]]:
+    deep_report = report.get("deep_report", report)
+    materials = deep_report.get("materials", [])
+    if isinstance(materials, dict):
+        return {"textures": [], "missing_textures": []}
+
+    dependencies: list[Path] = []
+    missing_textures: list[str] = []
+    seen: set[Path] = set()
+    seen_missing: set[str] = set()
+    for material in materials:
+        for slot in material.get("slots", {}).values():
+            file_value = slot.get("file")
+            if not file_value:
+                continue
+            candidates = find_texture_file_candidates(str(file_value), source_parent)
+            if candidates:
+                for candidate in candidates:
+                    if candidate not in seen:
+                        seen.add(candidate)
+                        dependencies.append(candidate)
+                continue
+            missing = str(file_value)
+            if missing not in seen_missing:
+                seen_missing.add(missing)
+                missing_textures.append(missing)
+    return {"textures": dependencies, "missing_textures": missing_textures}
+
+
 def is_overlay_current(
     source: str | Path,
     overlay: str | Path,
     root: str | Path,
     manifest: str | Path,
     *,
+    settings: dict[str, Any] | None = None,
     converter_settings: dict[str, Any] | None = None,
 ) -> bool:
     source_path = Path(source)
@@ -73,7 +189,18 @@ def is_overlay_current(
         return False
     if data.get("schema_version") != SCHEMA_VERSION or data.get("source_sha256") != file_sha256(source_path):
         return False
-    if converter_settings is not None and data.get("converter_settings", {}) != converter_settings:
+    if data.get("converter", {}).get("schema_version") != CONVERTER_SCHEMA_VERSION:
+        return False
+    for group in _DEPENDENCY_GROUPS:
+        for entry in data.get("dependencies", {}).get(group, []):
+            if not _dependency_is_current(entry):
+                return False
+    for missing_texture in data.get("dependencies", {}).get("missing_textures", []):
+        if not _missing_texture_still_missing(str(missing_texture), source_path.parent):
+            return False
+    requested_settings = _effective_settings(settings, converter_settings)
+    manifest_settings = data.get("settings", {})
+    if requested_settings and any(manifest_settings.get(key) != value for key, value in requested_settings.items()):
         return False
     return True
 
@@ -84,6 +211,9 @@ def write_manifest(
     source: str | Path,
     overlay: str | Path,
     root: str | Path,
+    dependencies: dict[str, Any] | None = None,
+    settings: dict[str, Any] | None = None,
+    converter: dict[str, Any] | None = None,
     converter_settings: dict[str, Any] | None = None,
 ) -> None:
     manifest_path = Path(manifest)
@@ -94,7 +224,9 @@ def write_manifest(
         "overlay": str(Path(overlay)),
         "root": str(Path(root)),
         "source_sha256": file_sha256(source_path),
-        "converter_settings": converter_settings or {},
+        "converter": _default_converter(converter),
+        "dependencies": _normalize_dependencies(dependencies),
+        "settings": _effective_settings(settings, converter_settings),
     }
     manifest_path.parent.mkdir(parents=True, exist_ok=True)
     manifest_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -108,18 +240,18 @@ def ensure_blender_material_overlay(
     samples: int = 16,
 ) -> Path:
     paths = blender_overlay_paths(usd_path)
-    converter_settings = {"resolution": resolution, "samples": samples}
+    settings = {"resolution": resolution, "samples": samples}
     if not force and is_overlay_current(
         paths.source,
         paths.overlay,
         paths.root,
         paths.manifest,
-        converter_settings=converter_settings,
+        settings=settings,
     ):
         return paths.root
 
     paths.cache.mkdir(parents=True, exist_ok=True)
-    generate_blender_overlay(
+    report = generate_blender_overlay(
         paths.source,
         paths.overlay,
         paths.root,
@@ -132,6 +264,7 @@ def ensure_blender_material_overlay(
         source=paths.source,
         overlay=paths.overlay,
         root=paths.root,
-        converter_settings=converter_settings,
+        dependencies=_texture_dependencies_from_report(report, paths.source.parent),
+        settings=settings,
     )
     return paths.root

--- a/roboverse_pack/blender/usd/kit_overlay.py
+++ b/roboverse_pack/blender/usd/kit_overlay.py
@@ -1,0 +1,38 @@
+"""Optional Kit entry point for Blender USD material overlays."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .overlay import generate_blender_overlay
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a Blender material overlay without requiring Kit imports.")
+    parser.add_argument("--input", help="Input USD stage.")
+    parser.add_argument("--overlay", help="Output overlay USD layer.")
+    parser.add_argument("--root", help="Output root USD layer.")
+    parser.add_argument("--texture-cache", help="Texture cache/report directory.")
+    parser.add_argument("--resolution", type=int, default=2048)
+    parser.add_argument("--samples", type=int, default=16)
+    args = parser.parse_args(argv)
+
+    if not (args.input and args.overlay and args.root and args.texture_cache):
+        print("Kit MDL bake is not enabled; provide --input, --overlay, --root, and --texture-cache to generate the MVP overlay.")
+        return 0
+
+    generate_blender_overlay(
+        Path(args.input),
+        Path(args.overlay),
+        Path(args.root),
+        Path(args.texture_cache),
+        resolution=args.resolution,
+        samples=args.samples,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/roboverse_pack/blender/usd/material_graph/__init__.py
+++ b/roboverse_pack/blender/usd/material_graph/__init__.py
@@ -1,0 +1,2 @@
+"""Material graph helpers for Blender USD overlay generation."""
+

--- a/roboverse_pack/blender/usd/material_graph/adapters/__init__.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/__init__.py
@@ -21,6 +21,7 @@ from .base import MaterialAdapter
 from .existing_preview import ExistingPreviewSurfaceAdapter
 from .fallback import ScalarFallbackAdapter, SemanticClassFallbackAdapter
 from .generic import GenericTextureGraphAdapter
+from .mdl_bake import MdlBakeAdapter, choose_conversion_policy
 from .omnipbr import OmniPBRAdapter
 
 ADAPTERS: tuple[MaterialAdapter, ...] = (
@@ -40,10 +41,38 @@ def select_adapter(
     return max(registry, key=lambda adapter: adapter.score(raw))
 
 
+def select_adapter_by_policy(raw: RawMaterialSpec, *, enable_mdl_bake: bool = False) -> MaterialAdapter:
+    policy = choose_conversion_policy(raw)
+    if policy == "preserve_existing_preview":
+        return ExistingPreviewSurfaceAdapter()
+    if policy == "mdl_bake":
+        if enable_mdl_bake:
+            return MdlBakeAdapter()
+        if raw.values:
+            return ScalarFallbackAdapter()
+        return SemanticClassFallbackAdapter()
+    if policy == "direct_graph":
+        omnipbr = OmniPBRAdapter()
+        if omnipbr.score(raw) > 0:
+            return omnipbr
+        return GenericTextureGraphAdapter()
+    if policy == "scalar_fallback":
+        return ScalarFallbackAdapter()
+    return SemanticClassFallbackAdapter()
+
+
 def convert_material(
     raw: RawMaterialSpec,
     context: MaterialContext,
     adapters: Sequence[MaterialAdapter] | None = None,
 ) -> PreviewMaterialSpec:
-    adapter = select_adapter(raw, adapters)
-    return replace(adapter.convert(raw, context), adapter_name=adapter.name)
+    if adapters is not None:
+        adapter = select_adapter(raw, adapters)
+        return replace(adapter.convert(raw, context), adapter_name=adapter.name)
+
+    policy = choose_conversion_policy(raw)
+    adapter = select_adapter_by_policy(raw, enable_mdl_bake=context.enable_mdl_bake)
+    spec = replace(adapter.convert(raw, context), adapter_name=adapter.name)
+    if policy == "mdl_bake" and not context.enable_mdl_bake:
+        return replace(spec, quality_notes=(*spec.quality_notes, "mdl_bake_unavailable"))
+    return spec

--- a/roboverse_pack/blender/usd/material_graph/adapters/__init__.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/__init__.py
@@ -1,0 +1,47 @@
+"""Material graph adapter registry.
+
+Score table:
+- existing_preview: 100
+- omnipbr direct graph: 80
+- generic texture graph: 40
+- scalar fallback: 20
+- semantic class fallback: 1
+
+MDL baking is a later policy-first path, not score-first adapter selection.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ..context import MaterialContext
+from ..schema import PreviewMaterialSpec, RawMaterialSpec
+from .base import MaterialAdapter
+from .existing_preview import ExistingPreviewSurfaceAdapter
+from .fallback import ScalarFallbackAdapter, SemanticClassFallbackAdapter
+from .generic import GenericTextureGraphAdapter
+from .omnipbr import OmniPBRAdapter
+
+ADAPTERS: tuple[MaterialAdapter, ...] = (
+    ExistingPreviewSurfaceAdapter(),
+    OmniPBRAdapter(),
+    GenericTextureGraphAdapter(),
+    ScalarFallbackAdapter(),
+    SemanticClassFallbackAdapter(),
+)
+
+
+def select_adapter(
+    raw: RawMaterialSpec,
+    adapters: Sequence[MaterialAdapter] | None = None,
+) -> MaterialAdapter:
+    registry = adapters if adapters is not None else ADAPTERS
+    return max(registry, key=lambda adapter: adapter.score(raw))
+
+
+def convert_material(
+    raw: RawMaterialSpec,
+    context: MaterialContext,
+    adapters: Sequence[MaterialAdapter] | None = None,
+) -> PreviewMaterialSpec:
+    return select_adapter(raw, adapters).convert(raw, context)

--- a/roboverse_pack/blender/usd/material_graph/adapters/__init__.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/__init__.py
@@ -13,6 +13,7 @@ MDL baking is a later policy-first path, not score-first adapter selection.
 from __future__ import annotations
 
 from collections.abc import Sequence
+from dataclasses import replace
 
 from ..context import MaterialContext
 from ..schema import PreviewMaterialSpec, RawMaterialSpec
@@ -44,4 +45,5 @@ def convert_material(
     context: MaterialContext,
     adapters: Sequence[MaterialAdapter] | None = None,
 ) -> PreviewMaterialSpec:
-    return select_adapter(raw, adapters).convert(raw, context)
+    adapter = select_adapter(raw, adapters)
+    return replace(adapter.convert(raw, context), adapter_name=adapter.name)

--- a/roboverse_pack/blender/usd/material_graph/adapters/base.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/base.py
@@ -1,0 +1,18 @@
+"""Material graph adapter protocol."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from ..context import MaterialContext
+from ..schema import PreviewMaterialSpec, RawMaterialSpec
+
+
+class MaterialAdapter(Protocol):
+    name: str
+
+    def score(self, raw: RawMaterialSpec) -> int:
+        """Return adapter confidence for a raw material."""
+
+    def convert(self, raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
+        """Convert a raw material into the preview material IR."""

--- a/roboverse_pack/blender/usd/material_graph/adapters/existing_preview.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/existing_preview.py
@@ -1,0 +1,27 @@
+"""Adapter for source graphs that already contain UsdPreviewSurface."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from ..context import MaterialContext
+from ..normalize import normalize_material
+from ..schema import PreviewMaterialSpec, RawMaterialSpec
+
+
+class ExistingPreviewSurfaceAdapter:
+    name = "existing_preview"
+
+    def score(self, raw: RawMaterialSpec) -> int:
+        shader_ids = set(raw.shader_ids)
+        if raw.connected_surface_shader_id:
+            shader_ids.add(raw.connected_surface_shader_id)
+        return 100 if "UsdPreviewSurface" in shader_ids else 0
+
+    def convert(self, raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
+        spec = normalize_material(raw)
+        return replace(
+            spec,
+            conversion_policy="preserve_existing_preview",
+            quality_notes=("source UsdPreviewSurface graph preserved without overlay opinion",),
+        )

--- a/roboverse_pack/blender/usd/material_graph/adapters/fallback.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/fallback.py
@@ -1,0 +1,62 @@
+"""Fallback material adapters."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from ..aliases import IOR_ALIASES
+from ..context import MaterialContext
+from ..extract import coerce_float
+from ..fallback import CLASS_FALLBACKS, find_material_class
+from ..normalize import normalize_material
+from ..schema import InputSpec, PreviewMaterialSpec, RawMaterialSpec
+
+
+class ScalarFallbackAdapter:
+    name = "scalar_fallback"
+
+    def score(self, raw: RawMaterialSpec) -> int:
+        return 20 if raw.values else 0
+
+    def convert(self, raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
+        return replace(normalize_material(raw), conversion_policy="scalar_fallback")
+
+
+class SemanticClassFallbackAdapter:
+    name = "semantic_class_fallback"
+
+    def score(self, raw: RawMaterialSpec) -> int:
+        return 1
+
+    def convert(self, raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
+        material_class = find_material_class(raw.material_path, raw.connected_surface_shader_id)
+        base_color = CLASS_FALLBACKS.get(material_class, (0.5, 0.5, 0.5))
+        opacity_value = _float_for_alias(raw, ("opacity", "opacity_constant"))
+        ior_value = _float_for_alias(raw, IOR_ALIASES)
+        return PreviewMaterialSpec(
+            material_path=raw.material_path,
+            material_name=raw.material_name,
+            source_shader_ids=raw.shader_ids,
+            mdl_source_asset=raw.mdl_source_asset,
+            base_color=InputSpec(value=base_color),
+            normal=None,
+            metallic=None,
+            roughness=None,
+            specular_color=None,
+            emissive_color=None,
+            opacity=InputSpec(value=opacity_value) if opacity_value is not None else None,
+            ior=ior_value,
+            material_class=material_class,
+            conversion_policy="class_fallback",
+            quality_notes=("semantic class fallback used",),
+        )
+
+
+def _float_for_alias(raw: RawMaterialSpec, aliases: tuple[str, ...]) -> float | None:
+    for alias in aliases:
+        if alias not in raw.values:
+            continue
+        value = coerce_float(raw.values.get(alias))
+        if value is not None:
+            return value
+    return None

--- a/roboverse_pack/blender/usd/material_graph/adapters/generic.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/generic.py
@@ -1,0 +1,24 @@
+"""Adapter for simple non-Omni texture graphs."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from ..aliases import TEXTURE_ALIASES
+from ..context import MaterialContext
+from ..extract import asset_path_string
+from ..normalize import normalize_material
+from ..schema import PreviewMaterialSpec, RawMaterialSpec
+
+
+class GenericTextureGraphAdapter:
+    name = "generic_texture_graph"
+
+    def score(self, raw: RawMaterialSpec) -> int:
+        for alias in TEXTURE_ALIASES:
+            if asset_path_string(raw.values.get(alias)):
+                return 40
+        return 0
+
+    def convert(self, raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
+        return replace(normalize_material(raw), conversion_policy="direct_graph")

--- a/roboverse_pack/blender/usd/material_graph/adapters/generic.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/generic.py
@@ -9,6 +9,7 @@ from ..context import MaterialContext
 from ..extract import asset_path_string
 from ..normalize import normalize_material
 from ..schema import PreviewMaterialSpec, RawMaterialSpec
+from ..texture_paths import normalize_texture_asset_path
 
 
 class GenericTextureGraphAdapter:
@@ -21,4 +22,18 @@ class GenericTextureGraphAdapter:
         return 0
 
     def convert(self, raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
-        return replace(normalize_material(raw), conversion_policy="direct_graph")
+        spec = replace(normalize_material(raw), conversion_policy="direct_graph")
+        texture = spec.base_color.texture
+        if texture is None:
+            return spec
+
+        path_result = normalize_texture_asset_path(texture.file, context.texture_base_dir)
+        base_color = replace(
+            spec.base_color,
+            texture=replace(texture, file=path_result.normalized, role="base_color"),
+        )
+        return replace(
+            spec,
+            base_color=base_color,
+            quality_notes=(*spec.quality_notes, *path_result.warnings),
+        )

--- a/roboverse_pack/blender/usd/material_graph/adapters/mdl_bake.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/mdl_bake.py
@@ -1,0 +1,99 @@
+"""Policy adapter for complex MDL materials that require Kit baking."""
+
+from __future__ import annotations
+
+from .. import kit_bake
+from ..aliases import IOR_ALIASES, TEXTURE_ALIASES
+from ..context import MaterialContext
+from ..extract import asset_path_string
+from ..schema import ConversionPolicy, PreviewMaterialSpec, RawMaterialSpec
+from ..slots import SLOT_REGISTRY
+
+COMPLEX_MDL_HINTS = ("procedural", "noise", "clearcoat", "flake", "subsurface", "layer", "blend")
+
+_SLOT_PREFIXES = {
+    "base_color": "BaseColor",
+    "normal": "Normal",
+    "metallic": "Metallic",
+    "roughness": "Roughness",
+    "glossiness": "Gloss",
+    "specular": "Specular",
+    "emissive": "Emissive",
+    "opacity": "Opacity",
+}
+
+
+def choose_conversion_policy(raw: RawMaterialSpec) -> ConversionPolicy:
+    # Mirror ExistingPreviewSurfaceAdapter so policy-first selection preserves existing graphs.
+    shader_ids = set(raw.shader_ids)
+    if raw.connected_surface_shader_id:
+        shader_ids.add(raw.connected_surface_shader_id)
+    if "UsdPreviewSurface" in shader_ids:
+        return "preserve_existing_preview"
+
+    if raw.mdl_source_asset and _has_procedural_or_complex_nodes(raw):
+        return "mdl_bake"
+
+    if _looks_like_simple_omnipbr_file_texture_material(raw):
+        return "direct_graph"
+
+    if _has_direct_texture_alias(raw):
+        return "direct_graph"
+
+    if raw.values:
+        return "scalar_fallback"
+    return "class_fallback"
+
+
+class MdlBakeAdapter:
+    name = "mdl_bake"
+
+    def score(self, raw: RawMaterialSpec) -> float:
+        return 90.0 if choose_conversion_policy(raw) == "mdl_bake" else 0.0
+
+    def convert(self, raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
+        return kit_bake.bake_mdl_material_to_preview(raw, context)
+
+
+def _looks_like_simple_omnipbr_file_texture_material(raw: RawMaterialSpec) -> bool:
+    if not _is_omnipbr_like(raw):
+        return False
+
+    known_keys = _known_simple_omnipbr_keys()
+    return all(key in known_keys for key in raw.values)
+
+
+def _has_procedural_or_complex_nodes(raw: RawMaterialSpec) -> bool:
+    candidates = [*raw.shader_ids, *raw.values.keys()]
+    if raw.connected_surface_shader_id:
+        candidates.append(raw.connected_surface_shader_id)
+    return any(hint in candidate.lower() for candidate in candidates for hint in COMPLEX_MDL_HINTS)
+
+
+def _has_direct_texture_alias(raw: RawMaterialSpec) -> bool:
+    return any(asset_path_string(raw.values.get(alias)) for alias in TEXTURE_ALIASES)
+
+
+def _is_omnipbr_like(raw: RawMaterialSpec) -> bool:
+    if raw.connected_surface_shader_id:
+        return "omnipbr" in raw.connected_surface_shader_id.lower()
+
+    candidates = [*raw.shader_ids]
+    if raw.mdl_source_asset:
+        candidates.append(raw.mdl_source_asset)
+    return any("omnipbr" in candidate.lower() for candidate in candidates)
+
+
+def _known_simple_omnipbr_keys() -> set[str]:
+    keys: set[str] = {"MaxTexCoordIndex", *IOR_ALIASES}
+    for slot_name, slot in SLOT_REGISTRY.items():
+        keys.update(slot.value_aliases)
+        keys.update(slot.texture_aliases)
+        keys.update(slot.enable_aliases)
+        keys.update(slot.uva_aliases)
+        keys.update(getattr(slot, "intensity_aliases", ()))
+
+        prefix = _SLOT_PREFIXES.get(slot_name)
+        if prefix:
+            keys.add(f"{prefix}_MaxTexCoordIndex")
+    return keys

--- a/roboverse_pack/blender/usd/material_graph/adapters/omnipbr.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/omnipbr.py
@@ -1,0 +1,145 @@
+"""Adapter for OmniPBR-like MDL material graphs."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from ..context import MaterialContext
+from ..extract import asset_path_string, coerce_float
+from ..fallback import CLASS_FALLBACKS, find_material_class
+from ..aliases import IOR_ALIASES
+from ..schema import InputSpec, PreviewMaterialSpec, RawMaterialSpec, TextureSpec
+from ..slots import SLOT_REGISTRY, SlotSpec
+
+
+class OmniPBRAdapter:
+    name = "omnipbr"
+
+    def score(self, raw: RawMaterialSpec) -> int:
+        if raw.connected_surface_shader_id:
+            return 80 if "omnipbr" in raw.connected_surface_shader_id.lower() else 0
+        candidates = (*raw.shader_ids, raw.mdl_source_asset or "")
+        return 80 if any("omnipbr" in candidate.lower() for candidate in candidates) else 0
+
+    def convert(self, raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
+        base_color = _input_from_slot(raw.values, SLOT_REGISTRY["base_color"])
+        material_class = find_material_class(raw.material_path, raw.connected_surface_shader_id)
+        quality_notes: list[str] = []
+        if base_color is None:
+            if material_class:
+                base_color = InputSpec(value=CLASS_FALLBACKS[material_class])
+            else:
+                base_color = InputSpec(value=(0.5, 0.5, 0.5))
+            quality_notes.append("No diffuse color or texture alias found.")
+
+        roughness = _input_from_slot(raw.values, SLOT_REGISTRY["roughness"])
+        glossiness = _input_from_slot(raw.values, SLOT_REGISTRY["glossiness"])
+        if roughness is None and glossiness is not None:
+            roughness = glossiness
+
+        specular = _input_from_slot(raw.values, SLOT_REGISTRY["specular"])
+
+        return PreviewMaterialSpec(
+            material_path=raw.material_path,
+            material_name=raw.material_name,
+            source_shader_ids=raw.shader_ids,
+            mdl_source_asset=raw.mdl_source_asset,
+            base_color=base_color,
+            normal=_input_from_slot(raw.values, SLOT_REGISTRY["normal"]),
+            metallic=_input_from_slot(raw.values, SLOT_REGISTRY["metallic"]),
+            roughness=roughness,
+            specular_color=specular,
+            emissive_color=_input_from_slot(raw.values, SLOT_REGISTRY["emissive"]),
+            opacity=_input_from_slot(raw.values, SLOT_REGISTRY["opacity"]),
+            ior=_ior(raw.values),
+            use_specular_workflow=specular is not None,
+            material_class=material_class,
+            conversion_policy="direct_graph",
+            quality_notes=tuple(quality_notes),
+        )
+
+
+def _input_from_slot(values: Mapping[str, object], slot: SlotSpec) -> InputSpec | None:
+    if not _slot_enabled(values, slot):
+        return None
+
+    for alias in slot.texture_aliases:
+        texture_file = asset_path_string(values.get(alias))
+        if not texture_file:
+            continue
+        scale = (-1.0, -1.0, -1.0, -1.0) if slot.invert_to_roughness else slot.scale
+        bias = (1.0, 1.0, 1.0, 1.0) if slot.invert_to_roughness else slot.bias
+        return InputSpec(
+            texture=TextureSpec(
+                file=texture_file,
+                source_color_space=slot.color_space,
+                channel=slot.texture_output,
+                scale=scale,
+                bias=bias,
+                source_input=alias,
+            ),
+            source_inputs=(alias,),
+        )
+
+    for alias in slot.value_aliases:
+        if alias not in values or values.get(alias) is None:
+            continue
+        raw_value = values[alias]
+        value = _coerce_value(raw_value, slot)
+        if value is None:
+            continue
+        if slot.invert_to_roughness:
+            scalar = coerce_float(value)
+            if scalar is None:
+                continue
+            value = 1.0 - scalar
+        return InputSpec(value=value, source_inputs=(alias,))
+    return None
+
+
+def _slot_enabled(values: Mapping[str, object], slot: SlotSpec) -> bool:
+    for alias in slot.enable_aliases:
+        if alias not in values:
+            continue
+        value = values.get(alias)
+        if value is None:
+            return False
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, (int, float)):
+            return float(value) != 0.0
+        if isinstance(value, str):
+            return value.strip().lower() not in {"false", "0"}
+        return True
+    return True
+
+
+def _coerce_value(value: object, slot: SlotSpec) -> object | None:
+    if slot.name in {"metallic", "roughness", "glossiness", "opacity"}:
+        return _coerce_scalar_value(value)
+
+    scalar = coerce_float(value)
+    if scalar is not None:
+        return scalar
+    try:
+        return (float(value[0]), float(value[1]), float(value[2]))  # type: ignore[index]
+    except (TypeError, ValueError, IndexError):
+        return None
+
+
+def _coerce_scalar_value(value: object) -> float | None:
+    scalar = coerce_float(value)
+    if scalar is not None:
+        return scalar
+    try:
+        return float(value[0])  # type: ignore[index]
+    except (TypeError, ValueError, IndexError):
+        return None
+
+
+def _ior(values: Mapping[str, object]) -> float | None:
+    for alias in IOR_ALIASES:
+        value = coerce_float(values.get(alias))
+        if value is not None:
+            return value
+    return None

--- a/roboverse_pack/blender/usd/material_graph/adapters/omnipbr.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/omnipbr.py
@@ -8,8 +8,21 @@ from ..context import MaterialContext
 from ..extract import asset_path_string, coerce_float
 from ..fallback import CLASS_FALLBACKS, find_material_class
 from ..aliases import IOR_ALIASES
+from ..bindings import resolve_uv_set
 from ..schema import InputSpec, PreviewMaterialSpec, RawMaterialSpec, TextureSpec
 from ..slots import SLOT_REGISTRY, SlotSpec
+from ..uv import resolve_slot_uv_transform
+
+_SLOT_PREFIXES = {
+    "base_color": "BaseColor",
+    "normal": "Normal",
+    "metallic": "Metallic",
+    "roughness": "Roughness",
+    "glossiness": "Gloss",
+    "specular": "Specular",
+    "emissive": "Emissive",
+    "opacity": "Opacity",
+}
 
 
 class OmniPBRAdapter:
@@ -22,7 +35,7 @@ class OmniPBRAdapter:
         return 80 if any("omnipbr" in candidate.lower() for candidate in candidates) else 0
 
     def convert(self, raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
-        base_color = _input_from_slot(raw.values, SLOT_REGISTRY["base_color"])
+        base_color = _input_from_slot(raw.values, SLOT_REGISTRY["base_color"], context)
         material_class = find_material_class(raw.material_path, raw.connected_surface_shader_id)
         quality_notes: list[str] = []
         if base_color is None:
@@ -32,12 +45,12 @@ class OmniPBRAdapter:
                 base_color = InputSpec(value=(0.5, 0.5, 0.5))
             quality_notes.append("No diffuse color or texture alias found.")
 
-        roughness = _input_from_slot(raw.values, SLOT_REGISTRY["roughness"])
-        glossiness = _input_from_slot(raw.values, SLOT_REGISTRY["glossiness"])
+        roughness = _input_from_slot(raw.values, SLOT_REGISTRY["roughness"], context)
+        glossiness = _input_from_slot(raw.values, SLOT_REGISTRY["glossiness"], context)
         if roughness is None and glossiness is not None:
             roughness = glossiness
 
-        specular = _input_from_slot(raw.values, SLOT_REGISTRY["specular"])
+        specular = _input_from_slot(raw.values, SLOT_REGISTRY["specular"], context)
 
         return PreviewMaterialSpec(
             material_path=raw.material_path,
@@ -45,12 +58,12 @@ class OmniPBRAdapter:
             source_shader_ids=raw.shader_ids,
             mdl_source_asset=raw.mdl_source_asset,
             base_color=base_color,
-            normal=_input_from_slot(raw.values, SLOT_REGISTRY["normal"]),
-            metallic=_input_from_slot(raw.values, SLOT_REGISTRY["metallic"]),
+            normal=_input_from_slot(raw.values, SLOT_REGISTRY["normal"], context),
+            metallic=_input_from_slot(raw.values, SLOT_REGISTRY["metallic"], context),
             roughness=roughness,
             specular_color=specular,
-            emissive_color=_input_from_slot(raw.values, SLOT_REGISTRY["emissive"]),
-            opacity=_input_from_slot(raw.values, SLOT_REGISTRY["opacity"]),
+            emissive_color=_input_from_slot(raw.values, SLOT_REGISTRY["emissive"], context),
+            opacity=_input_from_slot(raw.values, SLOT_REGISTRY["opacity"], context),
             ior=_ior(raw.values),
             use_specular_workflow=specular is not None,
             material_class=material_class,
@@ -59,7 +72,7 @@ class OmniPBRAdapter:
         )
 
 
-def _input_from_slot(values: Mapping[str, object], slot: SlotSpec) -> InputSpec | None:
+def _input_from_slot(values: Mapping[str, object], slot: SlotSpec, context: MaterialContext) -> InputSpec | None:
     if not _slot_enabled(values, slot):
         return None
 
@@ -69,11 +82,15 @@ def _input_from_slot(values: Mapping[str, object], slot: SlotSpec) -> InputSpec 
             continue
         scale = (-1.0, -1.0, -1.0, -1.0) if slot.invert_to_roughness else slot.scale
         bias = (1.0, 1.0, 1.0, 1.0) if slot.invert_to_roughness else slot.bias
+        slot_prefix = _SLOT_PREFIXES[slot.name]
+        requested_uv_index = _first_int(values, (f"{slot_prefix}_MaxTexCoordIndex", "MaxTexCoordIndex"))
         return InputSpec(
             texture=TextureSpec(
                 file=texture_file,
                 source_color_space=slot.color_space,
                 channel=slot.texture_output,
+                uv_set=resolve_uv_set(requested_uv_index, _common_uv_primvars(context)),
+                uv_transform=resolve_slot_uv_transform(values, slot_prefix, slot.uva_aliases),
                 scale=scale,
                 bias=bias,
                 source_input=alias,
@@ -135,6 +152,37 @@ def _coerce_scalar_value(value: object) -> float | None:
         return float(value[0])  # type: ignore[index]
     except (TypeError, ValueError, IndexError):
         return None
+
+
+def _first_int(values: Mapping[str, object], aliases: tuple[str, ...]) -> int | None:
+    for alias in aliases:
+        if alias not in values or values.get(alias) is None:
+            continue
+        value = values.get(alias)
+        try:
+            return int(value)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            try:
+                return int(float(value))  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def _common_uv_primvars(context: MaterialContext) -> tuple[str, ...]:
+    if not context.uv_primvars_by_prim:
+        return ("st",)
+
+    paths = context.bound_prim_paths or tuple(context.uv_primvars_by_prim)
+    sets = [set(context.uv_primvars_by_prim.get(path, ())) for path in paths]
+    if not sets:
+        return ("st",)
+
+    intersection = set.intersection(*sets)
+    if intersection:
+        return tuple(sorted(intersection))
+
+    return ("st",)
 
 
 def _ior(values: Mapping[str, object]) -> float | None:

--- a/roboverse_pack/blender/usd/material_graph/adapters/omnipbr.py
+++ b/roboverse_pack/blender/usd/material_graph/adapters/omnipbr.py
@@ -11,6 +11,7 @@ from ..aliases import IOR_ALIASES
 from ..bindings import resolve_uv_set
 from ..schema import InputSpec, PreviewMaterialSpec, RawMaterialSpec, TextureSpec
 from ..slots import SLOT_REGISTRY, SlotSpec
+from ..texture_paths import normalize_texture_asset_path
 from ..uv import resolve_slot_uv_transform
 
 _SLOT_PREFIXES = {
@@ -35,9 +36,10 @@ class OmniPBRAdapter:
         return 80 if any("omnipbr" in candidate.lower() for candidate in candidates) else 0
 
     def convert(self, raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
-        base_color = _input_from_slot(raw.values, SLOT_REGISTRY["base_color"], context)
-        material_class = find_material_class(raw.material_path, raw.connected_surface_shader_id)
         quality_notes: list[str] = []
+        base_color, notes = _input_from_slot(raw.values, SLOT_REGISTRY["base_color"], context)
+        quality_notes.extend(notes)
+        material_class = find_material_class(raw.material_path, raw.connected_surface_shader_id)
         if base_color is None:
             if material_class:
                 base_color = InputSpec(value=CLASS_FALLBACKS[material_class])
@@ -45,12 +47,22 @@ class OmniPBRAdapter:
                 base_color = InputSpec(value=(0.5, 0.5, 0.5))
             quality_notes.append("No diffuse color or texture alias found.")
 
-        roughness = _input_from_slot(raw.values, SLOT_REGISTRY["roughness"], context)
-        glossiness = _input_from_slot(raw.values, SLOT_REGISTRY["glossiness"], context)
-        if roughness is None and glossiness is not None:
-            roughness = glossiness
+        roughness, notes = _input_from_slot(raw.values, SLOT_REGISTRY["roughness"], context)
+        quality_notes.extend(notes)
+        if roughness is None:
+            roughness, notes = _input_from_slot(raw.values, SLOT_REGISTRY["glossiness"], context)
+            quality_notes.extend(notes)
 
-        specular = _input_from_slot(raw.values, SLOT_REGISTRY["specular"], context)
+        specular, notes = _input_from_slot(raw.values, SLOT_REGISTRY["specular"], context)
+        quality_notes.extend(notes)
+        normal, notes = _input_from_slot(raw.values, SLOT_REGISTRY["normal"], context)
+        quality_notes.extend(notes)
+        metallic, notes = _input_from_slot(raw.values, SLOT_REGISTRY["metallic"], context)
+        quality_notes.extend(notes)
+        emissive, notes = _input_from_slot(raw.values, SLOT_REGISTRY["emissive"], context)
+        quality_notes.extend(notes)
+        opacity, notes = _input_from_slot(raw.values, SLOT_REGISTRY["opacity"], context)
+        quality_notes.extend(notes)
 
         return PreviewMaterialSpec(
             material_path=raw.material_path,
@@ -58,12 +70,12 @@ class OmniPBRAdapter:
             source_shader_ids=raw.shader_ids,
             mdl_source_asset=raw.mdl_source_asset,
             base_color=base_color,
-            normal=_input_from_slot(raw.values, SLOT_REGISTRY["normal"], context),
-            metallic=_input_from_slot(raw.values, SLOT_REGISTRY["metallic"], context),
+            normal=normal,
+            metallic=metallic,
             roughness=roughness,
             specular_color=specular,
-            emissive_color=_input_from_slot(raw.values, SLOT_REGISTRY["emissive"], context),
-            opacity=_input_from_slot(raw.values, SLOT_REGISTRY["opacity"], context),
+            emissive_color=emissive,
+            opacity=opacity,
             ior=_ior(raw.values),
             use_specular_workflow=specular is not None,
             material_class=material_class,
@@ -72,31 +84,35 @@ class OmniPBRAdapter:
         )
 
 
-def _input_from_slot(values: Mapping[str, object], slot: SlotSpec, context: MaterialContext) -> InputSpec | None:
+def _input_from_slot(
+    values: Mapping[str, object], slot: SlotSpec, context: MaterialContext
+) -> tuple[InputSpec | None, tuple[str, ...]]:
     if not _slot_enabled(values, slot):
-        return None
+        return None, ()
 
     for alias in slot.texture_aliases:
         texture_file = asset_path_string(values.get(alias))
         if not texture_file:
             continue
+        path_result = normalize_texture_asset_path(str(texture_file), context.texture_base_dir)
         scale = (-1.0, -1.0, -1.0, -1.0) if slot.invert_to_roughness else slot.scale
         bias = (1.0, 1.0, 1.0, 1.0) if slot.invert_to_roughness else slot.bias
         slot_prefix = _SLOT_PREFIXES[slot.name]
         requested_uv_index = _first_int(values, (f"{slot_prefix}_MaxTexCoordIndex", "MaxTexCoordIndex"))
         return InputSpec(
             texture=TextureSpec(
-                file=texture_file,
+                file=path_result.normalized,
                 source_color_space=slot.color_space,
                 channel=slot.texture_output,
                 uv_set=resolve_uv_set(requested_uv_index, _common_uv_primvars(context)),
                 uv_transform=resolve_slot_uv_transform(values, slot_prefix, slot.uva_aliases),
                 scale=scale,
                 bias=bias,
+                role=slot.name,
                 source_input=alias,
             ),
             source_inputs=(alias,),
-        )
+        ), path_result.warnings
 
     for alias in slot.value_aliases:
         if alias not in values or values.get(alias) is None:
@@ -110,8 +126,8 @@ def _input_from_slot(values: Mapping[str, object], slot: SlotSpec, context: Mate
             if scalar is None:
                 continue
             value = 1.0 - scalar
-        return InputSpec(value=value, source_inputs=(alias,))
-    return None
+        return InputSpec(value=value, source_inputs=(alias,)), ()
+    return None, ()
 
 
 def _slot_enabled(values: Mapping[str, object], slot: SlotSpec) -> bool:

--- a/roboverse_pack/blender/usd/material_graph/aliases.py
+++ b/roboverse_pack/blender/usd/material_graph/aliases.py
@@ -1,0 +1,19 @@
+"""Shader input aliases used by Blender USD material overlay generation."""
+
+from __future__ import annotations
+
+COLOR_ALIASES = ("diffuseColor", "BaseColor_Color", "diffuse_color_constant", "base_color")
+TEXTURE_ALIASES = (
+    "BaseColor_Tex",
+    "BaseColor_Texture",
+    "diffuse_texture",
+    "albedo_texture",
+    "base_color_texture",
+    "diffuseColor_texture",
+)
+ROUGHNESS_ALIASES = ("roughness", "reflection_roughness_constant")
+METALLIC_ALIASES = ("metallic", "metallic_constant")
+OPACITY_ALIASES = ("opacity", "opacity_constant")
+EMISSIVE_ALIASES = ("emissiveColor", "Emissive_Color")
+IOR_ALIASES = ("ior", "glass_ior", "index_of_refraction")
+

--- a/roboverse_pack/blender/usd/material_graph/aliases.py
+++ b/roboverse_pack/blender/usd/material_graph/aliases.py
@@ -11,9 +11,8 @@ TEXTURE_ALIASES = (
     "base_color_texture",
     "diffuseColor_texture",
 )
-ROUGHNESS_ALIASES = ("roughness", "reflection_roughness_constant")
-METALLIC_ALIASES = ("metallic", "metallic_constant")
+ROUGHNESS_ALIASES = ("roughness", "reflection_roughness_constant", "Roughness")
+METALLIC_ALIASES = ("metallic", "metallic_constant", "Metallic_Color", "Metallic")
 OPACITY_ALIASES = ("opacity", "opacity_constant")
 EMISSIVE_ALIASES = ("emissiveColor", "Emissive_Color")
-IOR_ALIASES = ("ior", "glass_ior", "index_of_refraction")
-
+IOR_ALIASES = ("ior", "glass_ior", "index_of_refraction", "IOR", "FresnelB")

--- a/roboverse_pack/blender/usd/material_graph/author_preview.py
+++ b/roboverse_pack/blender/usd/material_graph/author_preview.py
@@ -1,0 +1,70 @@
+"""Author USD PreviewSurface graphs for Blender material overlays."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def connect_surface(material: Any, shader: Any) -> None:
+    output = material.CreateSurfaceOutput()
+    output.ConnectToSource(shader.ConnectableAPI(), "surface")
+
+
+def author_texture_chain(
+    material_path: Any,
+    preview: Any,
+    texture_asset: str,
+    overlay_stage: Any,
+    Sdf: Any,
+    UsdShade: Any,
+) -> None:
+    reader = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewSTReader"))
+    reader.CreateIdAttr("UsdPrimvarReader_float2")
+    reader.CreateInput("varname", Sdf.ValueTypeNames.String).Set("st")
+    reader.CreateOutput("result", Sdf.ValueTypeNames.Float2)
+
+    texture = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewTexture"))
+    texture.CreateIdAttr("UsdUVTexture")
+    texture.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath(texture_asset))
+    texture.CreateInput("st", Sdf.ValueTypeNames.Float2).ConnectToSource(reader.ConnectableAPI(), "result")
+    texture.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
+
+    preview.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).ConnectToSource(texture.ConnectableAPI(), "rgb")
+
+
+def author_preview_surface(overlay_stage: Any, material_path: Any, params: dict[str, Any], Sdf: Any, UsdShade: Any) -> None:
+    overlay_material = UsdShade.Material.Define(overlay_stage, material_path)
+    preview = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewSurface"))
+    preview.CreateIdAttr("UsdPreviewSurface")
+    connect_surface(overlay_material, preview)
+
+    diffuse_texture = params.get("diffuse_texture")
+    if diffuse_texture:
+        author_texture_chain(material_path, preview, diffuse_texture, overlay_stage, Sdf, UsdShade)
+    elif params.get("diffuse_color") is not None:
+        preview.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(params["diffuse_color"])
+
+    roughness = params.get("roughness")
+    if roughness is not None:
+        preview.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(roughness)
+
+    metallic = params.get("metallic")
+    if metallic is not None:
+        preview.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(metallic)
+    elif params.get("material_class") == "metal":
+        preview.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(1.0)
+
+    opacity = params.get("opacity")
+    if opacity is not None:
+        preview.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(opacity)
+    elif params.get("material_class") == "glass":
+        preview.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(0.35)
+
+    if params.get("material_class") == "glass":
+        ior = params.get("ior")
+        preview.CreateInput("ior", Sdf.ValueTypeNames.Float).Set(ior if ior is not None else 1.45)
+
+    emissive = params.get("emissive")
+    if emissive is not None:
+        preview.CreateInput("emissiveColor", Sdf.ValueTypeNames.Color3f).Set(emissive)
+

--- a/roboverse_pack/blender/usd/material_graph/author_preview.py
+++ b/roboverse_pack/blender/usd/material_graph/author_preview.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from .report import adapter_from_policy
 from .schema import InputSpec, PreviewMaterialSpec, TextureSpec, UVTransformSpec
 
 _COLOR_INPUTS = {"diffuseColor", "emissiveColor", "specularColor"}
@@ -26,6 +27,15 @@ _ALPHA_CHANNEL_SOURCE_INPUTS = {
 def connect_surface(material: Any, shader: Any) -> None:
     output = material.CreateSurfaceOutput()
     output.ConnectToSource(shader.ConnectableAPI(), "surface")
+
+
+def _author_roboverse_custom_data(material: Any, spec: PreviewMaterialSpec) -> None:
+    prim = material.GetPrim()
+    custom_data = dict(prim.GetCustomData())
+    custom_data["roboverse:material_conversion_policy"] = spec.conversion_policy
+    custom_data["roboverse:material_adapter"] = spec.adapter_name or adapter_from_policy(spec.conversion_policy)
+    custom_data["roboverse:material_graph_version"] = "v1"
+    prim.SetCustomData(custom_data)
 
 
 def _value_type(Sdf: Any, type_name: str) -> Any:
@@ -158,6 +168,7 @@ def connect_or_set(
 def author_material(stage: Any, spec: PreviewMaterialSpec, Gf: Any, Sdf: Any, UsdShade: Any) -> None:
     material_path = Sdf.Path(spec.material_path)
     overlay_material = UsdShade.Material.Define(stage, material_path)
+    _author_roboverse_custom_data(overlay_material, spec)
     preview = UsdShade.Shader.Define(stage, material_path.AppendChild("PreviewSurface"))
     preview.CreateIdAttr("UsdPreviewSurface")
     connect_surface(overlay_material, preview)

--- a/roboverse_pack/blender/usd/material_graph/author_preview.py
+++ b/roboverse_pack/blender/usd/material_graph/author_preview.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .schema import InputSpec, PreviewMaterialSpec, TextureSpec
+from .schema import InputSpec, PreviewMaterialSpec, TextureSpec, UVTransformSpec
 
 _COLOR_INPUTS = {"diffuseColor", "emissiveColor", "specularColor"}
 _TEXTURE_OUTPUT_TYPES = {
@@ -44,11 +44,24 @@ def author_texture_chain(
     reader.CreateIdAttr("UsdPrimvarReader_float2")
     reader.CreateInput("varname", Sdf.ValueTypeNames.String).Set(texture_spec.uv_set.primvar_name)
     reader.CreateOutput("result", Sdf.ValueTypeNames.Float2)
+    st_source = reader
+
+    if texture_spec.uv_transform is not None:
+        st_source = author_transform2d(
+            stage,
+            material_path,
+            slot_name,
+            texture_spec.uv_transform,
+            reader,
+            "result",
+            Sdf,
+            UsdShade,
+        )
 
     texture = UsdShade.Shader.Define(stage, material_path.AppendChild(f"{slot_name}_Texture"))
     texture.CreateIdAttr("UsdUVTexture")
     texture.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath(texture_spec.file))
-    texture.CreateInput("st", Sdf.ValueTypeNames.Float2).ConnectToSource(reader.ConnectableAPI(), "result")
+    texture.CreateInput("st", Sdf.ValueTypeNames.Float2).ConnectToSource(st_source.ConnectableAPI(), "result")
     texture.CreateInput("sourceColorSpace", Sdf.ValueTypeNames.Token).Set(texture_spec.source_color_space)
     if texture_spec.scale is not None:
         texture.CreateInput("scale", Sdf.ValueTypeNames.Float4).Set(texture_spec.scale)
@@ -61,6 +74,26 @@ def author_texture_chain(
         texture.CreateOutput(output_name, _value_type(Sdf, type_name))
 
     return texture
+
+
+def author_transform2d(
+    stage: Any,
+    material_path: Any,
+    slot_name: str,
+    transform_spec: UVTransformSpec,
+    prior_source: Any,
+    prior_output: str,
+    Sdf: Any,
+    UsdShade: Any,
+) -> Any:
+    transform = UsdShade.Shader.Define(stage, material_path.AppendChild(f"{slot_name}_Transform2d"))
+    transform.CreateIdAttr("UsdTransform2d")
+    transform.CreateInput("in", Sdf.ValueTypeNames.Float2).ConnectToSource(prior_source.ConnectableAPI(), prior_output)
+    transform.CreateInput("scale", Sdf.ValueTypeNames.Float2).Set(transform_spec.scale)
+    transform.CreateInput("rotation", Sdf.ValueTypeNames.Float).Set(transform_spec.rotation_degrees)
+    transform.CreateInput("translation", Sdf.ValueTypeNames.Float2).Set(transform_spec.translation)
+    transform.CreateOutput("result", Sdf.ValueTypeNames.Float2)
+    return transform
 
 
 def _preview_input_type(input_name: str, Sdf: Any) -> Any:

--- a/roboverse_pack/blender/usd/material_graph/author_preview.py
+++ b/roboverse_pack/blender/usd/material_graph/author_preview.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .schema import InputSpec, PreviewMaterialSpec, TextureSpec
+
 
 def connect_surface(material: Any, shader: Any) -> None:
     output = material.CreateSurfaceOutput()
@@ -13,7 +15,7 @@ def connect_surface(material: Any, shader: Any) -> None:
 def author_texture_chain(
     material_path: Any,
     preview: Any,
-    texture_asset: str,
+    texture_spec: TextureSpec,
     overlay_stage: Any,
     Sdf: Any,
     UsdShade: Any,
@@ -25,46 +27,64 @@ def author_texture_chain(
 
     texture = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewTexture"))
     texture.CreateIdAttr("UsdUVTexture")
-    texture.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath(texture_asset))
+    texture.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath(texture_spec.file))
     texture.CreateInput("st", Sdf.ValueTypeNames.Float2).ConnectToSource(reader.ConnectableAPI(), "result")
     texture.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
 
     preview.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).ConnectToSource(texture.ConnectableAPI(), "rgb")
 
 
-def author_preview_surface(overlay_stage: Any, material_path: Any, params: dict[str, Any], Sdf: Any, UsdShade: Any) -> None:
-    overlay_material = UsdShade.Material.Define(overlay_stage, material_path)
-    preview = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewSurface"))
+def _preview_input_type(input_name: str, Sdf: Any) -> Any:
+    if input_name in {"diffuseColor", "emissiveColor", "specularColor"}:
+        return Sdf.ValueTypeNames.Color3f
+    return Sdf.ValueTypeNames.Float
+
+
+def _preview_input_value(value: Any, input_name: str, Gf: Any) -> Any:
+    if value is not None and input_name in {"diffuseColor", "emissiveColor", "specularColor"}:
+        try:
+            return Gf.Vec3f(float(value[0]), float(value[1]), float(value[2]))
+        except (TypeError, ValueError, IndexError):
+            return value
+    return value
+
+
+def _set_preview_input(preview: Any, input_name: str, spec: InputSpec, Gf: Any, Sdf: Any) -> None:
+    if spec.value is None:
+        return
+    preview.CreateInput(input_name, _preview_input_type(input_name, Sdf)).Set(
+        _preview_input_value(spec.value, input_name, Gf)
+    )
+
+
+def author_preview_material(stage: Any, spec: PreviewMaterialSpec, Gf: Any, Sdf: Any, UsdShade: Any) -> None:
+    material_path = Sdf.Path(spec.material_path)
+    overlay_material = UsdShade.Material.Define(stage, material_path)
+    preview = UsdShade.Shader.Define(stage, material_path.AppendChild("PreviewSurface"))
     preview.CreateIdAttr("UsdPreviewSurface")
     connect_surface(overlay_material, preview)
 
-    diffuse_texture = params.get("diffuse_texture")
+    diffuse_texture = spec.base_color.texture
     if diffuse_texture:
-        author_texture_chain(material_path, preview, diffuse_texture, overlay_stage, Sdf, UsdShade)
-    elif params.get("diffuse_color") is not None:
-        preview.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(params["diffuse_color"])
+        author_texture_chain(material_path, preview, diffuse_texture, stage, Sdf, UsdShade)
+    else:
+        _set_preview_input(preview, "diffuseColor", spec.base_color, Gf, Sdf)
 
-    roughness = params.get("roughness")
-    if roughness is not None:
-        preview.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(roughness)
+    if spec.roughness is not None:
+        _set_preview_input(preview, "roughness", spec.roughness, Gf, Sdf)
 
-    metallic = params.get("metallic")
-    if metallic is not None:
-        preview.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(metallic)
-    elif params.get("material_class") == "metal":
+    if spec.metallic is not None and spec.metallic.value is not None:
+        _set_preview_input(preview, "metallic", spec.metallic, Gf, Sdf)
+    elif spec.material_class == "metal":
         preview.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(1.0)
 
-    opacity = params.get("opacity")
-    if opacity is not None:
-        preview.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(opacity)
-    elif params.get("material_class") == "glass":
+    if spec.opacity is not None and spec.opacity.value is not None:
+        _set_preview_input(preview, "opacity", spec.opacity, Gf, Sdf)
+    elif spec.material_class == "glass":
         preview.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(0.35)
 
-    if params.get("material_class") == "glass":
-        ior = params.get("ior")
-        preview.CreateInput("ior", Sdf.ValueTypeNames.Float).Set(ior if ior is not None else 1.45)
+    if spec.material_class == "glass":
+        preview.CreateInput("ior", Sdf.ValueTypeNames.Float).Set(spec.ior if spec.ior is not None else 1.45)
 
-    emissive = params.get("emissive")
-    if emissive is not None:
-        preview.CreateInput("emissiveColor", Sdf.ValueTypeNames.Color3f).Set(emissive)
-
+    if spec.emissive_color is not None:
+        _set_preview_input(preview, "emissiveColor", spec.emissive_color, Gf, Sdf)

--- a/roboverse_pack/blender/usd/material_graph/author_preview.py
+++ b/roboverse_pack/blender/usd/material_graph/author_preview.py
@@ -6,42 +6,77 @@ from typing import Any
 
 from .schema import InputSpec, PreviewMaterialSpec, TextureSpec
 
+_COLOR_INPUTS = {"diffuseColor", "emissiveColor", "specularColor"}
+_TEXTURE_OUTPUT_TYPES = {
+    "rgb": "Float3",
+    "r": "Float",
+    "g": "Float",
+    "b": "Float",
+    "a": "Float",
+}
+_ALPHA_CHANNEL_SOURCE_INPUTS = {
+    "Opacity_Tex",
+    "Opacity_Texture",
+    "Alpha_Tex",
+    "Alpha_Texture",
+    "alpha_texture",
+}
+
 
 def connect_surface(material: Any, shader: Any) -> None:
     output = material.CreateSurfaceOutput()
     output.ConnectToSource(shader.ConnectableAPI(), "surface")
 
 
+def _value_type(Sdf: Any, type_name: str) -> Any:
+    return getattr(Sdf.ValueTypeNames, type_name)
+
+
 def author_texture_chain(
+    stage: Any,
     material_path: Any,
-    preview: Any,
+    slot_name: str,
     texture_spec: TextureSpec,
-    overlay_stage: Any,
     Sdf: Any,
     UsdShade: Any,
-) -> None:
-    reader = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewSTReader"))
+) -> Any:
+    reader = UsdShade.Shader.Define(stage, material_path.AppendChild(f"{slot_name}_Primvar"))
     reader.CreateIdAttr("UsdPrimvarReader_float2")
-    reader.CreateInput("varname", Sdf.ValueTypeNames.String).Set("st")
+    reader.CreateInput("varname", Sdf.ValueTypeNames.String).Set(texture_spec.uv_set.primvar_name)
     reader.CreateOutput("result", Sdf.ValueTypeNames.Float2)
 
-    texture = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewTexture"))
+    texture = UsdShade.Shader.Define(stage, material_path.AppendChild(f"{slot_name}_Texture"))
     texture.CreateIdAttr("UsdUVTexture")
     texture.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath(texture_spec.file))
     texture.CreateInput("st", Sdf.ValueTypeNames.Float2).ConnectToSource(reader.ConnectableAPI(), "result")
-    texture.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
+    texture.CreateInput("sourceColorSpace", Sdf.ValueTypeNames.Token).Set(texture_spec.source_color_space)
+    if texture_spec.scale is not None:
+        texture.CreateInput("scale", Sdf.ValueTypeNames.Float4).Set(texture_spec.scale)
+    if texture_spec.bias is not None:
+        texture.CreateInput("bias", Sdf.ValueTypeNames.Float4).Set(texture_spec.bias)
+    texture.CreateInput("wrapS", Sdf.ValueTypeNames.Token).Set(texture_spec.wrap_s or "repeat")
+    texture.CreateInput("wrapT", Sdf.ValueTypeNames.Token).Set(texture_spec.wrap_t or "repeat")
 
-    preview.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).ConnectToSource(texture.ConnectableAPI(), "rgb")
+    for output_name, type_name in _TEXTURE_OUTPUT_TYPES.items():
+        texture.CreateOutput(output_name, _value_type(Sdf, type_name))
+
+    return texture
 
 
 def _preview_input_type(input_name: str, Sdf: Any) -> Any:
-    if input_name in {"diffuseColor", "emissiveColor", "specularColor"}:
+    if input_name in _COLOR_INPUTS:
+        return Sdf.ValueTypeNames.Color3f
+    if input_name == "normal":
+        if hasattr(Sdf.ValueTypeNames, "Normal3f"):
+            return Sdf.ValueTypeNames.Normal3f
+        if hasattr(Sdf.ValueTypeNames, "Float3"):
+            return Sdf.ValueTypeNames.Float3
         return Sdf.ValueTypeNames.Color3f
     return Sdf.ValueTypeNames.Float
 
 
 def _preview_input_value(value: Any, input_name: str, Gf: Any) -> Any:
-    if value is not None and input_name in {"diffuseColor", "emissiveColor", "specularColor"}:
+    if value is not None and input_name in _COLOR_INPUTS:
         try:
             return Gf.Vec3f(float(value[0]), float(value[1]), float(value[2]))
         except (TypeError, ValueError, IndexError):
@@ -49,42 +84,88 @@ def _preview_input_value(value: Any, input_name: str, Gf: Any) -> Any:
     return value
 
 
-def _set_preview_input(preview: Any, input_name: str, spec: InputSpec, Gf: Any, Sdf: Any) -> None:
+def _resolved_texture_channel(texture: TextureSpec) -> str:
+    if texture.channel != "a_or_r":
+        return texture.channel
+    if texture.source_input in _ALPHA_CHANNEL_SOURCE_INPUTS:
+        return "a"
+    return "r"
+
+
+def connect_or_set(
+    stage: Any,
+    material_path: Any,
+    surface: Any,
+    input_name: str,
+    slot_name: str,
+    spec: InputSpec | None,
+    Gf: Any,
+    Sdf: Any,
+    UsdShade: Any,
+) -> None:
+    if spec is None:
+        return
+
+    if spec.texture is not None:
+        texture = author_texture_chain(stage, material_path, slot_name, spec.texture, Sdf, UsdShade)
+        channel = _resolved_texture_channel(spec.texture)
+        surface.CreateInput(input_name, _preview_input_type(input_name, Sdf)).ConnectToSource(
+            texture.ConnectableAPI(), channel
+        )
+        return
+
     if spec.value is None:
         return
-    preview.CreateInput(input_name, _preview_input_type(input_name, Sdf)).Set(
+
+    surface.CreateInput(input_name, _preview_input_type(input_name, Sdf)).Set(
         _preview_input_value(spec.value, input_name, Gf)
     )
 
 
-def author_preview_material(stage: Any, spec: PreviewMaterialSpec, Gf: Any, Sdf: Any, UsdShade: Any) -> None:
+def author_material(stage: Any, spec: PreviewMaterialSpec, Gf: Any, Sdf: Any, UsdShade: Any) -> None:
     material_path = Sdf.Path(spec.material_path)
     overlay_material = UsdShade.Material.Define(stage, material_path)
     preview = UsdShade.Shader.Define(stage, material_path.AppendChild("PreviewSurface"))
     preview.CreateIdAttr("UsdPreviewSurface")
     connect_surface(overlay_material, preview)
 
-    diffuse_texture = spec.base_color.texture
-    if diffuse_texture:
-        author_texture_chain(material_path, preview, diffuse_texture, stage, Sdf, UsdShade)
-    else:
-        _set_preview_input(preview, "diffuseColor", spec.base_color, Gf, Sdf)
+    connect_or_set(stage, material_path, preview, "diffuseColor", "base_color", spec.base_color, Gf, Sdf, UsdShade)
+    if spec.normal is not None and spec.normal.texture is not None:
+        connect_or_set(stage, material_path, preview, "normal", "normal", spec.normal, Gf, Sdf, UsdShade)
+    connect_or_set(stage, material_path, preview, "roughness", "roughness", spec.roughness, Gf, Sdf, UsdShade)
 
-    if spec.roughness is not None:
-        _set_preview_input(preview, "roughness", spec.roughness, Gf, Sdf)
-
-    if spec.metallic is not None and spec.metallic.value is not None:
-        _set_preview_input(preview, "metallic", spec.metallic, Gf, Sdf)
+    if spec.metallic is not None and (spec.metallic.texture is not None or spec.metallic.value is not None):
+        connect_or_set(stage, material_path, preview, "metallic", "metallic", spec.metallic, Gf, Sdf, UsdShade)
     elif spec.material_class == "metal":
         preview.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(1.0)
 
-    if spec.opacity is not None and spec.opacity.value is not None:
-        _set_preview_input(preview, "opacity", spec.opacity, Gf, Sdf)
+    if spec.specular_color is not None:
+        connect_or_set(
+            stage,
+            material_path,
+            preview,
+            "specularColor",
+            "specular",
+            spec.specular_color,
+            Gf,
+            Sdf,
+            UsdShade,
+        )
+    if spec.use_specular_workflow:
+        preview.CreateInput("useSpecularWorkflow", Sdf.ValueTypeNames.Int).Set(1)
+
+    connect_or_set(
+        stage, material_path, preview, "emissiveColor", "emissive", spec.emissive_color, Gf, Sdf, UsdShade
+    )
+
+    if spec.opacity is not None and (spec.opacity.texture is not None or spec.opacity.value is not None):
+        connect_or_set(stage, material_path, preview, "opacity", "opacity", spec.opacity, Gf, Sdf, UsdShade)
     elif spec.material_class == "glass":
         preview.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(0.35)
 
     if spec.material_class == "glass":
         preview.CreateInput("ior", Sdf.ValueTypeNames.Float).Set(spec.ior if spec.ior is not None else 1.45)
 
-    if spec.emissive_color is not None:
-        _set_preview_input(preview, "emissiveColor", spec.emissive_color, Gf, Sdf)
+
+def author_preview_material(stage: Any, spec: PreviewMaterialSpec, Gf: Any, Sdf: Any, UsdShade: Any) -> None:
+    author_material(stage, spec, Gf, Sdf, UsdShade)

--- a/roboverse_pack/blender/usd/material_graph/bindings.py
+++ b/roboverse_pack/blender/usd/material_graph/bindings.py
@@ -1,0 +1,117 @@
+"""Material binding context and UV primvar resolution helpers."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any, Mapping
+
+from .schema import UVSetSpec
+
+_UV_PRIMVAR_RE = re.compile(r"^(?:st\d*|uv\d*|map\d+)$")
+
+
+@dataclass(frozen=True)
+class MaterialBindingContext:
+    material_path: str
+    bound_prim_paths: tuple[str, ...]
+    uv_primvars_by_prim: Mapping[str, tuple[str, ...]]
+
+
+def _attr_name(attribute: Any) -> str:
+    get_name = getattr(attribute, "GetName", None)
+    if get_name is not None:
+        return str(get_name())
+    return str(attribute)
+
+
+def _uv_primvars(prim: Any, UsdGeom: Any) -> tuple[str, ...]:
+    names: set[str] = set()
+    get_attributes = getattr(prim, "GetAttributes", None)
+    if get_attributes is None:
+        return ()
+    for attribute in get_attributes():
+        full_name = _attr_name(attribute)
+        if not full_name.startswith("primvars:"):
+            continue
+        name = full_name.removeprefix("primvars:").split(":", 1)[0]
+        if _UV_PRIMVAR_RE.match(name):
+            names.add(name)
+    return tuple(sorted(names))
+
+
+def _bound_material_path(prim: Any, UsdShade: Any) -> str | None:
+    try:
+        binding = UsdShade.MaterialBindingAPI(prim)
+        bound = binding.ComputeBoundMaterial()
+    except Exception:
+        return None
+    material = bound[0] if isinstance(bound, tuple) else bound
+    if not material:
+        return None
+    get_prim = getattr(material, "GetPrim", None)
+    material_prim = get_prim() if get_prim is not None else material
+    get_path = getattr(material_prim, "GetPath", None)
+    if get_path is None:
+        return None
+    return str(get_path())
+
+
+def _is_bindable_geometry(prim: Any, UsdGeom: Any) -> bool:
+    if UsdGeom is None:
+        return True
+    is_a = getattr(prim, "IsA", None)
+    if is_a is None:
+        return True
+    for schema_name in ("Gprim", "Mesh"):
+        schema = getattr(UsdGeom, schema_name, None)
+        if schema is None:
+            continue
+        try:
+            if prim.IsA(schema):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def collect_material_binding_contexts(stage: Any, UsdShade: Any, UsdGeom: Any) -> dict[str, MaterialBindingContext]:
+    bound_paths: dict[str, list[str]] = {}
+    uv_sets: dict[str, dict[str, tuple[str, ...]]] = {}
+
+    for prim in stage.Traverse():
+        if not _is_bindable_geometry(prim, UsdGeom):
+            continue
+        material_path = _bound_material_path(prim, UsdShade)
+        if material_path is None:
+            continue
+        prim_path = str(prim.GetPath())
+        bound_paths.setdefault(material_path, []).append(prim_path)
+        uv_sets.setdefault(material_path, {})[prim_path] = _uv_primvars(prim, UsdGeom)
+
+    return {
+        material_path: MaterialBindingContext(
+            material_path=material_path,
+            bound_prim_paths=tuple(paths),
+            uv_primvars_by_prim=MappingProxyType(dict(uv_sets.get(material_path, {}))),
+        )
+        for material_path, paths in bound_paths.items()
+    }
+
+
+def resolve_uv_set(requested_index: int | None, available_primvars: tuple[str, ...]) -> UVSetSpec:
+    available = set(available_primvars)
+    if requested_index is None or requested_index == 0:
+        preferences = ("st", "st0", "uv", "uv0", "map1")
+    else:
+        preferences = (
+            f"st{requested_index}",
+            f"uv{requested_index}",
+            f"uv{requested_index + 1}",
+            f"map{requested_index + 1}",
+        )
+    for primvar_name in preferences:
+        if primvar_name in available:
+            return UVSetSpec(primvar_name, requested_index, "matched")
+    return UVSetSpec("st", requested_index, "guessed_or_missing")

--- a/roboverse_pack/blender/usd/material_graph/context.py
+++ b/roboverse_pack/blender/usd/material_graph/context.py
@@ -1,0 +1,17 @@
+"""Context carried through material graph adapter conversion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class MaterialContext:
+    source_path: Path
+    texture_base_dir: Path
+    material_path: str
+    bound_prim_paths: tuple[str, ...] = ()
+    uv_primvars_by_prim: Mapping[str, tuple[str, ...]] | None = None
+    enable_mdl_bake: bool = False

--- a/roboverse_pack/blender/usd/material_graph/extract.py
+++ b/roboverse_pack/blender/usd/material_graph/extract.py
@@ -174,6 +174,19 @@ def extract_material(material_prim: Any, UsdShade: Any) -> RawMaterialSpec:
     )
 
 
+def iter_material_prims(stage: Any, UsdShade: Any | None = None) -> Any:
+    for prim in stage.Traverse():
+        if UsdShade is not None:
+            try:
+                if prim.IsA(UsdShade.Material):
+                    yield prim
+                    continue
+            except Exception:
+                pass
+        if getattr(prim, "GetTypeName", lambda: None)() == "Material":
+            yield prim
+
+
 def shader_ids(material_prim: Any, Usd: Any, UsdShade: Any) -> list[str]:
     ids = []
     for descendant in Usd.PrimRange(material_prim):

--- a/roboverse_pack/blender/usd/material_graph/extract.py
+++ b/roboverse_pack/blender/usd/material_graph/extract.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .schema import RawMaterialSpec, freeze_values
+
 
 def coerce_float(value: Any) -> float | None:
     if value is None:
@@ -30,6 +32,16 @@ def asset_path_string(value: Any) -> str | None:
     return path or str(value)
 
 
+def _source_asset_path_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    path = getattr(value, "path", None)
+    candidate = str(path) if path is not None else asset_path_string(value)
+    if candidate is None or not candidate.strip():
+        return None
+    return candidate
+
+
 def shader_input(shader: Any, aliases: tuple[str, ...]) -> Any:
     if shader is None:
         return None
@@ -39,6 +51,47 @@ def shader_input(shader: Any, aliases: tuple[str, ...]) -> Any:
             value = shader_input_value.Get()
             if value is not None:
                 return value
+    return None
+
+
+def _source_asset_from_get_source_asset(shader: Any) -> str | None:
+    get_source_asset = getattr(shader, "GetSourceAsset", None)
+    if get_source_asset is None:
+        return None
+    try:
+        return _source_asset_path_string(get_source_asset("mdl"))
+    except (TypeError, AttributeError):
+        return None
+
+
+def _source_asset_from_info_attribute(shader: Any) -> str | None:
+    get_prim = getattr(shader, "GetPrim", None)
+    prim = get_prim() if get_prim is not None else getattr(shader, "prim", None)
+    get_attribute = getattr(prim, "GetAttribute", None)
+    if get_attribute is None:
+        return None
+    attribute = get_attribute("info:mdl:sourceAsset")
+    if not attribute:
+        return None
+    return _source_asset_path_string(attribute.Get())
+
+
+def _source_asset_from_legacy_input(shader: Any) -> str | None:
+    source_input_value = shader.GetInput("mdl:sourceAsset")
+    if not source_input_value:
+        return None
+    return _source_asset_path_string(source_input_value.Get())
+
+
+def source_asset_from_shader(shader: Any) -> str | None:
+    for extractor in (
+        _source_asset_from_get_source_asset,
+        _source_asset_from_info_attribute,
+        _source_asset_from_legacy_input,
+    ):
+        source_asset = extractor(shader)
+        if source_asset is not None:
+            return source_asset
     return None
 
 
@@ -55,6 +108,70 @@ def connected_surface_shader_id(material: Any) -> str | None:
         return None
     shader_id_value = shader.GetIdAttr().Get()
     return str(shader_id_value) if shader_id_value else None
+
+
+def _iter_descendants(prim: Any) -> Any:
+    for child in prim.GetChildren():
+        yield child
+        yield from _iter_descendants(child)
+
+
+def _input_base_name(shader_input_value: Any) -> str:
+    get_base_name = getattr(shader_input_value, "GetBaseName", None)
+    if get_base_name is not None:
+        base_name = get_base_name()
+        if base_name:
+            return str(base_name)
+    full_name = shader_input_value.GetFullName()
+    return str(full_name).split(":")[-1]
+
+
+def _record_shader_inputs(values: dict[str, object], shader: Any) -> None:
+    if not shader:
+        return
+    for shader_input_value in shader.GetInputs():
+        value = shader_input_value.Get()
+        if value is not None:
+            values.setdefault(_input_base_name(shader_input_value), value)
+
+
+def input_values(material_prim: Any, UsdShade: Any) -> dict[str, object]:
+    values: dict[str, object] = {}
+    _record_shader_inputs(values, surface_shader(UsdShade.Material(material_prim)))
+    for descendant in _iter_descendants(material_prim):
+        if descendant.IsA(UsdShade.Shader):
+            _record_shader_inputs(values, UsdShade.Shader(descendant))
+    return values
+
+
+def extract_material(material_prim: Any, UsdShade: Any) -> RawMaterialSpec:
+    material = UsdShade.Material(material_prim)
+    ids: list[str] = []
+    mdl_source_asset = None
+    connected_shader = surface_shader(material)
+    connected_shader_id_value = connected_shader.GetIdAttr().Get() if connected_shader else None
+    if connected_shader_id_value:
+        ids.append(str(connected_shader_id_value))
+
+    for descendant in _iter_descendants(material_prim):
+        if not descendant.IsA(UsdShade.Shader):
+            continue
+        shader = UsdShade.Shader(descendant)
+        shader_id = shader.GetIdAttr().Get()
+        if shader_id and str(shader_id) not in ids:
+            ids.append(str(shader_id))
+        source_asset = source_asset_from_shader(shader)
+        if source_asset is not None and mdl_source_asset is None:
+            mdl_source_asset = source_asset
+
+    return RawMaterialSpec(
+        material_path=str(material_prim.GetPath()),
+        material_name=material_prim.GetName(),
+        shader_ids=tuple(ids),
+        connected_surface_shader_id=connected_surface_shader_id(material),
+        mdl_source_asset=mdl_source_asset,
+        values=freeze_values(input_values(material_prim, UsdShade)),
+    )
 
 
 def shader_ids(material_prim: Any, Usd: Any, UsdShade: Any) -> list[str]:
@@ -74,10 +191,7 @@ def source_asset_from_material(material_prim: Any, Usd: Any, UsdShade: Any) -> s
         if descendant.GetPath() == material_prim.GetPath() or not descendant.IsA(UsdShade.Shader):
             continue
         shader = UsdShade.Shader(descendant)
-        source_input_value = shader.GetInput("mdl:sourceAsset")
-        if source_input_value:
-            source_asset = asset_path_string(source_input_value.Get())
-            if source_asset is not None:
-                return source_asset
+        source_asset = source_asset_from_shader(shader)
+        if source_asset is not None:
+            return source_asset
     return None
-

--- a/roboverse_pack/blender/usd/material_graph/extract.py
+++ b/roboverse_pack/blender/usd/material_graph/extract.py
@@ -1,0 +1,83 @@
+"""Extraction helpers for source USD material graphs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def coerce_vec3(value: Any, Gf: Any) -> Any | None:
+    if value is None:
+        return None
+    try:
+        return Gf.Vec3f(float(value[0]), float(value[1]), float(value[2]))
+    except (TypeError, ValueError, IndexError):
+        return None
+
+
+def asset_path_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    path = getattr(value, "path", None)
+    return path or str(value)
+
+
+def shader_input(shader: Any, aliases: tuple[str, ...]) -> Any:
+    if shader is None:
+        return None
+    for alias in aliases:
+        shader_input_value = shader.GetInput(alias)
+        if shader_input_value:
+            value = shader_input_value.Get()
+            if value is not None:
+                return value
+    return None
+
+
+def surface_shader(material: Any) -> Any:
+    source = material.ComputeSurfaceSource()
+    if isinstance(source, tuple):
+        return source[0] if source else None
+    return source
+
+
+def connected_surface_shader_id(material: Any) -> str | None:
+    shader = surface_shader(material)
+    if not shader:
+        return None
+    shader_id_value = shader.GetIdAttr().Get()
+    return str(shader_id_value) if shader_id_value else None
+
+
+def shader_ids(material_prim: Any, Usd: Any, UsdShade: Any) -> list[str]:
+    ids = []
+    for descendant in Usd.PrimRange(material_prim):
+        if descendant.GetPath() == material_prim.GetPath() or not descendant.IsA(UsdShade.Shader):
+            continue
+        shader = UsdShade.Shader(descendant)
+        shader_id = shader.GetIdAttr().Get()
+        if shader_id:
+            ids.append(str(shader_id))
+    return ids
+
+
+def source_asset_from_material(material_prim: Any, Usd: Any, UsdShade: Any) -> str | None:
+    for descendant in Usd.PrimRange(material_prim):
+        if descendant.GetPath() == material_prim.GetPath() or not descendant.IsA(UsdShade.Shader):
+            continue
+        shader = UsdShade.Shader(descendant)
+        source_input_value = shader.GetInput("mdl:sourceAsset")
+        if source_input_value:
+            source_asset = asset_path_string(source_input_value.Get())
+            if source_asset is not None:
+                return source_asset
+    return None
+

--- a/roboverse_pack/blender/usd/material_graph/fallback.py
+++ b/roboverse_pack/blender/usd/material_graph/fallback.py
@@ -1,0 +1,35 @@
+"""Fallback material classification for Blender USD preview authoring."""
+
+from __future__ import annotations
+
+CLASS_FALLBACKS = {
+    "wall": (0.72, 0.72, 0.68),
+    "floor": (0.55, 0.50, 0.44),
+    "cabinet": (0.60, 0.46, 0.32),
+    "glass": (0.78, 0.90, 0.96),
+    "screen": (0.02, 0.02, 0.025),
+    "metal": (0.55, 0.55, 0.55),
+    "fabric": (0.48, 0.42, 0.38),
+}
+
+
+def find_material_class(material_path: str, shader_id: str | None) -> str | None:
+    text = f"{material_path} {shader_id or ''}".lower()
+    for material_class in CLASS_FALLBACKS:
+        if material_class in text:
+            return material_class
+    return None
+
+
+def is_glass_material(material_class: str | None) -> bool:
+    return material_class == "glass"
+
+
+def is_default_gray_color(value: object) -> bool:
+    if value is None:
+        return False
+    try:
+        return tuple(float(value[index]) for index in range(3)) == (0.5, 0.5, 0.5)
+    except (TypeError, ValueError, IndexError):
+        return False
+

--- a/roboverse_pack/blender/usd/material_graph/kit_bake.py
+++ b/roboverse_pack/blender/usd/material_graph/kit_bake.py
@@ -1,0 +1,38 @@
+"""Kit/Isaac Sim command helpers for MDL material baking."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .context import MaterialContext
+from .schema import PreviewMaterialSpec, RawMaterialSpec
+
+
+def kit_bake_command(
+    isaacsim_bin: Path,
+    script_path: Path,
+    source_path: Path,
+    material_path: str,
+    cache_dir: Path,
+) -> list[str]:
+    return [
+        str(isaacsim_bin),
+        "--no-window",
+        "--/app/window/enabled=false",
+        "--exec",
+        str(script_path),
+        "--",
+        "--source",
+        str(source_path),
+        "--material",
+        str(material_path),
+        "--cache-dir",
+        str(cache_dir),
+    ]
+
+
+def bake_mdl_material_to_preview(raw: RawMaterialSpec, context: MaterialContext) -> PreviewMaterialSpec:
+    raise RuntimeError(
+        "MDL bake requires Kit execution; call kit_overlay.py or configure the MDL bake runner before selecting "
+        "MdlBakeAdapter"
+    )

--- a/roboverse_pack/blender/usd/material_graph/normalize.py
+++ b/roboverse_pack/blender/usd/material_graph/normalize.py
@@ -1,0 +1,44 @@
+"""Normalize source material inputs into preview authoring parameters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .aliases import (
+    COLOR_ALIASES,
+    EMISSIVE_ALIASES,
+    IOR_ALIASES,
+    METALLIC_ALIASES,
+    OPACITY_ALIASES,
+    ROUGHNESS_ALIASES,
+    TEXTURE_ALIASES,
+)
+from .extract import asset_path_string, coerce_float, coerce_vec3, shader_input
+from .fallback import CLASS_FALLBACKS, find_material_class
+
+
+def normalize_preview_parameters(source_shader: Any, material_path: str, shader_id: str | None, Gf: Any) -> dict[str, Any]:
+    """Return preview authoring params; ``None`` values mean skip the input."""
+    material_class = find_material_class(material_path, shader_id)
+    warnings = []
+
+    diffuse_color = coerce_vec3(shader_input(source_shader, COLOR_ALIASES), Gf)
+    diffuse_texture = asset_path_string(shader_input(source_shader, TEXTURE_ALIASES))
+    if not diffuse_texture:
+        if diffuse_color is None and material_class:
+            diffuse_color = Gf.Vec3f(*CLASS_FALLBACKS[material_class])
+        if diffuse_color is None:
+            warnings.append("No diffuse color or texture alias found.")
+
+    return {
+        "diffuse_color": diffuse_color,
+        "diffuse_texture": diffuse_texture,
+        "roughness": coerce_float(shader_input(source_shader, ROUGHNESS_ALIASES)),
+        "metallic": coerce_float(shader_input(source_shader, METALLIC_ALIASES)),
+        "opacity": coerce_float(shader_input(source_shader, OPACITY_ALIASES)),
+        "ior": coerce_float(shader_input(source_shader, IOR_ALIASES)),
+        "emissive": coerce_vec3(shader_input(source_shader, EMISSIVE_ALIASES), Gf),
+        "material_class": material_class,
+        "warnings": warnings,
+    }
+

--- a/roboverse_pack/blender/usd/material_graph/normalize.py
+++ b/roboverse_pack/blender/usd/material_graph/normalize.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Mapping
 
 from .aliases import (
     COLOR_ALIASES,
@@ -13,32 +13,95 @@ from .aliases import (
     ROUGHNESS_ALIASES,
     TEXTURE_ALIASES,
 )
-from .extract import asset_path_string, coerce_float, coerce_vec3, shader_input
+from .extract import asset_path_string, coerce_float
 from .fallback import CLASS_FALLBACKS, find_material_class
+from .schema import ConversionPolicy, InputSpec, PreviewMaterialSpec, RawMaterialSpec, TextureSpec
 
 
-def normalize_preview_parameters(source_shader: Any, material_path: str, shader_id: str | None, Gf: Any) -> dict[str, Any]:
-    """Return preview authoring params; ``None`` values mean skip the input."""
-    material_class = find_material_class(material_path, shader_id)
-    warnings = []
+def _value_for_alias(values: Mapping[str, object], aliases: tuple[str, ...]) -> tuple[object | None, str | None]:
+    for alias in aliases:
+        value = values.get(alias)
+        if value is not None:
+            return value, alias
+    return None, None
 
-    diffuse_color = coerce_vec3(shader_input(source_shader, COLOR_ALIASES), Gf)
-    diffuse_texture = asset_path_string(shader_input(source_shader, TEXTURE_ALIASES))
-    if not diffuse_texture:
+
+def _coerce_vec3_tuple(value: object | None) -> tuple[float, float, float] | None:
+    if value is None:
+        return None
+    try:
+        return (float(value[0]), float(value[1]), float(value[2]))  # type: ignore[index]
+    except (TypeError, ValueError, IndexError):
+        return None
+
+
+def _scalar_input(value: object | None, source: str | None) -> InputSpec | None:
+    coerced = coerce_float(value)
+    if coerced is None:
+        return None
+    return InputSpec(value=coerced, source_inputs=(source,) if source else ())
+
+
+def _vec3_input(value: object | None, source: str | None) -> InputSpec | None:
+    coerced = _coerce_vec3_tuple(value)
+    if coerced is None:
+        return None
+    return InputSpec(value=coerced, source_inputs=(source,) if source else ())
+
+
+def normalize_material(raw: RawMaterialSpec) -> PreviewMaterialSpec:
+    material_class = find_material_class(raw.material_path, raw.connected_surface_shader_id)
+    quality_notes: list[str] = []
+    conversion_policy: ConversionPolicy = "direct_graph"
+
+    diffuse_value, diffuse_source = _value_for_alias(raw.values, COLOR_ALIASES)
+    diffuse_color = _coerce_vec3_tuple(diffuse_value)
+    texture_value, texture_source = _value_for_alias(raw.values, TEXTURE_ALIASES)
+    diffuse_texture = asset_path_string(texture_value)
+
+    if diffuse_texture:
+        base_color = InputSpec(
+            texture=TextureSpec(
+                file=diffuse_texture,
+                source_color_space="sRGB",
+                source_input=texture_source,
+            ),
+            source_inputs=(texture_source,) if texture_source else (),
+        )
+    else:
         if diffuse_color is None and material_class:
-            diffuse_color = Gf.Vec3f(*CLASS_FALLBACKS[material_class])
+            diffuse_color = CLASS_FALLBACKS[material_class]
+            conversion_policy = "class_fallback"
         if diffuse_color is None:
-            warnings.append("No diffuse color or texture alias found.")
+            quality_notes.append("No diffuse color or texture alias found.")
+        base_color = InputSpec(value=diffuse_color, source_inputs=(diffuse_source,) if diffuse_source else ())
 
-    return {
-        "diffuse_color": diffuse_color,
-        "diffuse_texture": diffuse_texture,
-        "roughness": coerce_float(shader_input(source_shader, ROUGHNESS_ALIASES)),
-        "metallic": coerce_float(shader_input(source_shader, METALLIC_ALIASES)),
-        "opacity": coerce_float(shader_input(source_shader, OPACITY_ALIASES)),
-        "ior": coerce_float(shader_input(source_shader, IOR_ALIASES)),
-        "emissive": coerce_vec3(shader_input(source_shader, EMISSIVE_ALIASES), Gf),
-        "material_class": material_class,
-        "warnings": warnings,
-    }
+    roughness_value, roughness_source = _value_for_alias(raw.values, ROUGHNESS_ALIASES)
+    metallic_value, metallic_source = _value_for_alias(raw.values, METALLIC_ALIASES)
+    opacity_value, opacity_source = _value_for_alias(raw.values, OPACITY_ALIASES)
+    ior_value, ior_source = _value_for_alias(raw.values, IOR_ALIASES)
+    emissive_value, emissive_source = _value_for_alias(raw.values, EMISSIVE_ALIASES)
 
+    roughness = _scalar_input(roughness_value, roughness_source)
+    metallic = _scalar_input(metallic_value, metallic_source)
+    opacity = _scalar_input(opacity_value, opacity_source)
+    emissive_color = _vec3_input(emissive_value, emissive_source)
+    ior = coerce_float(ior_value)
+
+    return PreviewMaterialSpec(
+        material_path=raw.material_path,
+        material_name=raw.material_name,
+        source_shader_ids=raw.shader_ids,
+        mdl_source_asset=raw.mdl_source_asset,
+        base_color=base_color,
+        normal=None,
+        metallic=metallic,
+        roughness=roughness,
+        specular_color=None,
+        emissive_color=emissive_color,
+        opacity=opacity,
+        ior=ior,
+        material_class=material_class,
+        conversion_policy=conversion_policy,
+        quality_notes=tuple(quality_notes),
+    )

--- a/roboverse_pack/blender/usd/material_graph/report.py
+++ b/roboverse_pack/blender/usd/material_graph/report.py
@@ -1,0 +1,45 @@
+"""Report helpers for Blender USD material overlay conversion."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def material_entry(material_path: str) -> dict[str, Any]:
+    return {
+        "status": "converted",
+        "warnings": [],
+        "material_class": None,
+    }
+
+
+def write_conversion_report_md(report: dict[str, Any], path: str | Path) -> None:
+    lines = [
+        "# Blender Material Overlay Conversion Report",
+        "",
+        f"Input: `{report.get('input_path', '')}`",
+        f"Overlay: `{report.get('overlay_path', '')}`",
+        f"Root: `{report.get('root_path', '')}`",
+        "",
+        "| Material | Status | Class | Warnings |",
+        "| --- | --- | --- | --- |",
+    ]
+    for material_path, entry in sorted(report.get("materials", {}).items()):
+        warnings = "; ".join(entry.get("warnings", []))
+        lines.append(
+            f"| `{material_path}` | {entry.get('status', '')} | {entry.get('material_class') or ''} | {warnings} |"
+        )
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_conversion_reports(report: dict[str, Any], cache: str | Path) -> None:
+    output_dir = Path(cache)
+    report_json = output_dir / "conversion_report.json"
+    report_md = output_dir / "conversion_report.md"
+    report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_conversion_report_md(report, report_md)
+

--- a/roboverse_pack/blender/usd/material_graph/report.py
+++ b/roboverse_pack/blender/usd/material_graph/report.py
@@ -6,12 +6,22 @@ import json
 from pathlib import Path
 from typing import Any
 
+from .schema import PreviewMaterialSpec
+
 
 def material_entry(material_path: str) -> dict[str, Any]:
     return {
         "status": "converted",
         "warnings": [],
         "material_class": None,
+    }
+
+
+def material_entry_from_spec(spec: PreviewMaterialSpec) -> dict[str, Any]:
+    return {
+        "status": "converted",
+        "warnings": list(spec.quality_notes),
+        "material_class": spec.material_class,
     }
 
 
@@ -42,4 +52,3 @@ def write_conversion_reports(report: dict[str, Any], cache: str | Path) -> None:
     report_md = output_dir / "conversion_report.md"
     report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     write_conversion_report_md(report, report_md)
-

--- a/roboverse_pack/blender/usd/material_graph/report.py
+++ b/roboverse_pack/blender/usd/material_graph/report.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
-from .schema import PreviewMaterialSpec
+from .schema import InputSpec, PreviewMaterialSpec, TextureSpec, UVTransformSpec
 
 
 def material_entry(material_path: str) -> dict[str, Any]:
@@ -15,6 +16,17 @@ def material_entry(material_path: str) -> dict[str, Any]:
         "warnings": [],
         "material_class": None,
     }
+
+
+def adapter_from_policy(policy: str) -> str:
+    return {
+        "preserve_existing_preview": "existing_preview",
+        "direct_graph": "omnipbr",
+        "mdl_bake": "mdl_bake",
+        "scalar_fallback": "scalar_fallback",
+        "class_fallback": "semantic_class_fallback",
+        "failed": "failed",
+    }.get(policy, "unknown")
 
 
 def material_entry_from_spec(spec: PreviewMaterialSpec) -> dict[str, Any]:
@@ -26,38 +38,253 @@ def material_entry_from_spec(spec: PreviewMaterialSpec) -> dict[str, Any]:
     }
 
 
-def failed_material_entry(error: Exception) -> dict[str, Any]:
+def failed_material_entry(error: Exception | str) -> dict[str, Any]:
+    warning = str(error)
+    if not warning.startswith("conversion failed: "):
+        warning = f"conversion failed: {warning}"
     return {
         "status": "failed",
-        "warnings": [f"conversion failed: {error}"],
+        "warnings": [warning],
         "material_class": None,
     }
 
 
-def write_conversion_report_md(report: dict[str, Any], path: str | Path) -> None:
+_SLOT_FIELDS = {
+    "base_color": "base_color",
+    "normal": "normal",
+    "metallic": "metallic",
+    "roughness": "roughness",
+    "specular": "specular_color",
+    "emissive": "emissive_color",
+    "opacity": "opacity",
+}
+
+
+def _empty_summary() -> dict[str, int]:
+    return {
+        "materials_total": 0,
+        "preserve_existing_preview": 0,
+        "converted_by_direct_graph": 0,
+        "converted_by_mdl_distill_bake": 0,
+        "scalar_fallback": 0,
+        "class_fallback": 0,
+        "failed": 0,
+    }
+
+
+def _empty_texture_slots() -> dict[str, dict[str, int]]:
+    slots = {slot: {"texture": 0, "scalar": 0, "missing": 0} for slot in _SLOT_FIELDS}
+    slots["glossiness"] = {"texture_inverted": 0, "scalar_inverted": 0}
+    return slots
+
+
+def _empty_uv() -> dict[str, int]:
+    return {
+        "uv_transforms_found": 0,
+        "uv_transforms_converted": 0,
+        "multi_uv_requested": 0,
+        "multi_uv_resolved": 0,
+        "multi_uv_unresolved": 0,
+    }
+
+
+def _empty_udim() -> dict[str, int]:
+    return {"materials_with_udim": 0, "normalized": 0}
+
+
+def _uv_transform_dict(transform: UVTransformSpec) -> dict[str, Any]:
+    return {
+        "scale": list(transform.scale),
+        "rotation_degrees": transform.rotation_degrees,
+        "translation": list(transform.translation),
+        "source_input": transform.source_input,
+    }
+
+
+def _texture_dict(texture: TextureSpec) -> dict[str, Any]:
+    data: dict[str, Any] = {
+        "file": texture.file,
+        "source_color_space": texture.source_color_space,
+        "channel": texture.channel,
+        "uv_set": {
+            "primvar_name": texture.uv_set.primvar_name,
+            "requested_index": texture.uv_set.requested_index,
+            "resolution_status": texture.uv_set.resolution_status,
+        },
+    }
+    if texture.source_input is not None:
+        data["source_input"] = texture.source_input
+    if texture.uv_transform is not None:
+        data["uv_transform"] = _uv_transform_dict(texture.uv_transform)
+    if texture.scale is not None:
+        data["scale"] = list(texture.scale)
+    if texture.bias is not None:
+        data["bias"] = list(texture.bias)
+    return data
+
+
+def _slot_entry(slot: InputSpec | None) -> dict[str, Any]:
+    if slot is None:
+        return {"status": "missing"}
+    if slot.texture is not None:
+        data = {"status": "texture", "source_inputs": list(slot.source_inputs)}
+        data.update(_texture_dict(slot.texture))
+        return data
+    if slot.value is not None:
+        return {
+            "status": "scalar",
+            "value": _jsonable(slot.value),
+            "source_inputs": list(slot.source_inputs),
+        }
+    return {"status": "missing", "source_inputs": list(slot.source_inputs)}
+
+
+class ConversionReport:
+    def __init__(self, **metadata: Any) -> None:
+        self._metadata = dict(metadata)
+        self._materials: list[dict[str, Any]] = []
+
+    def add_material(self, spec: PreviewMaterialSpec) -> None:
+        slots = {
+            slot_name: _slot_entry(getattr(spec, field_name))
+            for slot_name, field_name in _SLOT_FIELDS.items()
+        }
+        self._materials.append(
+            {
+                "material_path": spec.material_path,
+                "adapter": spec.adapter_name or adapter_from_policy(spec.conversion_policy),
+                "policy": spec.conversion_policy,
+                "slots": slots,
+                "warnings": list(spec.quality_notes),
+            }
+        )
+
+    def add_failed_material(self, material_path: str, warning: str) -> None:
+        self._materials.append(
+            {
+                "material_path": material_path,
+                "adapter": adapter_from_policy("failed"),
+                "policy": "failed",
+                "slots": {},
+                "warnings": [warning],
+            }
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        summary = _empty_summary()
+        texture_slots = _empty_texture_slots()
+        uv = _empty_uv()
+        udim = _empty_udim()
+
+        materials: list[dict[str, Any]] = []
+        for material in self._materials:
+            materials.append(deepcopy(material))
+            summary["materials_total"] += 1
+            policy = material["policy"]
+            if policy == "direct_graph":
+                summary["converted_by_direct_graph"] += 1
+            elif policy == "mdl_bake":
+                summary["converted_by_mdl_distill_bake"] += 1
+            elif policy in summary:
+                summary[policy] += 1
+
+            material_has_udim = False
+            for slot_name, slot in material.get("slots", {}).items():
+                if slot_name in texture_slots and slot["status"] in texture_slots[slot_name]:
+                    texture_slots[slot_name][slot["status"]] += 1
+                if slot_name == "roughness" and _slot_has_glossiness_conversion(slot):
+                    key = "texture_inverted" if slot["status"] == "texture" else "scalar_inverted"
+                    texture_slots["glossiness"][key] += 1
+                if slot["status"] != "texture":
+                    continue
+                if slot.get("uv_transform") is not None:
+                    uv["uv_transforms_found"] += 1
+                    uv["uv_transforms_converted"] += 1
+                uv_set = slot.get("uv_set", {})
+                if uv_set.get("requested_index") is not None:
+                    uv["multi_uv_requested"] += 1
+                    if uv_set.get("resolution_status") in {"matched", "resolved"}:
+                        uv["multi_uv_resolved"] += 1
+                    else:
+                        uv["multi_uv_unresolved"] += 1
+                if "<UDIM>" in slot.get("file", ""):
+                    material_has_udim = True
+            if material_has_udim:
+                udim["materials_with_udim"] += 1
+                udim["normalized"] += 1
+
+        data: dict[str, Any] = dict(self._metadata)
+        data.update(
+            {
+                "summary": summary,
+                "texture_slots": texture_slots,
+                "uv": uv,
+                "udim": udim,
+                "materials": materials,
+            }
+        )
+        return data
+
+
+def _slot_has_glossiness_conversion(slot: dict[str, Any]) -> bool:
+    sources = list(slot.get("source_inputs", []))
+    if slot.get("source_input"):
+        sources.append(slot["source_input"])
+    return any("gloss" in source.lower() for source in sources)
+
+
+def _jsonable(value: Any) -> Any:
+    if value is None or isinstance(value, str | int | float | bool):
+        return value
+    if isinstance(value, tuple | list):
+        return [_jsonable(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    try:
+        return [_jsonable(item) for item in value]
+    except TypeError:
+        return str(value)
+
+
+def _report_dict(report: dict[str, Any] | ConversionReport) -> dict[str, Any]:
+    if isinstance(report, ConversionReport):
+        return report.to_dict()
+    return report
+
+
+def write_conversion_report_md(report: dict[str, Any] | ConversionReport, path: str | Path) -> None:
+    report_data = _report_dict(report)
     lines = [
         "# Blender Material Overlay Conversion Report",
         "",
-        f"Input: `{report.get('input_path', '')}`",
-        f"Overlay: `{report.get('overlay_path', '')}`",
-        f"Root: `{report.get('root_path', '')}`",
+        f"Input: `{report_data.get('input_path', '')}`",
+        f"Overlay: `{report_data.get('overlay_path', '')}`",
+        f"Root: `{report_data.get('root_path', '')}`",
         "",
         "| Material | Status | Class | Warnings |",
         "| --- | --- | --- | --- |",
     ]
-    for material_path, entry in sorted(report.get("materials", {}).items()):
-        warnings = "; ".join(entry.get("warnings", []))
-        lines.append(
-            f"| `{material_path}` | {entry.get('status', '')} | {entry.get('material_class') or ''} | {warnings} |"
-        )
+    materials = report_data.get("materials", {})
+    if isinstance(materials, dict):
+        for material_path, entry in sorted(materials.items()):
+            warnings = "; ".join(entry.get("warnings", []))
+            lines.append(
+                f"| `{material_path}` | {entry.get('status', '')} | {entry.get('material_class') or ''} | {warnings} |"
+            )
+    else:
+        for entry in sorted(materials, key=lambda item: item.get("material_path", "")):
+            warnings = "; ".join(entry.get("warnings", []))
+            status = "failed" if entry.get("policy") == "failed" else entry.get("policy", "")
+            lines.append(f"| `{entry.get('material_path', '')}` | {status} |  | {warnings} |")
     output = Path(path)
     output.parent.mkdir(parents=True, exist_ok=True)
     output.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
-def write_conversion_reports(report: dict[str, Any], cache: str | Path) -> None:
+def write_conversion_reports(report: dict[str, Any] | ConversionReport, cache: str | Path) -> None:
     output_dir = Path(cache)
     report_json = output_dir / "conversion_report.json"
     report_md = output_dir / "conversion_report.md"
-    report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    report_data = _report_dict(report)
+    report_json.write_text(json.dumps(report_data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     write_conversion_report_md(report, report_md)

--- a/roboverse_pack/blender/usd/material_graph/report.py
+++ b/roboverse_pack/blender/usd/material_graph/report.py
@@ -18,10 +18,19 @@ def material_entry(material_path: str) -> dict[str, Any]:
 
 
 def material_entry_from_spec(spec: PreviewMaterialSpec) -> dict[str, Any]:
+    status = "skipped" if spec.conversion_policy == "preserve_existing_preview" else "converted"
     return {
-        "status": "converted",
+        "status": status,
         "warnings": list(spec.quality_notes),
         "material_class": spec.material_class,
+    }
+
+
+def failed_material_entry(error: Exception) -> dict[str, Any]:
+    return {
+        "status": "failed",
+        "warnings": [f"conversion failed: {error}"],
+        "material_class": None,
     }
 
 

--- a/roboverse_pack/blender/usd/material_graph/schema.py
+++ b/roboverse_pack/blender/usd/material_graph/schema.py
@@ -83,6 +83,7 @@ class PreviewMaterialSpec:
     material_class: str | None = None
     conversion_policy: ConversionPolicy = "direct_graph"
     quality_notes: tuple[str, ...] = ()
+    adapter_name: str | None = None
 
 
 def freeze_values(values: Mapping[str, object]) -> Mapping[str, object]:

--- a/roboverse_pack/blender/usd/material_graph/schema.py
+++ b/roboverse_pack/blender/usd/material_graph/schema.py
@@ -1,0 +1,89 @@
+"""Typed intermediate representation for USD material graph conversion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import MappingProxyType
+from typing import Literal, Mapping
+
+ColorSpace = Literal["sRGB", "raw", "auto"]
+TextureChannel = Literal["rgb", "r", "g", "b", "a", "a_or_r"]
+ConversionPolicy = Literal[
+    "preserve_existing_preview",
+    "direct_graph",
+    "mdl_bake",
+    "scalar_fallback",
+    "class_fallback",
+    "failed",
+]
+
+
+@dataclass(frozen=True)
+class UVTransformSpec:
+    scale: tuple[float, float] = (1.0, 1.0)
+    rotation_degrees: float = 0.0
+    translation: tuple[float, float] = (0.0, 0.0)
+    source_input: str | None = None
+
+
+@dataclass(frozen=True)
+class UVSetSpec:
+    primvar_name: str = "st"
+    requested_index: int | None = None
+    resolution_status: str = "default"
+
+
+@dataclass(frozen=True)
+class TextureSpec:
+    file: str
+    source_color_space: ColorSpace
+    channel: TextureChannel = "rgb"
+    uv_set: UVSetSpec = field(default_factory=UVSetSpec)
+    uv_transform: UVTransformSpec | None = None
+    scale: tuple[float, float, float, float] | None = None
+    bias: tuple[float, float, float, float] | None = None
+    wrap_s: str | None = None
+    wrap_t: str | None = None
+    role: str | None = None
+    source_input: str | None = None
+
+
+@dataclass(frozen=True)
+class InputSpec:
+    value: object | None = None
+    texture: TextureSpec | None = None
+    source_inputs: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class RawMaterialSpec:
+    material_path: str
+    material_name: str
+    shader_ids: tuple[str, ...]
+    connected_surface_shader_id: str | None
+    mdl_source_asset: str | None
+    values: Mapping[str, object]
+
+
+@dataclass(frozen=True)
+class PreviewMaterialSpec:
+    material_path: str
+    material_name: str
+    source_shader_ids: tuple[str, ...]
+    mdl_source_asset: str | None
+    base_color: InputSpec
+    normal: InputSpec | None
+    metallic: InputSpec | None
+    roughness: InputSpec | None
+    specular_color: InputSpec | None
+    emissive_color: InputSpec | None
+    opacity: InputSpec | None
+    ior: float | None = None
+    use_specular_workflow: bool = False
+    material_class: str | None = None
+    conversion_policy: ConversionPolicy = "direct_graph"
+    quality_notes: tuple[str, ...] = ()
+
+
+def freeze_values(values: Mapping[str, object]) -> Mapping[str, object]:
+    return MappingProxyType(dict(values))

--- a/roboverse_pack/blender/usd/material_graph/slots.py
+++ b/roboverse_pack/blender/usd/material_graph/slots.py
@@ -1,0 +1,108 @@
+"""Declarative source input slots for OmniPBR-like material graphs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .aliases import (
+    COLOR_ALIASES,
+    EMISSIVE_ALIASES,
+    METALLIC_ALIASES,
+    OPACITY_ALIASES,
+    ROUGHNESS_ALIASES,
+    TEXTURE_ALIASES,
+)
+from .schema import ColorSpace, TextureChannel
+
+
+@dataclass(frozen=True)
+class SlotSpec:
+    name: str
+    value_aliases: tuple[str, ...] = ()
+    texture_aliases: tuple[str, ...] = ()
+    enable_aliases: tuple[str, ...] = ()
+    uva_aliases: tuple[str, ...] = ()
+    color_space: ColorSpace = "raw"
+    texture_output: TextureChannel = "rgb"
+    scale: tuple[float, float, float, float] | None = None
+    bias: tuple[float, float, float, float] | None = None
+    invert_to_roughness: bool = False
+    requires_specular_workflow: bool = False
+
+
+SLOT_REGISTRY: dict[str, SlotSpec] = {
+    "base_color": SlotSpec(
+        name="base_color",
+        value_aliases=COLOR_ALIASES,
+        texture_aliases=TEXTURE_ALIASES,
+        enable_aliases=("enable_base_color", "BaseColor_Enable", "base_color_enabled"),
+        uva_aliases=("BaseColor_UVA", "Diffuse_UVA", "BaseColor_UV", "BaseColor_UVSet", "base_color_uv"),
+        color_space="sRGB",
+    ),
+    "normal": SlotSpec(
+        name="normal",
+        texture_aliases=("Normal_Tex", "Normal_Texture", "normal_texture", "normalmap_texture", "bump_texture"),
+        enable_aliases=("enable_normal", "Normal_Enable", "normal_enabled"),
+        uva_aliases=("Normal_UVA", "Normal_UV", "Normal_UVSet", "normal_uv"),
+        color_space="raw",
+        scale=(2.0, 2.0, 2.0, 1.0),
+        bias=(-1.0, -1.0, -1.0, 0.0),
+    ),
+    "metallic": SlotSpec(
+        name="metallic",
+        value_aliases=METALLIC_ALIASES,
+        texture_aliases=("Metallic_Tex", "Metallic_Texture", "metallic_texture"),
+        enable_aliases=("enable_metallic", "Metallic_Enable", "metallic_enabled"),
+        uva_aliases=("Metallic_UVA", "Metallic_UV", "Metallic_UVSet", "metallic_uv"),
+        texture_output="r",
+    ),
+    "roughness": SlotSpec(
+        name="roughness",
+        value_aliases=ROUGHNESS_ALIASES,
+        texture_aliases=("Roughness_Tex", "Roughness_Texture", "roughness_texture"),
+        enable_aliases=("enable_roughness", "Roughness_Enable", "roughness_enabled"),
+        uva_aliases=("Roughness_UVA", "Roughness_UV", "Roughness_UVSet", "roughness_uv"),
+        texture_output="r",
+    ),
+    "glossiness": SlotSpec(
+        name="glossiness",
+        value_aliases=("glossiness", "Glossiness", "Gloss_Color", "glossiness_constant", "reflection_glossiness_constant"),
+        texture_aliases=("Glossiness_Tex", "Glossiness_Texture", "Gloss_Tex", "glossiness_texture", "gloss_texture"),
+        enable_aliases=("enable_glossiness", "Glossiness_Enable", "glossiness_enabled"),
+        uva_aliases=("Gloss_UVA", "Glossiness_UV", "Glossiness_UVSet", "glossiness_uv"),
+        texture_output="r",
+        invert_to_roughness=True,
+    ),
+    "specular": SlotSpec(
+        name="specular",
+        value_aliases=("specular", "specularColor", "Specular_Color", "specular_color"),
+        texture_aliases=("Specular_Tex", "Specular_Texture", "specular_texture"),
+        enable_aliases=("enable_specular", "Specular_Enable", "specular_enabled"),
+        uva_aliases=("Specular_UVA", "Specular_UV", "Specular_UVSet", "specular_uv"),
+        color_space="sRGB",
+        requires_specular_workflow=True,
+    ),
+    "emissive": SlotSpec(
+        name="emissive",
+        value_aliases=EMISSIVE_ALIASES + ("Emission_Color",),
+        texture_aliases=(
+            "Emissive_Tex",
+            "Emissive_Texture",
+            "Emission_Tex",
+            "Emission_Texture",
+            "emissive_texture",
+            "emission_texture",
+        ),
+        enable_aliases=("enable_emissive", "Emissive_Enable", "emissive_enabled"),
+        uva_aliases=("Emissive_UVA", "Emission_UVA", "Emissive_UV", "Emissive_UVSet", "emissive_uv"),
+        color_space="sRGB",
+    ),
+    "opacity": SlotSpec(
+        name="opacity",
+        value_aliases=OPACITY_ALIASES,
+        texture_aliases=("Opacity_Tex", "Opacity_Texture", "Alpha_Tex", "opacity_texture", "alpha_texture"),
+        enable_aliases=("enable_opacity", "Opacity_Enable", "opacity_enabled"),
+        uva_aliases=("Opacity_UVA", "Alpha_UVA", "Opacity_UV", "Opacity_UVSet", "opacity_uv"),
+        texture_output="a_or_r",
+    ),
+}

--- a/roboverse_pack/blender/usd/material_graph/texture_paths.py
+++ b/roboverse_pack/blender/usd/material_graph/texture_paths.py
@@ -1,0 +1,120 @@
+"""Texture asset path normalization and UDIM tile discovery."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+
+
+@dataclass(frozen=True)
+class UdimInfo:
+    normalized_path: str
+    first_tile: int | None
+
+
+@dataclass(frozen=True)
+class TexturePathResult:
+    raw: str
+    normalized: str
+    is_udim: bool
+    candidates: tuple[Path, ...]
+    exists: bool
+    warnings: tuple[str, ...] = ()
+
+
+_UDIM_TOKEN = "<UDIM>"
+_PRINTF_UDIM_TOKEN = "%(UDIM)d"
+_UDIM_TILE_RE = re.compile(r"(?P<prefix>.*[./])(?P<tile>1[0-9]{3})(?P<suffix>\.[A-Za-z0-9]+)$")
+
+
+def detect_udim_pattern(path: str) -> UdimInfo | None:
+    if _UDIM_TOKEN in path:
+        return UdimInfo(normalized_path=path, first_tile=None)
+
+    if _PRINTF_UDIM_TOKEN in path:
+        return UdimInfo(normalized_path=path.replace(_PRINTF_UDIM_TOKEN, _UDIM_TOKEN), first_tile=None)
+
+    match = _UDIM_TILE_RE.match(path)
+    if match is None:
+        return None
+
+    tile = int(match.group("tile"))
+    if not 1001 <= tile <= 1100:
+        return None
+
+    return UdimInfo(
+        normalized_path=f"{match.group('prefix')}{_UDIM_TOKEN}{match.group('suffix')}",
+        first_tile=tile,
+    )
+
+
+def find_texture_file_candidates(raw: str, base_dir: Path) -> list[Path]:
+    clean = _strip_asset_path(raw)
+    if not clean:
+        return []
+
+    udim = detect_udim_pattern(clean)
+    if udim is not None:
+        return _find_udim_candidates(udim.normalized_path, base_dir)
+
+    candidate = Path(clean)
+    if not candidate.is_absolute():
+        candidate = base_dir / candidate
+
+    return [candidate] if candidate.is_file() else []
+
+
+def normalize_texture_asset_path(raw: str, base_dir: Path) -> TexturePathResult:
+    clean = _strip_asset_path(raw)
+    udim = detect_udim_pattern(clean)
+    normalized = udim.normalized_path if udim is not None else clean
+    candidates = tuple(find_texture_file_candidates(clean, base_dir))
+    exists = bool(candidates)
+
+    warnings: tuple[str, ...] = ()
+    if not exists:
+        if udim is not None:
+            warnings = (f"UDIM texture tile/file not found: {normalized}",)
+        else:
+            warnings = (f"Texture file not found: {normalized}",)
+
+    return TexturePathResult(
+        raw=clean,
+        normalized=normalized,
+        is_udim=udim is not None,
+        candidates=candidates,
+        exists=exists,
+        warnings=warnings,
+    )
+
+
+def _strip_asset_path(raw: str) -> str:
+    return str(raw).strip().strip("@").strip()
+
+
+def _find_udim_candidates(normalized_path: str, base_dir: Path) -> list[Path]:
+    path = Path(normalized_path)
+    search_path = path if path.is_absolute() else base_dir / path
+    parent = search_path.parent
+    if not parent.is_dir():
+        return []
+
+    name_re = _udim_name_regex(search_path.name)
+    candidates: list[Path] = []
+    for child in sorted(parent.iterdir(), key=lambda candidate: candidate.name):
+        if not child.is_file():
+            continue
+        match = name_re.fullmatch(child.name)
+        if match is None:
+            continue
+        tile = int(match.group("tile"))
+        if 1001 <= tile <= 1100:
+            candidates.append(child)
+    return candidates
+
+
+def _udim_name_regex(name: str) -> re.Pattern[str]:
+    escaped = re.escape(name)
+    tile_pattern = r"(?P<tile>1[0-9]{3})"
+    return re.compile(escaped.replace(re.escape(_UDIM_TOKEN), tile_pattern))

--- a/roboverse_pack/blender/usd/material_graph/uv.py
+++ b/roboverse_pack/blender/usd/material_graph/uv.py
@@ -1,0 +1,119 @@
+"""UV transform parsing helpers for OmniPBR-style UVA inputs."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import replace
+from typing import Any
+
+from .schema import UVTransformSpec
+
+
+def _float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _pair(value: Any) -> tuple[float, float] | None:
+    scalar = _float(value)
+    if scalar is not None:
+        return (scalar, scalar)
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        return None
+    if len(value) < 2:
+        return None
+    first = _float(value[0])
+    second = _float(value[1])
+    if first is None or second is None:
+        return None
+    return (first, second)
+
+
+def _first_mapping_value(value: Mapping[str, Any], names: tuple[str, ...]) -> Any:
+    for name in names:
+        if name in value and value[name] is not None:
+            return value[name]
+    return None
+
+
+def parse_uva(value: Any) -> UVTransformSpec | None:
+    """Parse common UVA payloads.
+
+    Sequence values follow the OmniPBR-style convention:
+    float4 = (uScale, vScale, uOffset, vOffset), float3 = (uniformScale, uOffset, vOffset).
+    """
+
+    if isinstance(value, Mapping):
+        scale = _pair(_first_mapping_value(value, ("scale",))) or (1.0, 1.0)
+        translation = _pair(_first_mapping_value(value, ("translation", "offset"))) or (0.0, 0.0)
+        rotation = _float(_first_mapping_value(value, ("rotation", "rotation_degrees"))) or 0.0
+        return UVTransformSpec(scale=scale, rotation_degrees=rotation, translation=translation)
+
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        return None
+
+    try:
+        if len(value) == 4:
+            scale_u = _float(value[0])
+            scale_v = _float(value[1])
+            translate_u = _float(value[2])
+            translate_v = _float(value[3])
+            if None in (scale_u, scale_v, translate_u, translate_v):
+                return None
+            return UVTransformSpec(
+                scale=(scale_u, scale_v),  # type: ignore[arg-type]
+                translation=(translate_u, translate_v),  # type: ignore[arg-type]
+            )
+        if len(value) == 3:
+            scale = _float(value[0])
+            translate_u = _float(value[1])
+            translate_v = _float(value[2])
+            if None in (scale, translate_u, translate_v):
+                return None
+            return UVTransformSpec(
+                scale=(scale, scale),  # type: ignore[arg-type]
+                translation=(translate_u, translate_v),  # type: ignore[arg-type]
+            )
+    except (TypeError, IndexError):
+        return None
+    return None
+
+
+def resolve_slot_uv_transform(
+    values: Mapping[str, object],
+    prefix: str,
+    uva_aliases: tuple[str, ...],
+) -> UVTransformSpec | None:
+    for alias in uva_aliases:
+        if alias not in values:
+            continue
+        spec = parse_uva(values.get(alias))
+        if spec is not None:
+            return replace(spec, source_input=alias)
+
+    field_names = (
+        f"{prefix}_UScale",
+        f"{prefix}_VScale",
+        f"{prefix}_Rotation",
+        f"{prefix}_UOffset",
+        f"{prefix}_VOffset",
+    )
+    if not any(name in values and values.get(name) is not None for name in field_names):
+        return None
+
+    u_scale = _float(values.get(f"{prefix}_UScale"))
+    v_scale = _float(values.get(f"{prefix}_VScale"))
+    rotation = _float(values.get(f"{prefix}_Rotation"))
+    u_offset = _float(values.get(f"{prefix}_UOffset"))
+    v_offset = _float(values.get(f"{prefix}_VOffset"))
+
+    return UVTransformSpec(
+        scale=(1.0 if u_scale is None else u_scale, 1.0 if v_scale is None else v_scale),
+        rotation_degrees=0.0 if rotation is None else rotation,
+        translation=(0.0 if u_offset is None else u_offset, 0.0 if v_offset is None else v_offset),
+        source_input=f"{prefix}_*",
+    )

--- a/roboverse_pack/blender/usd/overlay.py
+++ b/roboverse_pack/blender/usd/overlay.py
@@ -7,10 +7,11 @@ import os
 from pathlib import Path
 from typing import Any
 
+from .material_graph.adapters import convert_material
 from .material_graph.author_preview import author_preview_material
+from .material_graph.context import MaterialContext
 from .material_graph.extract import extract_material, surface_shader
-from .material_graph.normalize import normalize_material
-from .material_graph.report import material_entry_from_spec, write_conversion_report_md, write_conversion_reports
+from .material_graph.report import failed_material_entry, material_entry_from_spec, write_conversion_reports
 
 
 def _clear_or_create_layer(path: Path, Sdf: Any) -> Any:
@@ -26,6 +27,60 @@ def _sublayer_path(layer_path: Path, root_parent: Path) -> str:
     if layer_path.is_absolute():
         return str(layer_path)
     return os.path.relpath(layer_path, root_parent)
+
+
+def _convert_and_author_material(
+    raw: Any,
+    context: MaterialContext,
+    report: dict[str, Any],
+    overlay_stage: Any,
+    Gf: Any,
+    Sdf: Any,
+    UsdShade: Any,
+) -> None:
+    try:
+        spec = convert_material(raw, context)
+        report["materials"][spec.material_path] = material_entry_from_spec(spec)
+        if spec.conversion_policy == "preserve_existing_preview":
+            return
+        author_preview_material(overlay_stage, spec, Gf, Sdf, UsdShade)
+    except Exception as exc:
+        report["materials"][raw.material_path] = failed_material_entry(exc)
+
+
+def _prim_path_string(prim: Any) -> str:
+    try:
+        return str(prim.GetPath())
+    except Exception:
+        return "<unknown material>"
+
+
+def _extract_convert_and_author_material(
+    prim: Any,
+    UsdShade: Any,
+    source_path: Path,
+    report: dict[str, Any],
+    overlay_stage: Any,
+    Gf: Any,
+    Sdf: Any,
+    authoring_usdshade: Any,
+) -> None:
+    material_path = _prim_path_string(prim)
+    try:
+        raw = extract_material(prim, UsdShade)
+        material_path = raw.material_path
+        context = MaterialContext(
+            source_path=source_path,
+            texture_base_dir=source_path.parent,
+            material_path=raw.material_path,
+        )
+        spec = convert_material(raw, context)
+        report["materials"][spec.material_path] = material_entry_from_spec(spec)
+        if spec.conversion_policy == "preserve_existing_preview":
+            return
+        author_preview_material(overlay_stage, spec, Gf, Sdf, authoring_usdshade)
+    except Exception as exc:
+        report["materials"][material_path] = failed_material_entry(exc)
 
 
 def generate_blender_overlay(
@@ -65,11 +120,7 @@ def generate_blender_overlay(
         if not prim.IsA(UsdShade.Material):
             continue
 
-        raw = extract_material(prim, UsdShade)
-        spec = normalize_material(raw)
-        author_preview_material(overlay_stage, spec, Gf, Sdf, UsdShade)
-
-        report["materials"][spec.material_path] = material_entry_from_spec(spec)
+        _extract_convert_and_author_material(prim, UsdShade, source_path, report, overlay_stage, Gf, Sdf, UsdShade)
 
     overlay_layer.Save()
     root_layer = _clear_or_create_layer(root, Sdf)

--- a/roboverse_pack/blender/usd/overlay.py
+++ b/roboverse_pack/blender/usd/overlay.py
@@ -7,10 +7,10 @@ import os
 from pathlib import Path
 from typing import Any
 
-from .material_graph.author_preview import author_preview_surface
-from .material_graph.extract import connected_surface_shader_id, surface_shader
-from .material_graph.normalize import normalize_preview_parameters
-from .material_graph.report import material_entry, write_conversion_report_md, write_conversion_reports
+from .material_graph.author_preview import author_preview_material
+from .material_graph.extract import extract_material, surface_shader
+from .material_graph.normalize import normalize_material
+from .material_graph.report import material_entry_from_spec, write_conversion_report_md, write_conversion_reports
 
 
 def _clear_or_create_layer(path: Path, Sdf: Any) -> Any:
@@ -65,20 +65,11 @@ def generate_blender_overlay(
         if not prim.IsA(UsdShade.Material):
             continue
 
-        material_path = prim.GetPath()
-        material_path_str = str(material_path)
-        source_material = UsdShade.Material(prim)
-        source_shader = surface_shader(source_material)
-        shader_id = connected_surface_shader_id(source_material)
-        params = normalize_preview_parameters(source_shader, material_path_str, shader_id, Gf)
+        raw = extract_material(prim, UsdShade)
+        spec = normalize_material(raw)
+        author_preview_material(overlay_stage, spec, Gf, Sdf, UsdShade)
 
-        entry = material_entry(material_path_str)
-        entry["material_class"] = params["material_class"]
-        entry["warnings"] = params["warnings"]
-
-        author_preview_surface(overlay_stage, material_path, params, Sdf, UsdShade)
-
-        report["materials"][material_path_str] = entry
+        report["materials"][spec.material_path] = material_entry_from_spec(spec)
 
     overlay_layer.Save()
     root_layer = _clear_or_create_layer(root, Sdf)

--- a/roboverse_pack/blender/usd/overlay.py
+++ b/roboverse_pack/blender/usd/overlay.py
@@ -1,0 +1,307 @@
+"""Generate a minimal Blender-friendly USD material overlay."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+COLOR_ALIASES = ("diffuseColor", "BaseColor_Color", "diffuse_color_constant", "base_color")
+TEXTURE_ALIASES = (
+    "BaseColor_Tex",
+    "BaseColor_Texture",
+    "diffuse_texture",
+    "albedo_texture",
+    "base_color_texture",
+    "diffuseColor_texture",
+)
+ROUGHNESS_ALIASES = ("roughness", "reflection_roughness_constant")
+METALLIC_ALIASES = ("metallic", "metallic_constant")
+OPACITY_ALIASES = ("opacity", "opacity_constant")
+EMISSIVE_ALIASES = ("emissiveColor", "Emissive_Color")
+
+CLASS_FALLBACKS = {
+    "wall": (0.72, 0.72, 0.68),
+    "floor": (0.55, 0.50, 0.44),
+    "cabinet": (0.60, 0.46, 0.32),
+    "glass": (0.78, 0.90, 0.96),
+    "screen": (0.02, 0.02, 0.025),
+    "metal": (0.55, 0.55, 0.55),
+    "fabric": (0.48, 0.42, 0.38),
+}
+
+
+def _find_material_class(material_path: str, shader_id: str | None) -> str | None:
+    text = f"{material_path} {shader_id or ''}".lower()
+    for material_class in CLASS_FALLBACKS:
+        if material_class in text:
+            return material_class
+    return None
+
+
+def _coerce_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_vec3(value: Any, Gf: Any) -> Any | None:
+    if value is None:
+        return None
+    try:
+        return Gf.Vec3f(float(value[0]), float(value[1]), float(value[2]))
+    except (TypeError, ValueError, IndexError):
+        return None
+
+
+def _asset_path_string(value: Any) -> str | None:
+    if value is None:
+        return None
+    path = getattr(value, "path", None)
+    return path or str(value)
+
+
+def _shader_input(shader: Any, aliases: tuple[str, ...]) -> Any:
+    if shader is None:
+        return None
+    for alias in aliases:
+        shader_input = shader.GetInput(alias)
+        if shader_input:
+            value = shader_input.Get()
+            if value is not None:
+                return value
+    return None
+
+
+def _surface_shader(material: Any) -> Any:
+    source = material.ComputeSurfaceSource()
+    if isinstance(source, tuple):
+        return source[0] if source else None
+    return source
+
+
+def _clear_or_create_layer(path: Path, Sdf: Any) -> Any:
+    layer = Sdf.Layer.FindOrOpen(str(path))
+    if layer is None:
+        layer = Sdf.Layer.CreateNew(str(path))
+    else:
+        layer.Clear()
+    return layer
+
+
+def _sublayer_path(layer_path: Path, root_parent: Path) -> str:
+    if layer_path.is_absolute():
+        return str(layer_path)
+    return os.path.relpath(layer_path, root_parent)
+
+
+def _connect_surface(material: Any, shader: Any) -> None:
+    output = material.CreateSurfaceOutput()
+    output.ConnectToSource(shader.ConnectableAPI(), "surface")
+
+
+def _author_texture_chain(material_path: Any, preview: Any, texture_asset: str, overlay_stage: Any, Sdf: Any, UsdShade: Any) -> None:
+    reader = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewSTReader"))
+    reader.CreateIdAttr("UsdPrimvarReader_float2")
+    reader.CreateInput("varname", Sdf.ValueTypeNames.String).Set("st")
+    reader.CreateOutput("result", Sdf.ValueTypeNames.Float2)
+
+    texture = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewTexture"))
+    texture.CreateIdAttr("UsdUVTexture")
+    texture.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath(texture_asset))
+    texture.CreateInput("st", Sdf.ValueTypeNames.Float2).ConnectToSource(reader.ConnectableAPI(), "result")
+    texture.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
+
+    preview.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).ConnectToSource(texture.ConnectableAPI(), "rgb")
+
+
+def _material_entry(material_path: str) -> dict[str, Any]:
+    return {
+        "status": "converted",
+        "warnings": [],
+        "material_class": None,
+    }
+
+
+def generate_blender_overlay(
+    input_path: str | Path,
+    overlay_path: str | Path,
+    root_path: str | Path,
+    texture_cache: str | Path,
+    resolution: int = 2048,
+    samples: int = 16,
+) -> dict[str, Any]:
+    from pxr import Gf, Sdf, Usd, UsdShade
+
+    source_path = Path(input_path)
+    overlay = Path(overlay_path)
+    root = Path(root_path)
+    cache = Path(texture_cache)
+    cache.mkdir(parents=True, exist_ok=True)
+    overlay.parent.mkdir(parents=True, exist_ok=True)
+    root.parent.mkdir(parents=True, exist_ok=True)
+
+    source_stage = Usd.Stage.Open(str(source_path))
+    if source_stage is None:
+        raise ValueError(f"Unable to open USD stage: {source_path}")
+
+    overlay_layer = _clear_or_create_layer(overlay, Sdf)
+    overlay_stage = Usd.Stage.Open(overlay_layer)
+    report = {
+        "input_path": str(source_path),
+        "overlay_path": str(overlay),
+        "root_path": str(root),
+        "resolution": resolution,
+        "samples": samples,
+        "materials": {},
+    }
+
+    for prim in source_stage.Traverse():
+        if not prim.IsA(UsdShade.Material):
+            continue
+
+        material_path = prim.GetPath()
+        material_path_str = str(material_path)
+        source_material = UsdShade.Material(prim)
+        source_shader = _surface_shader(source_material)
+        shader_id = None
+        if source_shader:
+            shader_id_value = source_shader.GetIdAttr().Get()
+            shader_id = str(shader_id_value) if shader_id_value else None
+
+        entry = _material_entry(material_path_str)
+        material_class = _find_material_class(material_path_str, shader_id)
+        entry["material_class"] = material_class
+
+        overlay_material = UsdShade.Material.Define(overlay_stage, material_path)
+        preview = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewSurface"))
+        preview.CreateIdAttr("UsdPreviewSurface")
+        _connect_surface(overlay_material, preview)
+
+        diffuse_color = _coerce_vec3(_shader_input(source_shader, COLOR_ALIASES), Gf)
+        diffuse_texture = _asset_path_string(_shader_input(source_shader, TEXTURE_ALIASES))
+        if diffuse_texture:
+            _author_texture_chain(material_path, preview, diffuse_texture, overlay_stage, Sdf, UsdShade)
+        else:
+            if diffuse_color is None and material_class:
+                diffuse_color = Gf.Vec3f(*CLASS_FALLBACKS[material_class])
+            if diffuse_color is not None:
+                preview.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(diffuse_color)
+            else:
+                entry["warnings"].append("No diffuse color or texture alias found.")
+
+        roughness = _coerce_float(_shader_input(source_shader, ROUGHNESS_ALIASES))
+        if roughness is not None:
+            preview.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(roughness)
+
+        metallic = _coerce_float(_shader_input(source_shader, METALLIC_ALIASES))
+        if metallic is not None:
+            preview.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(metallic)
+        elif material_class == "metal":
+            preview.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(1.0)
+
+        opacity = _coerce_float(_shader_input(source_shader, OPACITY_ALIASES))
+        if opacity is not None:
+            preview.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(opacity)
+        elif material_class == "glass":
+            preview.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(0.35)
+
+        if material_class == "glass":
+            ior = _coerce_float(_shader_input(source_shader, ("ior", "glass_ior", "index_of_refraction")))
+            preview.CreateInput("ior", Sdf.ValueTypeNames.Float).Set(ior if ior is not None else 1.45)
+
+        emissive = _coerce_vec3(_shader_input(source_shader, EMISSIVE_ALIASES), Gf)
+        if emissive is not None:
+            preview.CreateInput("emissiveColor", Sdf.ValueTypeNames.Color3f).Set(emissive)
+
+        report["materials"][material_path_str] = entry
+
+    overlay_layer.Save()
+    root_layer = _clear_or_create_layer(root, Sdf)
+    root_parent = root.parent if str(root.parent) else Path(".")
+    root_layer.subLayerPaths = [_sublayer_path(overlay, root_parent), _sublayer_path(source_path, root_parent)]
+    root_layer.Save()
+
+    report_json = cache / "conversion_report.json"
+    report_md = cache / "conversion_report.md"
+    report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_conversion_report_md(report, report_md)
+    return report
+
+
+def write_conversion_report_md(report: dict[str, Any], path: str | Path) -> None:
+    lines = [
+        "# Blender Material Overlay Conversion Report",
+        "",
+        f"Input: `{report.get('input_path', '')}`",
+        f"Overlay: `{report.get('overlay_path', '')}`",
+        f"Root: `{report.get('root_path', '')}`",
+        "",
+        "| Material | Status | Class | Warnings |",
+        "| --- | --- | --- | --- |",
+    ]
+    for material_path, entry in sorted(report.get("materials", {}).items()):
+        warnings = "; ".join(entry.get("warnings", []))
+        lines.append(
+            f"| `{material_path}` | {entry.get('status', '')} | {entry.get('material_class') or ''} | {warnings} |"
+        )
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def verify_overlay_material_coverage(root_path: str | Path, expected_material_paths: Any) -> None:
+    from pxr import Usd, UsdShade
+
+    stage = Usd.Stage.Open(str(Path(root_path)))
+    if stage is None:
+        raise ValueError(f"Unable to open USD stage: {root_path}")
+
+    missing = []
+    non_preview = []
+    for material_path in expected_material_paths:
+        material = UsdShade.Material.Get(stage, material_path)
+        if not material:
+            missing.append(str(material_path))
+            continue
+        shader = _surface_shader(material)
+        if not shader or shader.GetIdAttr().Get() != "UsdPreviewSurface":
+            non_preview.append(str(material_path))
+
+    if missing or non_preview:
+        details = []
+        if missing:
+            details.append(f"missing materials: {', '.join(missing)}")
+        if non_preview:
+            details.append(f"missing preview surfaces: {', '.join(non_preview)}")
+        raise AssertionError("; ".join(details))
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Generate a Blender USD material overlay.")
+    parser.add_argument("--input", required=True, help="Input USD stage.")
+    parser.add_argument("--overlay", required=True, help="Output overlay USD layer.")
+    parser.add_argument("--root", required=True, help="Output root USD layer.")
+    parser.add_argument("--texture-cache", required=True, help="Texture cache/report directory.")
+    parser.add_argument("--resolution", type=int, default=2048)
+    parser.add_argument("--samples", type=int, default=16)
+    args = parser.parse_args(argv)
+
+    generate_blender_overlay(
+        args.input,
+        args.overlay,
+        args.root,
+        args.texture_cache,
+        resolution=args.resolution,
+        samples=args.samples,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/roboverse_pack/blender/usd/overlay.py
+++ b/roboverse_pack/blender/usd/overlay.py
@@ -3,86 +3,14 @@
 from __future__ import annotations
 
 import argparse
-import json
 import os
 from pathlib import Path
 from typing import Any
 
-COLOR_ALIASES = ("diffuseColor", "BaseColor_Color", "diffuse_color_constant", "base_color")
-TEXTURE_ALIASES = (
-    "BaseColor_Tex",
-    "BaseColor_Texture",
-    "diffuse_texture",
-    "albedo_texture",
-    "base_color_texture",
-    "diffuseColor_texture",
-)
-ROUGHNESS_ALIASES = ("roughness", "reflection_roughness_constant")
-METALLIC_ALIASES = ("metallic", "metallic_constant")
-OPACITY_ALIASES = ("opacity", "opacity_constant")
-EMISSIVE_ALIASES = ("emissiveColor", "Emissive_Color")
-
-CLASS_FALLBACKS = {
-    "wall": (0.72, 0.72, 0.68),
-    "floor": (0.55, 0.50, 0.44),
-    "cabinet": (0.60, 0.46, 0.32),
-    "glass": (0.78, 0.90, 0.96),
-    "screen": (0.02, 0.02, 0.025),
-    "metal": (0.55, 0.55, 0.55),
-    "fabric": (0.48, 0.42, 0.38),
-}
-
-
-def _find_material_class(material_path: str, shader_id: str | None) -> str | None:
-    text = f"{material_path} {shader_id or ''}".lower()
-    for material_class in CLASS_FALLBACKS:
-        if material_class in text:
-            return material_class
-    return None
-
-
-def _coerce_float(value: Any) -> float | None:
-    if value is None:
-        return None
-    try:
-        return float(value)
-    except (TypeError, ValueError):
-        return None
-
-
-def _coerce_vec3(value: Any, Gf: Any) -> Any | None:
-    if value is None:
-        return None
-    try:
-        return Gf.Vec3f(float(value[0]), float(value[1]), float(value[2]))
-    except (TypeError, ValueError, IndexError):
-        return None
-
-
-def _asset_path_string(value: Any) -> str | None:
-    if value is None:
-        return None
-    path = getattr(value, "path", None)
-    return path or str(value)
-
-
-def _shader_input(shader: Any, aliases: tuple[str, ...]) -> Any:
-    if shader is None:
-        return None
-    for alias in aliases:
-        shader_input = shader.GetInput(alias)
-        if shader_input:
-            value = shader_input.Get()
-            if value is not None:
-                return value
-    return None
-
-
-def _surface_shader(material: Any) -> Any:
-    source = material.ComputeSurfaceSource()
-    if isinstance(source, tuple):
-        return source[0] if source else None
-    return source
+from .material_graph.author_preview import author_preview_surface
+from .material_graph.extract import connected_surface_shader_id, surface_shader
+from .material_graph.normalize import normalize_preview_parameters
+from .material_graph.report import material_entry, write_conversion_report_md, write_conversion_reports
 
 
 def _clear_or_create_layer(path: Path, Sdf: Any) -> Any:
@@ -98,34 +26,6 @@ def _sublayer_path(layer_path: Path, root_parent: Path) -> str:
     if layer_path.is_absolute():
         return str(layer_path)
     return os.path.relpath(layer_path, root_parent)
-
-
-def _connect_surface(material: Any, shader: Any) -> None:
-    output = material.CreateSurfaceOutput()
-    output.ConnectToSource(shader.ConnectableAPI(), "surface")
-
-
-def _author_texture_chain(material_path: Any, preview: Any, texture_asset: str, overlay_stage: Any, Sdf: Any, UsdShade: Any) -> None:
-    reader = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewSTReader"))
-    reader.CreateIdAttr("UsdPrimvarReader_float2")
-    reader.CreateInput("varname", Sdf.ValueTypeNames.String).Set("st")
-    reader.CreateOutput("result", Sdf.ValueTypeNames.Float2)
-
-    texture = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewTexture"))
-    texture.CreateIdAttr("UsdUVTexture")
-    texture.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath(texture_asset))
-    texture.CreateInput("st", Sdf.ValueTypeNames.Float2).ConnectToSource(reader.ConnectableAPI(), "result")
-    texture.CreateOutput("rgb", Sdf.ValueTypeNames.Float3)
-
-    preview.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).ConnectToSource(texture.ConnectableAPI(), "rgb")
-
-
-def _material_entry(material_path: str) -> dict[str, Any]:
-    return {
-        "status": "converted",
-        "warnings": [],
-        "material_class": None,
-    }
 
 
 def generate_blender_overlay(
@@ -168,56 +68,15 @@ def generate_blender_overlay(
         material_path = prim.GetPath()
         material_path_str = str(material_path)
         source_material = UsdShade.Material(prim)
-        source_shader = _surface_shader(source_material)
-        shader_id = None
-        if source_shader:
-            shader_id_value = source_shader.GetIdAttr().Get()
-            shader_id = str(shader_id_value) if shader_id_value else None
+        source_shader = surface_shader(source_material)
+        shader_id = connected_surface_shader_id(source_material)
+        params = normalize_preview_parameters(source_shader, material_path_str, shader_id, Gf)
 
-        entry = _material_entry(material_path_str)
-        material_class = _find_material_class(material_path_str, shader_id)
-        entry["material_class"] = material_class
+        entry = material_entry(material_path_str)
+        entry["material_class"] = params["material_class"]
+        entry["warnings"] = params["warnings"]
 
-        overlay_material = UsdShade.Material.Define(overlay_stage, material_path)
-        preview = UsdShade.Shader.Define(overlay_stage, material_path.AppendChild("PreviewSurface"))
-        preview.CreateIdAttr("UsdPreviewSurface")
-        _connect_surface(overlay_material, preview)
-
-        diffuse_color = _coerce_vec3(_shader_input(source_shader, COLOR_ALIASES), Gf)
-        diffuse_texture = _asset_path_string(_shader_input(source_shader, TEXTURE_ALIASES))
-        if diffuse_texture:
-            _author_texture_chain(material_path, preview, diffuse_texture, overlay_stage, Sdf, UsdShade)
-        else:
-            if diffuse_color is None and material_class:
-                diffuse_color = Gf.Vec3f(*CLASS_FALLBACKS[material_class])
-            if diffuse_color is not None:
-                preview.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set(diffuse_color)
-            else:
-                entry["warnings"].append("No diffuse color or texture alias found.")
-
-        roughness = _coerce_float(_shader_input(source_shader, ROUGHNESS_ALIASES))
-        if roughness is not None:
-            preview.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(roughness)
-
-        metallic = _coerce_float(_shader_input(source_shader, METALLIC_ALIASES))
-        if metallic is not None:
-            preview.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(metallic)
-        elif material_class == "metal":
-            preview.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(1.0)
-
-        opacity = _coerce_float(_shader_input(source_shader, OPACITY_ALIASES))
-        if opacity is not None:
-            preview.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(opacity)
-        elif material_class == "glass":
-            preview.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(0.35)
-
-        if material_class == "glass":
-            ior = _coerce_float(_shader_input(source_shader, ("ior", "glass_ior", "index_of_refraction")))
-            preview.CreateInput("ior", Sdf.ValueTypeNames.Float).Set(ior if ior is not None else 1.45)
-
-        emissive = _coerce_vec3(_shader_input(source_shader, EMISSIVE_ALIASES), Gf)
-        if emissive is not None:
-            preview.CreateInput("emissiveColor", Sdf.ValueTypeNames.Color3f).Set(emissive)
+        author_preview_surface(overlay_stage, material_path, params, Sdf, UsdShade)
 
         report["materials"][material_path_str] = entry
 
@@ -227,32 +86,8 @@ def generate_blender_overlay(
     root_layer.subLayerPaths = [_sublayer_path(overlay, root_parent), _sublayer_path(source_path, root_parent)]
     root_layer.Save()
 
-    report_json = cache / "conversion_report.json"
-    report_md = cache / "conversion_report.md"
-    report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-    write_conversion_report_md(report, report_md)
+    write_conversion_reports(report, cache)
     return report
-
-
-def write_conversion_report_md(report: dict[str, Any], path: str | Path) -> None:
-    lines = [
-        "# Blender Material Overlay Conversion Report",
-        "",
-        f"Input: `{report.get('input_path', '')}`",
-        f"Overlay: `{report.get('overlay_path', '')}`",
-        f"Root: `{report.get('root_path', '')}`",
-        "",
-        "| Material | Status | Class | Warnings |",
-        "| --- | --- | --- | --- |",
-    ]
-    for material_path, entry in sorted(report.get("materials", {}).items()):
-        warnings = "; ".join(entry.get("warnings", []))
-        lines.append(
-            f"| `{material_path}` | {entry.get('status', '')} | {entry.get('material_class') or ''} | {warnings} |"
-        )
-    output = Path(path)
-    output.parent.mkdir(parents=True, exist_ok=True)
-    output.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def verify_overlay_material_coverage(root_path: str | Path, expected_material_paths: Any) -> None:
@@ -269,7 +104,7 @@ def verify_overlay_material_coverage(root_path: str | Path, expected_material_pa
         if not material:
             missing.append(str(material_path))
             continue
-        shader = _surface_shader(material)
+        shader = surface_shader(material)
         if not shader or shader.GetIdAttr().Get() != "UsdPreviewSurface":
             non_preview.append(str(material_path))
 

--- a/roboverse_pack/blender/usd/overlay.py
+++ b/roboverse_pack/blender/usd/overlay.py
@@ -9,8 +9,9 @@ from typing import Any
 
 from .material_graph.adapters import convert_material
 from .material_graph.author_preview import author_preview_material
+from .material_graph.bindings import collect_material_binding_contexts
 from .material_graph.context import MaterialContext
-from .material_graph.extract import extract_material, surface_shader
+from .material_graph.extract import extract_material, iter_material_prims, surface_shader
 from .material_graph.report import failed_material_entry, material_entry_from_spec, write_conversion_reports
 
 
@@ -64,15 +65,19 @@ def _extract_convert_and_author_material(
     Gf: Any,
     Sdf: Any,
     authoring_usdshade: Any,
+    binding_contexts: dict[str, Any] | None = None,
 ) -> None:
     material_path = _prim_path_string(prim)
     try:
         raw = extract_material(prim, UsdShade)
         material_path = raw.material_path
+        binding_context = (binding_contexts or {}).get(raw.material_path)
         context = MaterialContext(
             source_path=source_path,
             texture_base_dir=source_path.parent,
             material_path=raw.material_path,
+            bound_prim_paths=binding_context.bound_prim_paths if binding_context is not None else (),
+            uv_primvars_by_prim=binding_context.uv_primvars_by_prim if binding_context is not None else None,
         )
         spec = convert_material(raw, context)
         report["materials"][spec.material_path] = material_entry_from_spec(spec)
@@ -91,7 +96,7 @@ def generate_blender_overlay(
     resolution: int = 2048,
     samples: int = 16,
 ) -> dict[str, Any]:
-    from pxr import Gf, Sdf, Usd, UsdShade
+    from pxr import Gf, Sdf, Usd, UsdGeom, UsdShade
 
     source_path = Path(input_path)
     overlay = Path(overlay_path)
@@ -116,11 +121,19 @@ def generate_blender_overlay(
         "materials": {},
     }
 
-    for prim in source_stage.Traverse():
-        if not prim.IsA(UsdShade.Material):
-            continue
-
-        _extract_convert_and_author_material(prim, UsdShade, source_path, report, overlay_stage, Gf, Sdf, UsdShade)
+    binding_contexts = collect_material_binding_contexts(source_stage, UsdShade, UsdGeom)
+    for prim in iter_material_prims(source_stage, UsdShade):
+        _extract_convert_and_author_material(
+            prim,
+            UsdShade,
+            source_path,
+            report,
+            overlay_stage,
+            Gf,
+            Sdf,
+            UsdShade,
+            binding_contexts,
+        )
 
     overlay_layer.Save()
     root_layer = _clear_or_create_layer(root, Sdf)

--- a/roboverse_pack/blender/usd/overlay.py
+++ b/roboverse_pack/blender/usd/overlay.py
@@ -12,7 +12,12 @@ from .material_graph.author_preview import author_preview_material
 from .material_graph.bindings import collect_material_binding_contexts
 from .material_graph.context import MaterialContext
 from .material_graph.extract import extract_material, iter_material_prims, surface_shader
-from .material_graph.report import failed_material_entry, material_entry_from_spec, write_conversion_reports
+from .material_graph.report import (
+    ConversionReport,
+    failed_material_entry,
+    material_entry_from_spec,
+    write_conversion_reports,
+)
 
 
 def _clear_or_create_layer(path: Path, Sdf: Any) -> Any:
@@ -38,15 +43,21 @@ def _convert_and_author_material(
     Gf: Any,
     Sdf: Any,
     UsdShade: Any,
+    *,
+    conversion_report: ConversionReport | None = None,
 ) -> None:
     try:
         spec = convert_material(raw, context)
         report["materials"][spec.material_path] = material_entry_from_spec(spec)
+        if conversion_report is not None:
+            conversion_report.add_material(spec)
         if spec.conversion_policy == "preserve_existing_preview":
             return
         author_preview_material(overlay_stage, spec, Gf, Sdf, UsdShade)
     except Exception as exc:
         report["materials"][raw.material_path] = failed_material_entry(exc)
+        if conversion_report is not None:
+            conversion_report.add_failed_material(raw.material_path, f"conversion failed: {exc}")
 
 
 def _prim_path_string(prim: Any) -> str:
@@ -66,6 +77,8 @@ def _extract_convert_and_author_material(
     Sdf: Any,
     authoring_usdshade: Any,
     binding_contexts: dict[str, Any] | None = None,
+    *,
+    conversion_report: ConversionReport | None = None,
 ) -> None:
     material_path = _prim_path_string(prim)
     try:
@@ -81,11 +94,15 @@ def _extract_convert_and_author_material(
         )
         spec = convert_material(raw, context)
         report["materials"][spec.material_path] = material_entry_from_spec(spec)
+        if conversion_report is not None:
+            conversion_report.add_material(spec)
         if spec.conversion_policy == "preserve_existing_preview":
             return
         author_preview_material(overlay_stage, spec, Gf, Sdf, authoring_usdshade)
     except Exception as exc:
         report["materials"][material_path] = failed_material_entry(exc)
+        if conversion_report is not None:
+            conversion_report.add_failed_material(material_path, f"conversion failed: {exc}")
 
 
 def generate_blender_overlay(
@@ -120,6 +137,13 @@ def generate_blender_overlay(
         "samples": samples,
         "materials": {},
     }
+    conversion_report = ConversionReport(
+        input_path=str(source_path),
+        overlay_path=str(overlay),
+        root_path=str(root),
+        resolution=resolution,
+        samples=samples,
+    )
 
     binding_contexts = collect_material_binding_contexts(source_stage, UsdShade, UsdGeom)
     for prim in iter_material_prims(source_stage, UsdShade):
@@ -133,6 +157,7 @@ def generate_blender_overlay(
             Sdf,
             UsdShade,
             binding_contexts,
+            conversion_report=conversion_report,
         )
 
     overlay_layer.Save()
@@ -141,7 +166,9 @@ def generate_blender_overlay(
     root_layer.subLayerPaths = [_sublayer_path(overlay, root_parent), _sublayer_path(source_path, root_parent)]
     root_layer.Save()
 
-    write_conversion_reports(report, cache)
+    deep_report = conversion_report.to_dict()
+    report["deep_report"] = deep_report
+    write_conversion_reports(conversion_report, cache)
     return report
 
 

--- a/scripts/benchmark/rendering/box_task_replay.py
+++ b/scripts/benchmark/rendering/box_task_replay.py
@@ -4,6 +4,7 @@ from collections.abc import MutableMapping
 from copy import deepcopy
 from dataclasses import dataclass
 import inspect
+import os
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,7 @@ _REPLAY_ROBOT_FIELDS = (
     "dof_vel_target",
     "dof_torque",
 )
+_DEFAULT_JOINT_LIMIT_MARGIN = 1.0e-3
 
 
 @dataclass(frozen=True)
@@ -113,7 +115,7 @@ def frame_to_source_indices(src_total_frames: int, out_frames: int) -> np.ndarra
         raise ValueError("out_frames must be positive")
     if out_frames == 1:
         return np.array([0], dtype=np.int32)
-    return np.linspace(0, src_total_frames - 1, out_frames).astype(np.int32)
+    return np.rint(np.linspace(0, src_total_frames - 1, out_frames)).astype(np.int32)
 
 
 def scene_frame_bounds(out_frames: int, scene_count: int) -> list[tuple[int, int]]:
@@ -167,11 +169,339 @@ def patch_state_for_replay(state: dict[str, Any], robot_name: str = "openarm_wuj
     return patched
 
 
+def patch_openarm_wuji_robot_cfg(robot_cfg: Any) -> Any:
+    """Rewrite legacy Wuji hand names in robot cfgs to match the generated USD."""
+    mapping = build_finger_joint_map()
+    for attr_name in ("joint_names", "left_hand_joint_names", "right_hand_joint_names", "ee_joint_names"):
+        names = getattr(robot_cfg, attr_name, None)
+        if isinstance(names, (list, tuple)):
+            _set_object_attr(robot_cfg, attr_name, [_canonical_joint_name(name, mapping) for name in names])
+
+    for attr_name in ("joint_limits", "default_joint_positions", "actuators", "control_type"):
+        keyed_values = getattr(robot_cfg, attr_name, None)
+        if isinstance(keyed_values, MutableMapping):
+            _set_object_attr(robot_cfg, attr_name, _rewrite_legacy_mapping_keys(keyed_values, mapping))
+    _set_generated_wuji_hand_defaults(robot_cfg)
+    _clamp_robot_default_joint_positions(robot_cfg)
+
+    body_name_map = {
+        "left_hand_palm_link": "left_palm_link",
+        "right_hand_palm_link": "right_palm_link",
+    }
+    for attr_name in ("left_ee_body_name", "right_ee_body_name", "ee_body_name"):
+        body_name = getattr(robot_cfg, attr_name, None)
+        if body_name in body_name_map:
+            _set_object_attr(robot_cfg, attr_name, body_name_map[body_name])
+
+    return robot_cfg
+
+
+def patch_openarm_wuji_scenario_robot_cfgs(scenario: Any) -> Any:
+    for robot_cfg in getattr(scenario, "robots", ()) or ():
+        if getattr(robot_cfg, "name", None) in {"openarm_wuji", "openarm_bimanual_wuji"}:
+            patch_openarm_wuji_robot_cfg(robot_cfg)
+    return scenario
+
+
+def disable_metasim_forced_exit_on_close() -> None:
+    os.environ["METASIM_FORCE_EXIT_ON_CLOSE"] = "0"
+
+
+def tensorize_replay_state(state: dict[str, Any], tensor_factory: Any | None = None) -> dict[str, Any]:
+    if tensor_factory is None:
+        import torch
+
+        tensor_factory = torch.as_tensor
+    return _tensorize_pose_fields(deepcopy(state), tensor_factory)
+
+
+def close_decode_env_without_closing_kit(env: Any) -> None:
+    handler = getattr(env, "handler", None)
+    if handler is not None:
+        setattr(handler, "_owns_simulation_app", False)
+    env.close()
+
+
+def install_numpy_pickle_aliases() -> list[str]:
+    """Install NumPy 1.x/2.x module aliases needed by pickled trajectories."""
+    import importlib
+    import sys
+    import warnings
+
+    inserted: list[str] = []
+
+    def set_alias(name: str, module: Any) -> None:
+        if name not in sys.modules:
+            sys.modules[name] = module
+            inserted.append(name)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="numpy.core is deprecated.*", category=DeprecationWarning)
+        try:
+            numpy_public_core = importlib.import_module("numpy.core")
+        except ModuleNotFoundError:
+            numpy_public_core = None
+        try:
+            numpy_private_core = importlib.import_module("numpy._core")
+        except ModuleNotFoundError:
+            numpy_private_core = None
+
+        if numpy_public_core is not None:
+            set_alias("numpy._core", numpy_public_core)
+            if hasattr(numpy_public_core, "multiarray"):
+                set_alias("numpy._core.multiarray", numpy_public_core.multiarray)
+            if hasattr(numpy_public_core, "umath"):
+                set_alias("numpy._core.umath", numpy_public_core.umath)
+
+        if numpy_private_core is not None:
+            set_alias("numpy.core", numpy_private_core)
+            if hasattr(numpy_private_core, "multiarray"):
+                set_alias("numpy.core.multiarray", numpy_private_core.multiarray)
+            if hasattr(numpy_private_core, "umath"):
+                set_alias("numpy.core.umath", numpy_private_core.umath)
+
+    return inserted
+
+
+def load_raw_v2_pickle(path: Path) -> Any:
+    import pickle
+    import sys
+
+    inserted_aliases = install_numpy_pickle_aliases()
+    try:
+        with Path(path).open("rb") as handle:
+            return pickle.load(handle)
+    finally:
+        for name in reversed(inserted_aliases):
+            sys.modules.pop(name, None)
+
+
+def convert_v2_state_to_v3(state: dict[str, Any], robot_name: str) -> dict[str, Any]:
+    if "robots" in state and "objects" in state:
+        return {
+            "robots": deepcopy(state["robots"]),
+            "objects": deepcopy(state["objects"]),
+        }
+
+    converted: dict[str, Any] = {"robots": {}, "objects": {}}
+    for name, entity_state in state.items():
+        if name == robot_name:
+            converted["robots"][name] = deepcopy(entity_state)
+        elif name not in ("robots", "objects"):
+            converted["objects"][name] = deepcopy(entity_state)
+    return converted
+
+
+def _first_v2_episode(payload: Any, robot_name: str) -> dict[str, Any]:
+    if not isinstance(payload, MutableMapping) or robot_name not in payload:
+        raise ValueError(f"Trajectory payload does not contain robot {robot_name!r}")
+    episodes = payload[robot_name]
+    if not isinstance(episodes, list) or not episodes:
+        raise ValueError(f"Trajectory payload for {robot_name!r} has no episodes")
+    episode = episodes[0]
+    if not isinstance(episode, MutableMapping):
+        raise ValueError(f"First trajectory episode for {robot_name!r} is not a mapping")
+    return episode
+
+
+def load_v2_episode_states(traj_path: Path, robot_name: str = "openarm_wuji") -> list[dict[str, Any]]:
+    payload = load_raw_v2_pickle(traj_path)
+    episode = _first_v2_episode(payload, robot_name)
+    episode_states = episode.get("states")
+    if not isinstance(episode_states, list) or not episode_states:
+        raise ValueError(f"First trajectory episode for {robot_name!r} has no states")
+    return [convert_v2_state_to_v3(state, robot_name) for state in episode_states]
+
+
+def load_v2_init_state(traj_path: Path, robot_name: str = "openarm_wuji") -> dict[str, Any] | None:
+    payload = load_raw_v2_pickle(traj_path)
+    episode = _first_v2_episode(payload, robot_name)
+    init_state = episode.get("init_state")
+    if init_state is None:
+        return None
+    if not isinstance(init_state, MutableMapping):
+        raise ValueError(f"Initial trajectory state for {robot_name!r} is not a mapping")
+    return convert_v2_state_to_v3(init_state, robot_name)
+
+
+def decode_trajectory_tensor_states(traj_path: Path, source_indices) -> dict[int, Any]:
+    import torch
+    from metasim.utils import hf_util
+    from metasim.task.base import BaseTaskEnv
+
+    disable_metasim_forced_exit_on_close()
+    # The replay bundle is local and complete; avoid recursive Hub downloads during smoke renders.
+    hf_util.check_and_download_recursive = lambda filepaths, n_processes=16: None
+    _patch_isaacsim_render_settings_for_decode()
+
+    episode_states = load_v2_episode_states(traj_path)
+    init_state = load_v2_init_state(traj_path)
+    unique_indices = sorted({int(index) for index in source_indices})
+    robot_name = "openarm_wuji"
+    bundle_paths = BoxTaskBundlePaths.from_root(traj_path.parents[2], traj_path=traj_path)
+    decode_scenario = build_decode_scenario(paths=bundle_paths)
+
+    class BoxTaskDecodeEnv(BaseTaskEnv):
+        scenario = decode_scenario
+
+        def _get_initial_states(self) -> list[dict[str, Any]]:
+            if init_state is not None:
+                initial_state = patch_state_for_replay(init_state, robot_name=robot_name)
+                initial_state.setdefault("cameras", {})
+                initial_state.setdefault("extras", {})
+                return [tensorize_replay_state(initial_state)]
+            return [{"objects": {}, "robots": {}, "cameras": {}, "extras": {}}]
+
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    env = None
+    try:
+        env = BoxTaskDecodeEnv(scenario=BoxTaskDecodeEnv.scenario, device=device)
+        tensor_states: dict[int, Any] = {}
+        for source_index in unique_indices:
+            state = patch_state_for_replay(episode_states[source_index], robot_name=robot_name)
+            state = tensorize_replay_state(state)
+            env.handler.set_states([state])
+            tensor_states[source_index] = env.handler.get_states(mode="tensor")
+        return tensor_states
+    finally:
+        if env is not None:
+            close_decode_env_without_closing_kit(env)
+
+
+def _patch_isaacsim_render_settings_for_decode() -> None:
+    import importlib
+
+    isaacsim_module = importlib.import_module("metasim.sim.isaacsim.isaacsim")
+    handler_cls = getattr(isaacsim_module, "IsaacsimHandler")
+    original = handler_cls._load_render_settings
+    if getattr(original, "_box_task_decode_patch", False):
+        return
+
+    def load_render_settings_without_replicator(self) -> None:
+        try:
+            return original(self)
+        except ModuleNotFoundError as exc:
+            if exc.name is None or not exc.name.startswith("omni.replicator"):
+                raise
+            import carb
+
+            settings = carb.settings.get_settings()
+            if self.scenario.render.mode == "pathtracing":
+                settings.set_string("/rtx/rendermode", "PathTracing")
+            elif self.scenario.render.mode == "raytracing":
+                settings.set_string("/rtx/rendermode", "RayTracedLighting")
+            elif self.scenario.render.mode == "rasterization":
+                raise ValueError("Isaaclab does not support rasterization")
+            else:
+                raise ValueError(f"Unknown render mode: {self.scenario.render.mode}")
+
+    load_render_settings_without_replicator._box_task_decode_patch = True
+    handler_cls._load_render_settings = load_render_settings_without_replicator
+
+
 def _rewrite_legacy_joint_keys(field_state: MutableMapping[str, Any], mapping: dict[str, str]) -> None:
     for legacy_name, replay_name in mapping.items():
         if legacy_name in field_state:
             value = field_state.pop(legacy_name)
             field_state.setdefault(replay_name, value)
+
+
+def _canonical_joint_name(name: str, mapping: dict[str, str]) -> str:
+    return mapping.get(name, name)
+
+
+def _rewrite_legacy_mapping_keys(keyed_values: MutableMapping[str, Any], mapping: dict[str, str]) -> dict[str, Any]:
+    rewritten: dict[str, Any] = {}
+    for key, value in keyed_values.items():
+        rewritten_key = _canonical_joint_name(key, mapping)
+        if rewritten_key not in rewritten or rewritten_key == key:
+            rewritten[rewritten_key] = value
+    return rewritten
+
+
+def _tensorize_pose_fields(value: Any, tensor_factory: Any, parent_key: str | None = None) -> Any:
+    if isinstance(value, MutableMapping):
+        return {key: _tensorize_pose_fields(child, tensor_factory, str(key)) for key, child in value.items()}
+    if parent_key in {"pos", "rot"} and _is_tensorizable_sequence(value):
+        return tensor_factory(value)
+    return value
+
+
+def _is_tensorizable_sequence(value: Any) -> bool:
+    if isinstance(value, np.ndarray):
+        return True
+    if isinstance(value, (list, tuple)):
+        return all(isinstance(item, (int, float, np.integer, np.floating)) for item in value)
+    return False
+
+
+def _clamp_robot_default_joint_positions(robot_cfg: Any) -> None:
+    defaults = getattr(robot_cfg, "default_joint_positions", None)
+    limits = getattr(robot_cfg, "joint_limits", None)
+    if not isinstance(defaults, MutableMapping) or not isinstance(limits, MutableMapping):
+        return
+
+    clamped = dict(defaults)
+    for joint_name, default_value in defaults.items():
+        joint_limits = limits.get(joint_name)
+        if not isinstance(joint_limits, (list, tuple)) or len(joint_limits) != 2:
+            continue
+        try:
+            value = float(default_value)
+            lower = float(joint_limits[0])
+            upper = float(joint_limits[1])
+        except (TypeError, ValueError):
+            continue
+        if lower <= value <= upper:
+            continue
+        clamped[joint_name] = _safe_joint_default(value=value, lower=lower, upper=upper)
+    _set_object_attr(robot_cfg, "default_joint_positions", clamped)
+
+
+def _set_generated_wuji_hand_defaults(robot_cfg: Any) -> None:
+    defaults = getattr(robot_cfg, "default_joint_positions", None)
+    if not isinstance(defaults, MutableMapping):
+        return
+
+    patched_defaults = dict(defaults)
+    for joint_name, default_value in defaults.items():
+        if not _is_canonical_wuji_hand_joint(joint_name):
+            continue
+        try:
+            value = float(default_value)
+        except (TypeError, ValueError):
+            continue
+        if value == 0.0:
+            patched_defaults[joint_name] = 0.1
+    _set_object_attr(robot_cfg, "default_joint_positions", patched_defaults)
+
+
+def _is_canonical_wuji_hand_joint(joint_name: str) -> bool:
+    return joint_name.startswith(("left_finger", "right_finger")) and "_joint" in joint_name
+
+
+def _safe_joint_default(*, value: float, lower: float, upper: float) -> float:
+    if upper < lower:
+        lower, upper = upper, lower
+    if upper - lower > 2.0 * _DEFAULT_JOINT_LIMIT_MARGIN:
+        lower += _DEFAULT_JOINT_LIMIT_MARGIN
+        upper -= _DEFAULT_JOINT_LIMIT_MARGIN
+    return round(min(max(value, lower), upper), 12)
+
+
+def _set_object_attr(obj: Any, name: str, value: Any) -> None:
+    try:
+        setattr(obj, name, value)
+        return
+    except (AttributeError, TypeError, ValueError):
+        pass
+
+    obj_dict = getattr(obj, "__dict__", None)
+    if isinstance(obj_dict, dict):
+        obj_dict[name] = value
+        return
+
+    raise AttributeError(f"{type(obj).__name__} does not allow setting {name!r}")
 
 
 def _build_scenario_cfg(scenario_cls: type, deferred_attrs: dict[str, Any], **kwargs: Any) -> Any:
@@ -294,15 +624,23 @@ def build_box_task_scenario(
         scene=scene,
         render=RenderCfg(mode="pathtracing"),
     )
-    return scenario
+    return patch_openarm_wuji_scenario_robot_cfgs(scenario)
 
 
-def build_decode_scenario():
+def build_decode_scenario(paths: BoxTaskBundlePaths | None = None):
     from metasim.constants import PhysicStateType
     from metasim.scenario.objects import PrimitiveCubeCfg, RigidObjCfg
     from metasim.scenario.scenario import ScenarioCfg, SimParamCfg
 
-    return _build_scenario_cfg(
+    cardboard_kwargs: dict[str, Any] = {"name": "cardboard_box", "physics": PhysicStateType.RIGIDBODY}
+    soda_kwargs: dict[str, Any] = {"name": "feast_soda_can", "physics": PhysicStateType.RIGIDBODY}
+    candle_kwargs: dict[str, Any] = {"name": "feast_scented_candle", "physics": PhysicStateType.RIGIDBODY}
+    if paths is not None:
+        cardboard_kwargs["usd_path"] = str(paths.cardboard_box_usd)
+        soda_kwargs["usd_path"] = str(paths.soda_can_usd)
+        candle_kwargs["usd_path"] = str(paths.scented_candle_usd)
+
+    scenario = _build_scenario_cfg(
         ScenarioCfg,
         deferred_attrs={"renderer": "isaacsim"},
         objects=[
@@ -314,9 +652,9 @@ def build_decode_scenario():
                 color=(0.85, 0.78, 0.62),
                 fix_base_link=True,
             ),
-            RigidObjCfg(name="cardboard_box", physics=PhysicStateType.RIGIDBODY),
-            RigidObjCfg(name="feast_soda_can", physics=PhysicStateType.RIGIDBODY),
-            RigidObjCfg(name="feast_scented_candle", physics=PhysicStateType.RIGIDBODY),
+            RigidObjCfg(**cardboard_kwargs),
+            RigidObjCfg(**soda_kwargs),
+            RigidObjCfg(**candle_kwargs),
         ],
         robots=["openarm_wuji"],
         sim_params=SimParamCfg(dt=0.005),
@@ -326,3 +664,4 @@ def build_decode_scenario():
         headless=True,
         num_envs=1,
     )
+    return patch_openarm_wuji_scenario_robot_cfgs(scenario)

--- a/scripts/benchmark/rendering/box_task_replay.py
+++ b/scripts/benchmark/rendering/box_task_replay.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from copy import deepcopy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+DEFAULT_BUNDLE_ROOT = Path("outputs/assets/box_task_replay_render_bundle_clean")
+DEFAULT_TRAJ_REL = Path("assets/traj/task3_meshycup_openarm_wuji_20260513_232823_0_v2.pkl")
+DEFAULT_SRC_TOTAL_FRAMES = 849
+
+_REPLAY_ROBOT_FIELDS = (
+    "dof_pos",
+    "dof_vel",
+    "dof_pos_target",
+    "dof_vel_target",
+    "dof_torque",
+)
+
+
+@dataclass(frozen=True)
+class BoxTaskBundlePaths:
+    bundle_root: Path
+    traj_path: Path
+    asset_root: Path
+    cardboard_box_usd: Path
+    soda_can_usd: Path
+    scented_candle_usd: Path
+
+    @classmethod
+    def from_root(cls, bundle_root: Path, traj_path: Path | None = None) -> BoxTaskBundlePaths:
+        root = bundle_root.resolve()
+        resolved_traj_path = (traj_path if traj_path is not None else root / DEFAULT_TRAJ_REL).resolve()
+        asset_root = root / "assets" / "local_pack_box"
+        paths = cls(
+            bundle_root=root,
+            traj_path=resolved_traj_path,
+            asset_root=asset_root,
+            cardboard_box_usd=asset_root / "cardboard_box" / "cardboard_box.usd",
+            soda_can_usd=asset_root / "feast_soda_can" / "feast_soda_can.usd",
+            scented_candle_usd=asset_root / "feast_scented_candle" / "feast_scented_candle.usd",
+        )
+        paths.validate()
+        return paths
+
+    def validate(self) -> None:
+        for path in (
+            self.traj_path,
+            self.cardboard_box_usd,
+            self.soda_can_usd,
+            self.scented_candle_usd,
+        ):
+            if not path.is_file():
+                raise FileNotFoundError(str(path))
+
+
+def normalize_scene_token(scene_token: str) -> str:
+    token = scene_token.strip()
+    if token.endswith(".usda"):
+        token = token[: -len(".usda")]
+
+    if token.startswith("kujiale_scene_"):
+        scene_id = token.removeprefix("kujiale_scene_")
+    elif token.startswith("usd_"):
+        scene_id = token.removeprefix("usd_")
+    elif token.isdigit():
+        scene_id = token
+    else:
+        raise ValueError(f"Invalid scene token: {scene_token}")
+
+    if not scene_id.isdigit() or len(scene_id) not in (3, 4):
+        raise ValueError("Scene token must be 3 or 4 digits")
+
+    return f"kujiale_scene_{int(scene_id):04d}"
+
+
+def parse_scene_tokens(scene_text: str) -> list[str]:
+    return [normalize_scene_token(token) for token in scene_text.split(",") if token.strip()]
+
+
+def compute_output_frames(
+    src_total_frames: int,
+    fps: int,
+    duration_sec: float | None,
+    out_frames: int | None,
+) -> int:
+    if duration_sec is not None and out_frames is not None:
+        raise ValueError("Use either --out-frames or --duration-sec")
+    if out_frames is not None:
+        if out_frames <= 0:
+            raise ValueError("--out-frames must be positive")
+        return out_frames
+    if duration_sec is not None:
+        if fps <= 0:
+            raise ValueError("--fps must be positive")
+        if duration_sec <= 0:
+            raise ValueError("--duration-sec must be positive")
+        return max(1, int(round(duration_sec * fps)))
+    if src_total_frames <= 0:
+        raise ValueError("src_total_frames must be positive")
+    return src_total_frames
+
+
+def frame_to_source_indices(src_total_frames: int, out_frames: int) -> np.ndarray:
+    if src_total_frames <= 0:
+        raise ValueError("src_total_frames must be positive")
+    if out_frames <= 0:
+        raise ValueError("out_frames must be positive")
+    if out_frames == 1:
+        return np.array([0], dtype=np.int32)
+    return np.linspace(0, src_total_frames - 1, out_frames).astype(np.int32)
+
+
+def scene_frame_bounds(out_frames: int, scene_count: int) -> list[tuple[int, int]]:
+    if out_frames <= 0:
+        raise ValueError("out_frames must be positive")
+    if scene_count <= 0:
+        raise ValueError("scene_count must be positive")
+    if scene_count > out_frames:
+        raise ValueError("scene_count must not exceed out_frames")
+    return [
+        (int(i * out_frames / scene_count), int((i + 1) * out_frames / scene_count))
+        for i in range(scene_count)
+    ]
+
+
+def build_finger_joint_map() -> dict[str, str]:
+    return {
+        f"{side}_hand_finger{finger}_joint{joint}": f"{side}_finger{finger}_joint{joint}"
+        for side in ("left", "right")
+        for finger in range(1, 6)
+        for joint in range(1, 5)
+    }
+
+
+def patch_state_for_replay(state: dict[str, Any], robot_name: str = "openarm_wuji") -> dict[str, Any]:
+    patched = deepcopy(state)
+    mapping = build_finger_joint_map()
+
+    robot_states: list[MutableMapping[str, Any]] = []
+    if isinstance(patched.get(robot_name), MutableMapping):
+        robot_states.append(patched[robot_name])
+    if isinstance(patched.get("robots"), MutableMapping) and isinstance(patched["robots"].get(robot_name), MutableMapping):
+        robot_states.append(patched["robots"][robot_name])
+    if isinstance(patched.get("robot_states"), MutableMapping) and isinstance(
+        patched["robot_states"].get(robot_name), MutableMapping
+    ):
+        robot_states.append(patched["robot_states"][robot_name])
+    if any(field in patched for field in _REPLAY_ROBOT_FIELDS):
+        robot_states.append(patched)
+
+    seen: set[int] = set()
+    for robot_state in robot_states:
+        if id(robot_state) in seen:
+            continue
+        seen.add(id(robot_state))
+        for field in _REPLAY_ROBOT_FIELDS:
+            field_state = robot_state.get(field)
+            if isinstance(field_state, MutableMapping):
+                _rewrite_legacy_joint_keys(field_state, mapping)
+
+    return patched
+
+
+def _rewrite_legacy_joint_keys(field_state: MutableMapping[str, Any], mapping: dict[str, str]) -> None:
+    for legacy_name, replay_name in mapping.items():
+        if legacy_name in field_state:
+            value = field_state.pop(legacy_name)
+            field_state.setdefault(replay_name, value)

--- a/scripts/benchmark/rendering/box_task_replay.py
+++ b/scripts/benchmark/rendering/box_task_replay.py
@@ -208,6 +208,24 @@ def disable_metasim_forced_exit_on_close() -> None:
     os.environ["METASIM_FORCE_EXIT_ON_CLOSE"] = "0"
 
 
+def kujiale_hdri_path(scene: str) -> Path | None:
+    scene_name = str(scene)
+    if scene_name.startswith("kujiale_scene_"):
+        scene_id = scene_name.removeprefix("kujiale_scene_")
+    elif scene_name.startswith("kujiale_"):
+        scene_id = scene_name.removeprefix("kujiale_")
+    elif scene_name.isdigit():
+        scene_id = f"{int(scene_name):04d}"
+    else:
+        return None
+
+    directory = Path(__file__).resolve().parents[3] / "third_party" / "InteriorAgent" / f"kujiale_{scene_id}"
+    try:
+        return next(iter(sorted(directory.glob("*.hdr"))))
+    except StopIteration:
+        return None
+
+
 @contextmanager
 def local_bundle_decode_runtime(hf_util: Any):
     original_force_exit = os.environ.get("METASIM_FORCE_EXIT_ON_CLOSE")
@@ -609,10 +627,15 @@ def build_box_task_scenario(
 ):
     from metasim.constants import PhysicStateType
     from metasim.scenario.cameras import PinholeCameraCfg
-    from metasim.scenario.lights import SphereLightCfg
+    from metasim.scenario.lights import DistantLightCfg, DomeLightCfg, SphereLightCfg
     from metasim.scenario.objects import PrimitiveCubeCfg, RigidObjCfg
     from metasim.scenario.render import RenderCfg
     from metasim.scenario.scenario import ScenarioCfg, SimParamCfg
+
+    dome_light = DomeLightCfg(name="box_task_dome", intensity=400.0)
+    hdri_path = kujiale_hdri_path(scene)
+    if hdri_path is not None:
+        _set_object_attr(dome_light, "texture_file", str(hdri_path))
 
     scenario = _build_scenario_cfg(
         ScenarioCfg,
@@ -656,6 +679,8 @@ def build_box_task_scenario(
             )
         ],
         lights=[
+            dome_light,
+            DistantLightCfg(name="box_task_key", intensity=2000.0, polar=35.0, azimuth=-35.0),
             SphereLightCfg(
                 name="overhead_light",
                 intensity=float(head_light_intensity),

--- a/scripts/benchmark/rendering/box_task_replay.py
+++ b/scripts/benchmark/rendering/box_task_replay.py
@@ -253,6 +253,19 @@ def resolve_decode_bundle_paths(
     return BoxTaskBundlePaths.from_root(resolved_traj_path.parents[2], traj_path=resolved_traj_path)
 
 
+def save_decoded_tensor_states(states: dict[int, Any], path: Path) -> None:
+    import torch
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    torch.save(states, path)
+
+
+def load_decoded_tensor_states(path: Path) -> dict[int, Any]:
+    import torch
+
+    return torch.load(path, map_location="cpu", weights_only=False)
+
+
 def install_numpy_pickle_aliases() -> list[str]:
     """Install NumPy 1.x/2.x module aliases needed by pickled trajectories."""
     import importlib

--- a/scripts/benchmark/rendering/box_task_replay.py
+++ b/scripts/benchmark/rendering/box_task_replay.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import MutableMapping
+from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 import inspect
@@ -207,6 +208,26 @@ def disable_metasim_forced_exit_on_close() -> None:
     os.environ["METASIM_FORCE_EXIT_ON_CLOSE"] = "0"
 
 
+@contextmanager
+def local_bundle_decode_runtime(hf_util: Any):
+    original_force_exit = os.environ.get("METASIM_FORCE_EXIT_ON_CLOSE")
+    original_download_check = hf_util.check_and_download_recursive
+    restore_render_settings = lambda: None
+    try:
+        disable_metasim_forced_exit_on_close()
+        # The replay bundle is local and complete; avoid recursive Hub downloads during decode.
+        hf_util.check_and_download_recursive = lambda *args, **kwargs: None
+        restore_render_settings = _patch_isaacsim_render_settings_for_decode()
+        yield
+    finally:
+        hf_util.check_and_download_recursive = original_download_check
+        if original_force_exit is None:
+            os.environ.pop("METASIM_FORCE_EXIT_ON_CLOSE", None)
+        else:
+            os.environ["METASIM_FORCE_EXIT_ON_CLOSE"] = original_force_exit
+        restore_render_settings()
+
+
 def tensorize_replay_state(state: dict[str, Any], tensor_factory: Any | None = None) -> dict[str, Any]:
     if tensor_factory is None:
         import torch
@@ -220,6 +241,16 @@ def close_decode_env_without_closing_kit(env: Any) -> None:
     if handler is not None:
         setattr(handler, "_owns_simulation_app", False)
     env.close()
+
+
+def resolve_decode_bundle_paths(
+    traj_path: Path,
+    bundle_paths: BoxTaskBundlePaths | None = None,
+) -> BoxTaskBundlePaths:
+    if bundle_paths is not None:
+        return bundle_paths
+    resolved_traj_path = Path(traj_path).expanduser().resolve()
+    return BoxTaskBundlePaths.from_root(resolved_traj_path.parents[2], traj_path=resolved_traj_path)
 
 
 def install_numpy_pickle_aliases() -> list[str]:
@@ -324,62 +355,62 @@ def load_v2_init_state(traj_path: Path, robot_name: str = "openarm_wuji") -> dic
     return convert_v2_state_to_v3(init_state, robot_name)
 
 
-def decode_trajectory_tensor_states(traj_path: Path, source_indices) -> dict[int, Any]:
+def decode_trajectory_tensor_states(
+    traj_path: Path,
+    source_indices,
+    bundle_paths: BoxTaskBundlePaths | None = None,
+) -> dict[int, Any]:
     import torch
     from metasim.utils import hf_util
     from metasim.task.base import BaseTaskEnv
 
-    disable_metasim_forced_exit_on_close()
-    # The replay bundle is local and complete; avoid recursive Hub downloads during smoke renders.
-    hf_util.check_and_download_recursive = lambda filepaths, n_processes=16: None
-    _patch_isaacsim_render_settings_for_decode()
+    with local_bundle_decode_runtime(hf_util):
+        episode_states = load_v2_episode_states(traj_path)
+        init_state = load_v2_init_state(traj_path)
+        unique_indices = sorted({int(index) for index in source_indices})
+        robot_name = "openarm_wuji"
+        decode_paths = resolve_decode_bundle_paths(traj_path, bundle_paths)
+        decode_scenario = build_decode_scenario(paths=decode_paths)
 
-    episode_states = load_v2_episode_states(traj_path)
-    init_state = load_v2_init_state(traj_path)
-    unique_indices = sorted({int(index) for index in source_indices})
-    robot_name = "openarm_wuji"
-    bundle_paths = BoxTaskBundlePaths.from_root(traj_path.parents[2], traj_path=traj_path)
-    decode_scenario = build_decode_scenario(paths=bundle_paths)
+        class BoxTaskDecodeEnv(BaseTaskEnv):
+            scenario = decode_scenario
 
-    class BoxTaskDecodeEnv(BaseTaskEnv):
-        scenario = decode_scenario
+            def _get_initial_states(self) -> list[dict[str, Any]]:
+                if init_state is not None:
+                    initial_state = patch_state_for_replay(init_state, robot_name=robot_name)
+                    initial_state.setdefault("cameras", {})
+                    initial_state.setdefault("extras", {})
+                    return [tensorize_replay_state(initial_state)]
+                return [{"objects": {}, "robots": {}, "cameras": {}, "extras": {}}]
 
-        def _get_initial_states(self) -> list[dict[str, Any]]:
-            if init_state is not None:
-                initial_state = patch_state_for_replay(init_state, robot_name=robot_name)
-                initial_state.setdefault("cameras", {})
-                initial_state.setdefault("extras", {})
-                return [tensorize_replay_state(initial_state)]
-            return [{"objects": {}, "robots": {}, "cameras": {}, "extras": {}}]
-
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    env = None
-    try:
-        env = BoxTaskDecodeEnv(scenario=BoxTaskDecodeEnv.scenario, device=device)
-        tensor_states: dict[int, Any] = {}
-        for source_index in unique_indices:
-            state = patch_state_for_replay(episode_states[source_index], robot_name=robot_name)
-            state = tensorize_replay_state(state)
-            env.handler.set_states([state])
-            tensor_states[source_index] = env.handler.get_states(mode="tensor")
-        return tensor_states
-    finally:
-        if env is not None:
-            close_decode_env_without_closing_kit(env)
+        device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        env = None
+        try:
+            env = BoxTaskDecodeEnv(scenario=BoxTaskDecodeEnv.scenario, device=device)
+            tensor_states: dict[int, Any] = {}
+            for source_index in unique_indices:
+                state = patch_state_for_replay(episode_states[source_index], robot_name=robot_name)
+                state = tensorize_replay_state(state)
+                env.handler.set_states([state])
+                tensor_states[source_index] = env.handler.get_states(mode="tensor")
+            return tensor_states
+        finally:
+            if env is not None:
+                close_decode_env_without_closing_kit(env)
 
 
-def _patch_isaacsim_render_settings_for_decode() -> None:
+def _patch_isaacsim_render_settings_for_decode():
     import importlib
 
     isaacsim_module = importlib.import_module("metasim.sim.isaacsim.isaacsim")
     handler_cls = getattr(isaacsim_module, "IsaacsimHandler")
     original = handler_cls._load_render_settings
     if getattr(original, "_box_task_decode_patch", False):
-        return
+        return lambda: None
 
-    def load_render_settings_without_replicator(self) -> None:
+    def load_render_settings_without_replicator(self, *args, **kwargs) -> None:
         try:
-            return original(self)
+            return original(self, *args, **kwargs)
         except ModuleNotFoundError as exc:
             if exc.name is None or not exc.name.startswith("omni.replicator"):
                 raise
@@ -397,6 +428,12 @@ def _patch_isaacsim_render_settings_for_decode() -> None:
 
     load_render_settings_without_replicator._box_task_decode_patch = True
     handler_cls._load_render_settings = load_render_settings_without_replicator
+
+    def restore_render_settings() -> None:
+        if getattr(handler_cls, "_load_render_settings", None) is load_render_settings_without_replicator:
+            handler_cls._load_render_settings = original
+
+    return restore_render_settings
 
 
 def _rewrite_legacy_joint_keys(field_state: MutableMapping[str, Any], mapping: dict[str, str]) -> None:

--- a/scripts/benchmark/rendering/box_task_replay.py
+++ b/scripts/benchmark/rendering/box_task_replay.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections.abc import MutableMapping
 from copy import deepcopy
 from dataclasses import dataclass
+import inspect
 from pathlib import Path
 from typing import Any
 
@@ -171,3 +172,157 @@ def _rewrite_legacy_joint_keys(field_state: MutableMapping[str, Any], mapping: d
         if legacy_name in field_state:
             value = field_state.pop(legacy_name)
             field_state.setdefault(replay_name, value)
+
+
+def _build_scenario_cfg(scenario_cls: type, deferred_attrs: dict[str, Any], **kwargs: Any) -> Any:
+    supported_kwargs = _supported_constructor_kwargs(scenario_cls, kwargs)
+    scenario = scenario_cls(**supported_kwargs)
+    for name, value in deferred_attrs.items():
+        if name not in supported_kwargs:
+            _set_scenario_attr(scenario, name, value)
+    return scenario
+
+
+def _supported_constructor_kwargs(scenario_cls: type, kwargs: dict[str, Any]) -> dict[str, Any]:
+    try:
+        parameters = inspect.signature(scenario_cls).parameters.values()
+    except (TypeError, ValueError):
+        return kwargs
+
+    if any(parameter.kind == inspect.Parameter.VAR_KEYWORD for parameter in parameters):
+        return kwargs
+
+    supported_names = {
+        parameter.name
+        for parameter in parameters
+        if parameter.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
+    }
+    supported_names.discard("self")
+    return {name: value for name, value in kwargs.items() if name in supported_names}
+
+
+def _set_scenario_attr(scenario: Any, name: str, value: Any) -> None:
+    try:
+        setattr(scenario, name, value)
+        return
+    except (AttributeError, TypeError, ValueError):
+        pass
+
+    scenario_dict = getattr(scenario, "__dict__", None)
+    if isinstance(scenario_dict, dict):
+        scenario_dict[name] = value
+        return
+
+    raise AttributeError(f"ScenarioCfg does not allow setting {name!r} after construction")
+
+
+def build_box_task_scenario(
+    *,
+    paths: BoxTaskBundlePaths,
+    simulator: str,
+    scene: str,
+    width: int,
+    height: int,
+    camera_pos: tuple[float, float, float],
+    camera_look_at: tuple[float, float, float],
+    head_light_intensity: float,
+):
+    from metasim.constants import PhysicStateType
+    from metasim.scenario.cameras import PinholeCameraCfg
+    from metasim.scenario.lights import SphereLightCfg
+    from metasim.scenario.objects import PrimitiveCubeCfg, RigidObjCfg
+    from metasim.scenario.render import RenderCfg
+    from metasim.scenario.scenario import ScenarioCfg, SimParamCfg
+
+    scenario = _build_scenario_cfg(
+        ScenarioCfg,
+        deferred_attrs={"renderer": simulator, "scene": scene, "requested_scene_name": scene},
+        objects=[
+            PrimitiveCubeCfg(
+                name="front_table",
+                size=(0.60, 0.70, 0.04),
+                mass=80.0,
+                physics=PhysicStateType.RIGIDBODY,
+                color=(0.85, 0.78, 0.62),
+                fix_base_link=True,
+                default_position=(0.55, 0.0, 0.33),
+                default_orientation=(1.0, 0.0, 0.0, 0.0),
+            ),
+            RigidObjCfg(
+                name="cardboard_box",
+                physics=PhysicStateType.RIGIDBODY,
+                usd_path=str(paths.cardboard_box_usd),
+            ),
+            RigidObjCfg(
+                name="feast_soda_can",
+                physics=PhysicStateType.RIGIDBODY,
+                usd_path=str(paths.soda_can_usd),
+            ),
+            RigidObjCfg(
+                name="feast_scented_candle",
+                physics=PhysicStateType.RIGIDBODY,
+                usd_path=str(paths.scented_candle_usd),
+            ),
+        ],
+        robots=["openarm_wuji"],
+        cameras=[
+            PinholeCameraCfg(
+                name="camera0",
+                data_types=["rgb"],
+                width=width,
+                height=height,
+                pos=camera_pos,
+                look_at=camera_look_at,
+            )
+        ],
+        lights=[
+            SphereLightCfg(
+                name="overhead_light",
+                intensity=float(head_light_intensity),
+                color=(1.0, 1.0, 1.0),
+                radius=0.15,
+                pos=(0.55, 0.0, 1.45),
+                is_global=False,
+            )
+        ],
+        sim_params=SimParamCfg(dt=0.005),
+        decimation=4,
+        simulator=simulator,
+        renderer=simulator,
+        headless=True,
+        num_envs=1,
+        scene=scene,
+        render=RenderCfg(mode="pathtracing"),
+    )
+    return scenario
+
+
+def build_decode_scenario():
+    from metasim.constants import PhysicStateType
+    from metasim.scenario.objects import PrimitiveCubeCfg, RigidObjCfg
+    from metasim.scenario.scenario import ScenarioCfg, SimParamCfg
+
+    return _build_scenario_cfg(
+        ScenarioCfg,
+        deferred_attrs={"renderer": "isaacsim"},
+        objects=[
+            PrimitiveCubeCfg(
+                name="front_table",
+                size=(0.60, 0.70, 0.04),
+                mass=80.0,
+                physics=PhysicStateType.RIGIDBODY,
+                color=(0.85, 0.78, 0.62),
+                fix_base_link=True,
+            ),
+            RigidObjCfg(name="cardboard_box", physics=PhysicStateType.RIGIDBODY),
+            RigidObjCfg(name="feast_soda_can", physics=PhysicStateType.RIGIDBODY),
+            RigidObjCfg(name="feast_scented_candle", physics=PhysicStateType.RIGIDBODY),
+        ],
+        robots=["openarm_wuji"],
+        sim_params=SimParamCfg(dt=0.005),
+        decimation=4,
+        simulator="isaacsim",
+        renderer="isaacsim",
+        headless=True,
+        num_envs=1,
+    )

--- a/scripts/benchmark/rendering/render_box_task_blender_video.py
+++ b/scripts/benchmark/rendering/render_box_task_blender_video.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 import argparse
+import importlib
+from contextlib import contextmanager, suppress
+from copy import deepcopy
 import json
 import os
 import shutil
@@ -26,6 +29,40 @@ from scripts.benchmark.rendering.box_task_replay import (
     save_decoded_tensor_states,
     scene_frame_bounds,
 )
+
+KUJIALE_WALL_MATERIALS = (
+    "Wall",
+    "MI_Stucco_Facade_wfnhfaq_2K",
+)
+KUJIALE_TV_MATERIALS = (
+    "MI_554af95fe4b04227815a8fbd",
+    "MI_554af95fe4b04227815a8fbe",
+)
+KUJIALE_CABINET_MATERIALS = (
+    "MI_5a2788380c1ed46426c0f290",
+    "MI_5a2788380c1ed46426c0f293",
+    "MI_5a2788380c1ed46426c0f296",
+    "MI_5a2788380c1ed46426c0f297",
+    "MI_5a2788380c1ed46426c0f299",
+    "MI_5a2788380c1ed46426c0f29b",
+    "MI_5a2788380c1ed46426c0f29c",
+    "MI_5a2788380c1ed46426c0f29d",
+    "MI_5a2788380c1ed46426c0f29f",
+    "MI_5a2788380c1ed46426c0f2a2",
+    "MI_5a2788380c1ed46426c0f2a3",
+    "MI_5a2788380c1ed46426c0f2a5",
+    "MI_5a2788380c1ed46426c0f2a6",
+    "MI_5a2788380c1ed46426c0f2a7",
+    "MI_5a2788380c1ed46426c0f2a8",
+    "MI_5a2788390c1ed46426c0f2a9",
+)
+KUJIALE_MATERIAL_OVERRIDES: dict[str, tuple[float, float, float, float]] = {
+    **{name: (0.86, 0.84, 0.81, 1.0) for name in KUJIALE_WALL_MATERIALS},
+    **{name: (0.02, 0.02, 0.02, 1.0) for name in KUJIALE_TV_MATERIALS},
+    **{name: (0.78, 0.72, 0.64, 1.0) for name in KUJIALE_CABINET_MATERIALS},
+    "Wood_05": (0.50, 0.38, 0.26, 1.0),
+    "MI_Chevron_Walnut_Parquet_th4hfcfl_2K": (0.50, 0.38, 0.26, 1.0),
+}
 
 
 def parse_vec3(text: str) -> tuple[float, float, float]:
@@ -95,7 +132,25 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--out-frames", type=positive_int, default=None)
     parser.add_argument("--camera-pos", type=parse_vec3, default=(1.45, -1.0, 0.95))
     parser.add_argument("--camera-look-at", type=parse_vec3, default=(0.55, 0.0, 0.38))
-    parser.add_argument("--head-light-intensity", type=float, default=10000.0)
+    parser.add_argument("--head-light-intensity", type=float, default=400.0)
+    parser.add_argument("--exposure", type=float, default=-2.0)
+    parser.add_argument(
+        "--scene-task-offset",
+        default="none",
+        help="Task-frame translation: 'auto' uses -scenario.scene.default_position, 'none' keeps origin, or x,y,z.",
+    )
+    parser.add_argument(
+        "--scene-import-offset",
+        default="auto",
+        help="Blender scene-root translation after import: 'auto' uses scenario.scene.default_position, 'none' disables, or x,y,z.",
+    )
+    parser.add_argument(
+        "--no-clear-task-volume",
+        dest="clear_task_volume",
+        action="store_false",
+        help="Do not hide imported scene meshes that intersect the replay workspace.",
+    )
+    parser.set_defaults(clear_task_volume=True)
     parser.add_argument("--out-video", type=Path, default=None)
     parser.add_argument("--tmp-dir", type=Path, default=None)
     parser.add_argument("--keep-intermediates", action="store_true")
@@ -132,6 +187,11 @@ def build_plan(args: argparse.Namespace) -> dict[str, object]:
         "height": args.height,
         "samples": args.samples,
         "device": args.device,
+        "head_light_intensity": args.head_light_intensity,
+        "exposure": args.exposure,
+        "scene_task_offset": args.scene_task_offset,
+        "scene_import_offset": args.scene_import_offset,
+        "clear_task_volume": args.clear_task_volume,
         "scene_frame_bounds": [list(pair) for pair in scene_frame_bounds(out_frames=out_frames, scene_count=len(scenes))],
         "first_source_frame": int(source_indices[0]),
         "last_source_frame": int(source_indices[-1]),
@@ -203,6 +263,9 @@ def render_frames(
             camera_look_at=args.camera_look_at,
             head_light_intensity=args.head_light_intensity,
         )
+        state_offset = resolve_scene_task_offset(getattr(args, "scene_task_offset", "auto"), scenario)
+        scene_import_offset = resolve_scene_import_offset(getattr(args, "scene_import_offset", "auto"), scenario)
+        apply_scene_task_offset_to_scenario(scenario, state_offset)
         render_scene_segment(
             scenario=scenario,
             tensor_states_by_src=tensor_states_by_source,
@@ -212,6 +275,10 @@ def render_frames(
             out_end=end_frame,
             samples=args.samples,
             device=args.device,
+            exposure=getattr(args, "exposure", -2.0),
+            state_offset=state_offset,
+            scene_import_offset=scene_import_offset,
+            clear_task_volume=bool(getattr(args, "clear_task_volume", True)),
         )
 
 
@@ -252,23 +319,262 @@ def render_scene_segment(
     out_end: int,
     samples: int,
     device: str,
+    exposure: float = -2.0,
+    state_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    scene_import_offset: tuple[float, float, float] = (0.0, 0.0, 0.0),
+    clear_task_volume: bool = True,
 ) -> None:
     from metasim.sim.blender.blender import BlenderHandler
 
-    handler = BlenderHandler(scenario)
+    with local_bundle_render_runtime():
+        handler = BlenderHandler(scenario)
+        try:
+            handler.launch()
+            apply_scene_import_offset_to_handler(handler, scene_import_offset)
+            if clear_task_volume:
+                clearance = clear_task_volume_for_replay(handler, center=state_offset)
+                with suppress(Exception):
+                    setattr(scenario, "_box_task_volume_clearance", clearance)
+            material_repair = repair_imported_scene_materials()
+            with suppress(Exception):
+                setattr(scenario, "_box_task_room_material_repair", material_repair)
+            configure_blender_for_video(samples=samples, device=device, exposure=exposure)
+            camera = scenario.cameras[0]
+            for output_frame in range(out_start, out_end):
+                source_index = int(frame_to_src[output_frame])
+                state = translate_tensor_state(tensor_states_by_src[source_index], state_offset)
+                apply_state_to_handler(handler, state)
+                render_png_frame(handler=handler, camera=camera, path=frame_path(frame_dir, output_frame))
+        finally:
+            handler.close()
+
+
+def resolve_scene_task_offset(offset_text: str, scenario: Any) -> tuple[float, float, float]:
+    normalized = offset_text.strip().lower()
+    if normalized in {"none", "off", "false", "0"}:
+        return 0.0, 0.0, 0.0
+    if normalized != "auto":
+        return parse_vec3(offset_text)
+
+    scene_cfg = getattr(scenario, "scene", None)
+    default_position = getattr(scene_cfg, "default_position", None)
+    if default_position is None:
+        return 0.0, 0.0, 0.0
+    values = tuple(float(value) for value in default_position)
+    if len(values) != 3:
+        raise ValueError(f"Scene default_position must have 3 values, got {values!r}")
+    return -values[0], -values[1], -values[2]
+
+
+def resolve_scene_import_offset(offset_text: str, scenario: Any) -> tuple[float, float, float]:
+    normalized = offset_text.strip().lower()
+    if normalized in {"none", "off", "false", "0"}:
+        return 0.0, 0.0, 0.0
+    if normalized != "auto":
+        return parse_vec3(offset_text)
+
+    scene_cfg = getattr(scenario, "scene", None)
+    default_position = getattr(scene_cfg, "default_position", None)
+    if default_position is None:
+        return 0.0, 0.0, 0.0
+    values = tuple(float(value) for value in default_position)
+    if len(values) != 3:
+        raise ValueError(f"Scene default_position must have 3 values, got {values!r}")
+    return values
+
+
+def apply_scene_task_offset_to_scenario(scenario: Any, offset: tuple[float, float, float]) -> None:
+    if _is_zero_vec3(offset):
+        return
+    for camera in getattr(scenario, "cameras", ()) or ():
+        if hasattr(camera, "pos"):
+            _set_object_attr(camera, "pos", _translated_vec3(camera.pos, offset))
+        if hasattr(camera, "look_at"):
+            _set_object_attr(camera, "look_at", _translated_vec3(camera.look_at, offset))
+    for light in getattr(scenario, "lights", ()) or ():
+        if hasattr(light, "pos"):
+            _set_object_attr(light, "pos", _translated_vec3(light.pos, offset))
+
+
+def apply_scene_import_offset_to_handler(handler: Any, offset: tuple[float, float, float]) -> None:
+    if _is_zero_vec3(offset):
+        return
+    for root in getattr(handler, "_scene_objs", ()) or ():
+        _translate_blender_object_location(root, offset)
+    bpy = sys.modules.get("bpy")
+    view_layer = getattr(getattr(bpy, "context", None), "view_layer", None) if bpy is not None else None
+    update = getattr(view_layer, "update", None)
+    if callable(update):
+        update()
+
+
+def _translate_blender_object_location(obj: Any, offset: tuple[float, float, float]) -> None:
+    location = getattr(obj, "location", None)
+    if location is None:
+        return
     try:
-        handler.launch()
-        configure_blender_for_video(samples=samples, device=device)
-        camera = scenario.cameras[0]
-        for output_frame in range(out_start, out_end):
-            source_index = int(frame_to_src[output_frame])
-            apply_state_to_handler(handler, tensor_states_by_src[source_index])
-            render_png_frame(handler=handler, camera=camera, path=frame_path(frame_dir, output_frame))
-    finally:
-        handler.close()
+        for index in range(3):
+            location[index] = float(location[index]) + float(offset[index])
+        return
+    except (TypeError, AttributeError, IndexError, ValueError):
+        pass
+    if all(hasattr(location, attr_name) for attr_name in ("x", "y", "z")):
+        location.x = float(location.x) + float(offset[0])
+        location.y = float(location.y) + float(offset[1])
+        location.z = float(location.z) + float(offset[2])
+        return
+    _set_object_attr(obj, "location", _translated_vec3(location, offset))
 
 
-def configure_blender_for_video(*, samples: int, device: str) -> None:
+def clear_task_volume_for_replay(
+    handler: Any,
+    *,
+    center: tuple[float, float, float],
+    half_extents: tuple[float, float, float] = (2.0, 2.0, 2.4),
+) -> dict[str, Any]:
+    volume_min = tuple(float(center[index]) - float(half_extents[index]) for index in range(3))
+    volume_max = tuple(float(center[index]) + float(half_extents[index]) for index in range(3))
+    hidden_count = 0
+    for obj in _iter_scene_tree(getattr(handler, "_scene_objs", ()) or ()):
+        bounds = _object_world_bounds(obj)
+        if bounds is None:
+            continue
+        if _looks_like_floor(bounds):
+            continue
+        if not _bounds_intersect(bounds, (volume_min, volume_max)):
+            continue
+        with suppress(Exception):
+            obj.hide_render = True
+        with suppress(Exception):
+            obj.hide_viewport = True
+        hidden_count += 1
+    return {"status": "applied", "hidden_count": hidden_count}
+
+
+def _iter_scene_tree(roots: Sequence[Any]):
+    seen: set[int] = set()
+    stack = list(roots)
+    while stack:
+        obj = stack.pop()
+        obj_id = id(obj)
+        if obj_id in seen:
+            continue
+        seen.add(obj_id)
+        yield obj
+        stack.extend(getattr(obj, "children", ()) or ())
+
+
+def _object_world_bounds(obj: Any) -> tuple[tuple[float, float, float], tuple[float, float, float]] | None:
+    if getattr(obj, "type", None) != "MESH":
+        return None
+    bound_box = getattr(obj, "bound_box", None)
+    matrix_world = getattr(obj, "matrix_world", None)
+    if bound_box is None or matrix_world is None:
+        return None
+    try:
+        from mathutils import Vector
+    except Exception:
+        Vector = None
+    points: list[tuple[float, float, float]] = []
+    for corner in bound_box:
+        try:
+            world = matrix_world @ (Vector(corner) if Vector is not None else corner)
+            points.append((float(world[0]), float(world[1]), float(world[2])))
+        except Exception:
+            return None
+    if not points:
+        return None
+    return (
+        tuple(min(point[index] for point in points) for index in range(3)),
+        tuple(max(point[index] for point in points) for index in range(3)),
+    )
+
+
+def _looks_like_floor(bounds: tuple[tuple[float, float, float], tuple[float, float, float]]) -> bool:
+    min_corner, max_corner = bounds
+    return max_corner[2] <= 0.20 and (max_corner[2] - min_corner[2]) <= 0.25
+
+
+def _bounds_intersect(
+    first: tuple[tuple[float, float, float], tuple[float, float, float]],
+    second: tuple[tuple[float, float, float], tuple[float, float, float]],
+) -> bool:
+    first_min, first_max = first
+    second_min, second_max = second
+    return all(first_min[index] <= second_max[index] and first_max[index] >= second_min[index] for index in range(3))
+
+
+def translate_tensor_state(state: Any, offset: tuple[float, float, float]) -> Any:
+    if _is_zero_vec3(offset):
+        return state
+
+    shifted = deepcopy(state)
+    for collection_name in ("objects", "robots"):
+        collection = getattr(shifted, collection_name, {}) or {}
+        for entity_state in collection.values():
+            _translate_state_attr(entity_state, "root_state", offset)
+            _translate_state_attr(entity_state, "body_state", offset)
+    return shifted
+
+
+def _translate_state_attr(entity_state: Any, attr_name: str, offset: tuple[float, float, float]) -> None:
+    tensor = getattr(entity_state, attr_name, None)
+    if tensor is None:
+        return
+    translated = _clone_tensor_like(tensor)
+    translated[..., 0:3] = translated[..., 0:3] + _offset_like(tensor, offset)
+    setattr(entity_state, attr_name, translated)
+
+
+def _clone_tensor_like(tensor: Any) -> Any:
+    clone = getattr(tensor, "clone", None)
+    if callable(clone):
+        return clone()
+    copy = getattr(tensor, "copy", None)
+    if callable(copy):
+        return copy()
+    return deepcopy(tensor)
+
+
+def _offset_like(tensor: Any, offset: tuple[float, float, float]) -> Any:
+    new_tensor = getattr(tensor, "new_tensor", None)
+    if callable(new_tensor):
+        return new_tensor(offset)
+    try:
+        import numpy as np
+
+        return np.asarray(offset, dtype=getattr(tensor, "dtype", None))
+    except Exception:
+        return offset
+
+
+def _translated_vec3(value: Any, offset: tuple[float, float, float]) -> tuple[float, float, float]:
+    values = tuple(float(item) for item in value)
+    if len(values) != 3:
+        raise ValueError(f"Expected vec3, got {values!r}")
+    return tuple(values[index] + float(offset[index]) for index in range(3))
+
+
+def _is_zero_vec3(value: tuple[float, float, float]) -> bool:
+    return all(abs(float(item)) <= 1.0e-12 for item in value)
+
+
+def _set_object_attr(obj: Any, name: str, value: Any) -> None:
+    try:
+        setattr(obj, name, value)
+        return
+    except (AttributeError, TypeError, ValueError):
+        pass
+
+    obj_dict = getattr(obj, "__dict__", None)
+    if isinstance(obj_dict, dict):
+        obj_dict[name] = value
+        return
+
+    raise AttributeError(f"{type(obj).__name__} does not allow setting {name!r}")
+
+
+def configure_blender_for_video(*, samples: int, device: str, exposure: float = -2.0) -> None:
     import bpy
 
     scene = bpy.context.scene
@@ -276,9 +582,27 @@ def configure_blender_for_video(*, samples: int, device: str) -> None:
     scene.cycles.samples = int(samples)
     scene.render.image_settings.file_format = "PNG"
     scene.render.image_settings.color_mode = "RGB"
+    _set_if_supported(scene.render, "use_compositing", False)
+    _set_if_supported(scene.render, "use_sequencer", False)
     scene.view_settings.view_transform = "Standard"
-    scene.view_settings.exposure = 0.0
+    _set_if_supported(scene.view_settings, "look", "None")
+    scene.view_settings.exposure = float(exposure)
     scene.view_settings.gamma = 1.0
+    _set_if_supported(scene.cycles, "use_denoising", True)
+    _set_if_supported(scene.cycles, "denoiser", "OPTIX")
+    _set_if_supported(scene.cycles, "denoising_input_passes", "RGB_ALBEDO_NORMAL")
+    _set_if_supported(scene.cycles, "denoising_prefilter", "ACCURATE")
+    _set_if_supported(scene.cycles, "denoising_quality", "HIGH")
+    _set_if_supported(scene.cycles, "use_adaptive_sampling", False)
+    _set_if_supported(scene.cycles, "max_bounces", 10)
+    _set_if_supported(scene.cycles, "diffuse_bounces", 4)
+    _set_if_supported(scene.cycles, "glossy_bounces", 4)
+    _set_if_supported(scene.cycles, "transmission_bounces", 10)
+    _set_if_supported(scene.cycles, "transparent_max_bounces", 10)
+    _set_if_supported(scene.cycles, "caustics_reflective", True)
+    _set_if_supported(scene.cycles, "caustics_refractive", True)
+    _set_if_supported(scene.cycles, "sample_clamp_indirect", 10.0)
+    _set_if_supported(scene.cycles, "blur_glossy", 1.0)
 
     requested_device = device.upper()
     if requested_device == "CPU":
@@ -301,6 +625,56 @@ def configure_blender_for_video(*, samples: int, device: str) -> None:
         raise last_error
 
 
+def repair_imported_scene_materials() -> dict[str, Any]:
+    import bpy
+
+    objects = list(getattr(bpy.context.scene, "objects", ()))
+    status: dict[str, Any] = {
+        "status": "unknown",
+        "object_count": len(objects),
+        "override_count": len(KUJIALE_MATERIAL_OVERRIDES),
+    }
+    try:
+        blender_module = importlib.import_module("metasim.sim.blender.blender")
+        repair_imported_materials = getattr(blender_module, "_repair_imported_materials")
+        repair_imported_materials(objects, KUJIALE_MATERIAL_OVERRIDES)
+        status["status"] = "applied"
+    except Exception as exc:
+        status["status"] = "failed"
+        status["error"] = repr(exc)
+    with suppress(Exception):
+        bpy.context.view_layer.update()
+    return status
+
+
+@contextmanager
+def local_bundle_render_runtime():
+    try:
+        import metasim.utils.hf_util as hf_util
+    except Exception:
+        yield
+        return
+
+    original_single = getattr(hf_util, "check_and_download_single", None)
+    original_recursive = getattr(hf_util, "check_and_download_recursive", None)
+    hf_util.check_and_download_single = lambda filepath: None
+    hf_util.check_and_download_recursive = lambda filepaths, n_processes=16: None
+    try:
+        yield
+    finally:
+        if original_single is not None:
+            hf_util.check_and_download_single = original_single
+        if original_recursive is not None:
+            hf_util.check_and_download_recursive = original_recursive
+
+
+def _set_if_supported(obj: Any, name: str, value: Any) -> None:
+    try:
+        setattr(obj, name, value)
+    except (AttributeError, TypeError, ValueError):
+        pass
+
+
 def _enable_cycles_devices(preferences: Any, devices: Any = None) -> None:
     if devices is None:
         devices = getattr(preferences, "devices", ())
@@ -312,6 +686,9 @@ def _enable_cycles_devices(preferences: Any, devices: Any = None) -> None:
 
 
 def apply_state_to_handler(handler: Any, state: Any) -> None:
+    if apply_tensor_state_directly(handler, state):
+        return
+
     set_blender_image_format_if_loaded(file_format="BMP", color_mode="RGB")
     try:
         handler.set_states(state)
@@ -322,6 +699,30 @@ def apply_state_to_handler(handler: Any, state: Any) -> None:
     refresh_render = getattr(handler, "refresh_render", None)
     if callable(refresh_render):
         refresh_render()
+
+
+def apply_tensor_state_directly(handler: Any, state: Any) -> bool:
+    apply_tensor_state = getattr(handler, "_apply_tensor_state", None)
+    if not callable(apply_tensor_state) or not _looks_like_tensor_state(state):
+        return False
+
+    invalidate = getattr(handler, "_invalidate_state_caches", None)
+    if callable(invalidate):
+        invalidate()
+    apply_tensor_state(state)
+    setattr(handler, "_last_tensor_state", state)
+    setattr(handler, "_render_dirty", True)
+
+    bpy = sys.modules.get("bpy")
+    view_layer = getattr(getattr(bpy, "context", None), "view_layer", None) if bpy is not None else None
+    update = getattr(view_layer, "update", None)
+    if callable(update):
+        update()
+    return True
+
+
+def _looks_like_tensor_state(state: Any) -> bool:
+    return all(hasattr(state, attr_name) for attr_name in ("objects", "robots", "cameras"))
 
 
 def set_blender_image_format_if_loaded(*, file_format: str, color_mode: str) -> None:

--- a/scripts/benchmark/rendering/render_box_task_blender_video.py
+++ b/scripts/benchmark/rendering/render_box_task_blender_video.py
@@ -21,7 +21,9 @@ from scripts.benchmark.rendering.box_task_replay import (
     compute_output_frames,
     decode_trajectory_tensor_states,
     frame_to_source_indices,
+    load_decoded_tensor_states,
     parse_scene_tokens,
+    save_decoded_tensor_states,
     scene_frame_bounds,
 )
 
@@ -94,11 +96,19 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--camera-pos", type=parse_vec3, default=(1.45, -1.0, 0.95))
     parser.add_argument("--camera-look-at", type=parse_vec3, default=(0.55, 0.0, 0.38))
     parser.add_argument("--head-light-intensity", type=float, default=10000.0)
-    parser.add_argument("--out-video", type=Path, required=True)
+    parser.add_argument("--out-video", type=Path, default=None)
     parser.add_argument("--tmp-dir", type=Path, default=None)
     parser.add_argument("--keep-intermediates", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
-    return parser.parse_args(argv)
+    parser.add_argument("--decode-source-indices-json", default=None, help=argparse.SUPPRESS)
+    parser.add_argument("--decode-states-out", type=Path, default=None, help=argparse.SUPPRESS)
+    args = parser.parse_args(argv)
+    is_decode_worker = args.decode_source_indices_json is not None or args.decode_states_out is not None
+    if is_decode_worker and (args.decode_source_indices_json is None or args.decode_states_out is None):
+        parser.error("--decode-source-indices-json and --decode-states-out must be used together")
+    if not is_decode_worker and args.out_video is None:
+        parser.error("--out-video is required unless decoding states")
+    return args
 
 
 def build_plan(args: argparse.Namespace) -> dict[str, object]:
@@ -170,11 +180,13 @@ def render_frames(
     frame_dir: Path,
 ) -> None:
     unique_source_indices = sorted({int(index) for index in frame_to_src})
-    tensor_states_by_source = decode_trajectory_tensor_states(
-        paths.traj_path,
-        unique_source_indices,
-        bundle_paths=paths,
+    decoded_state_path = frame_dir.parent / "decoded_tensor_states.pt"
+    decode_trajectory_tensor_states_subprocess(
+        paths=paths,
+        source_indices=unique_source_indices,
+        state_path=decoded_state_path,
     )
+    tensor_states_by_source = load_decoded_tensor_states(decoded_state_path)
 
     for scene, (start_frame, end_frame) in zip(
         scenes,
@@ -201,6 +213,33 @@ def render_frames(
             samples=args.samples,
             device=args.device,
         )
+
+
+def decode_trajectory_tensor_states_subprocess(
+    *,
+    paths: BoxTaskBundlePaths,
+    source_indices: Sequence[int],
+    state_path: Path,
+    python_bin: str = sys.executable,
+    script_path: Path | None = None,
+) -> None:
+    worker_script = Path(__file__).resolve() if script_path is None else script_path
+    command = [
+        python_bin,
+        str(worker_script),
+        "--bundle-root",
+        str(paths.bundle_root),
+        "--traj-path",
+        str(paths.traj_path),
+        "--decode-source-indices-json",
+        json.dumps([int(index) for index in source_indices]),
+        "--decode-states-out",
+        str(state_path),
+    ]
+    proc = subprocess.run(command, text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        message = "\n".join(part for part in (proc.stderr.strip(), proc.stdout.strip()) if part)
+        raise RuntimeError(f"decode worker failed with exit code {proc.returncode}: {message[-1000:]}")
 
 
 def render_scene_segment(
@@ -273,13 +312,28 @@ def _enable_cycles_devices(preferences: Any, devices: Any = None) -> None:
 
 
 def apply_state_to_handler(handler: Any, state: Any) -> None:
+    set_blender_image_format_if_loaded(file_format="BMP", color_mode="RGB")
     try:
         handler.set_states(state)
     except TypeError:
         handler.set_states([state])
+    if getattr(handler, "set_states_refreshes", False):
+        return
     refresh_render = getattr(handler, "refresh_render", None)
     if callable(refresh_render):
         refresh_render()
+
+
+def set_blender_image_format_if_loaded(*, file_format: str, color_mode: str) -> None:
+    bpy = sys.modules.get("bpy")
+    if bpy is None:
+        return
+    scene = getattr(getattr(bpy, "context", None), "scene", None)
+    image_settings = getattr(getattr(scene, "render", None), "image_settings", None)
+    if image_settings is None:
+        return
+    image_settings.file_format = file_format
+    image_settings.color_mode = color_mode
 
 
 def camera_object_for(handler: Any, camera: Any) -> Any:
@@ -296,6 +350,8 @@ def render_png_frame(*, handler: Any, camera: Any, path: Path) -> None:
 
     path.parent.mkdir(parents=True, exist_ok=True)
     scene = bpy.context.scene
+    scene.render.image_settings.file_format = "PNG"
+    scene.render.image_settings.color_mode = "RGB"
     scene.camera = camera_object_for(handler, camera)
     scene.render.resolution_x = int(camera.width)
     scene.render.resolution_y = int(camera.height)
@@ -304,8 +360,29 @@ def render_png_frame(*, handler: Any, camera: Any, path: Path) -> None:
     bpy.ops.render.render(write_still=True)
 
 
+def run_decode_worker(args: argparse.Namespace) -> int:
+    paths = BoxTaskBundlePaths.from_root(args.bundle_root, traj_path=args.traj_path)
+    source_indices = json.loads(args.decode_source_indices_json)
+    states = decode_trajectory_tensor_states(paths.traj_path, source_indices, bundle_paths=paths)
+    save_decoded_tensor_states(states, args.decode_states_out)
+    print(
+        json.dumps(
+            {
+                "status": "decoded",
+                "states": str(args.decode_states_out),
+                "source_frames": len(source_indices),
+            }
+        )
+    )
+    return 0
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
+    if args.decode_source_indices_json is not None or args.decode_states_out is not None:
+        if args.decode_source_indices_json is None or args.decode_states_out is None:
+            raise ValueError("--decode-source-indices-json and --decode-states-out must be used together")
+        return run_decode_worker(args)
     plan = build_plan(args)
     if args.dry_run:
         print(json.dumps(plan, indent=2))

--- a/scripts/benchmark/rendering/render_box_task_blender_video.py
+++ b/scripts/benchmark/rendering/render_box_task_blender_video.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 from typing import Sequence
@@ -33,6 +36,44 @@ def positive_int(text: str) -> int:
     if value <= 0:
         raise argparse.ArgumentTypeError(f"Expected a positive integer, got {text!r}")
     return value
+
+
+def frame_path(frame_dir: Path, frame_index: int) -> Path:
+    return frame_dir / f"frame_{frame_index:06d}.png"
+
+
+def select_work_dir(*, bundle_root: Path, tmp_dir: Path | None, pid: int | None = None) -> Path:
+    selected_pid = os.getpid() if pid is None else pid
+    root = tmp_dir.expanduser().resolve() if tmp_dir is not None else bundle_root / ".tmp_box_task_blender"
+    return root / f"render_work_{selected_pid}"
+
+
+def ffmpeg_command(*, ffmpeg_bin: str, frame_dir: Path, fps: int, out_video: Path) -> list[str]:
+    return [
+        ffmpeg_bin,
+        "-y",
+        "-framerate",
+        str(fps),
+        "-i",
+        str(frame_dir / "frame_%06d.png"),
+        "-pix_fmt",
+        "yuv420p",
+        "-vcodec",
+        "libx264",
+        str(out_video),
+    ]
+
+
+def assemble_video(*, frame_dir: Path, fps: int, out_video: Path) -> None:
+    ffmpeg_bin = shutil.which("ffmpeg")
+    if ffmpeg_bin is None:
+        raise RuntimeError("ffmpeg not found in PATH")
+    out_video.parent.mkdir(parents=True, exist_ok=True)
+    command = ffmpeg_command(ffmpeg_bin=ffmpeg_bin, frame_dir=frame_dir, fps=fps, out_video=out_video)
+    proc = subprocess.run(command, text=True, capture_output=True, check=False)
+    if proc.returncode != 0:
+        message = "\n".join(part for part in (proc.stderr.strip(), proc.stdout.strip()) if part)
+        raise RuntimeError(f"ffmpeg failed with exit code {proc.returncode}: {message[-1000:]}")
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/scripts/benchmark/rendering/render_box_task_blender_video.py
+++ b/scripts/benchmark/rendering/render_box_task_blender_video.py
@@ -170,7 +170,11 @@ def render_frames(
     frame_dir: Path,
 ) -> None:
     unique_source_indices = sorted({int(index) for index in frame_to_src})
-    tensor_states_by_source = decode_trajectory_tensor_states(paths.traj_path, unique_source_indices)
+    tensor_states_by_source = decode_trajectory_tensor_states(
+        paths.traj_path,
+        unique_source_indices,
+        bundle_paths=paths,
+    )
 
     for scene, (start_frame, end_frame) in zip(
         scenes,

--- a/scripts/benchmark/rendering/render_box_task_blender_video.py
+++ b/scripts/benchmark/rendering/render_box_task_blender_video.py
@@ -8,7 +8,7 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Sequence
+from typing import Any, Sequence
 
 if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
@@ -17,7 +17,9 @@ from scripts.benchmark.rendering.box_task_replay import (
     DEFAULT_BUNDLE_ROOT,
     DEFAULT_SRC_TOTAL_FRAMES,
     BoxTaskBundlePaths,
+    build_box_task_scenario,
     compute_output_frames,
+    decode_trajectory_tensor_states,
     frame_to_source_indices,
     parse_scene_tokens,
     scene_frame_bounds,
@@ -128,7 +130,174 @@ def build_plan(args: argparse.Namespace) -> dict[str, object]:
 
 
 def render_video(args: argparse.Namespace) -> int:
-    raise NotImplementedError("Real rendering is added in the next task")
+    paths = BoxTaskBundlePaths.from_root(args.bundle_root, traj_path=args.traj_path)
+    scenes = parse_scene_tokens(args.scenes)
+    out_frames = compute_output_frames(
+        src_total_frames=args.src_total_frames,
+        fps=args.fps,
+        duration_sec=args.duration_sec,
+        out_frames=args.out_frames,
+    )
+    source_indices = frame_to_source_indices(src_total_frames=args.src_total_frames, out_frames=out_frames)
+    out_video = args.out_video.expanduser().resolve()
+    work_dir = select_work_dir(bundle_root=paths.bundle_root, tmp_dir=args.tmp_dir)
+    frame_dir = work_dir / "frames"
+    frame_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        render_frames(
+            args=args,
+            paths=paths,
+            scenes=scenes,
+            frame_to_src=source_indices,
+            frame_dir=frame_dir,
+        )
+        assemble_video(frame_dir=frame_dir, fps=args.fps, out_video=out_video)
+    finally:
+        if not args.keep_intermediates:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+    print(json.dumps({"status": "ok", "out_video": str(out_video), "frames": out_frames}))
+    return 0
+
+
+def render_frames(
+    *,
+    args: argparse.Namespace,
+    paths: BoxTaskBundlePaths,
+    scenes: Sequence[str],
+    frame_to_src,
+    frame_dir: Path,
+) -> None:
+    unique_source_indices = sorted({int(index) for index in frame_to_src})
+    tensor_states_by_source = decode_trajectory_tensor_states(paths.traj_path, unique_source_indices)
+
+    for scene, (start_frame, end_frame) in zip(
+        scenes,
+        scene_frame_bounds(out_frames=len(frame_to_src), scene_count=len(scenes)),
+        strict=True,
+    ):
+        scenario = build_box_task_scenario(
+            paths=paths,
+            simulator="blender",
+            scene=scene,
+            width=args.width,
+            height=args.height,
+            camera_pos=args.camera_pos,
+            camera_look_at=args.camera_look_at,
+            head_light_intensity=args.head_light_intensity,
+        )
+        render_scene_segment(
+            scenario=scenario,
+            tensor_states_by_src=tensor_states_by_source,
+            frame_to_src=frame_to_src,
+            frame_dir=frame_dir,
+            out_start=start_frame,
+            out_end=end_frame,
+            samples=args.samples,
+            device=args.device,
+        )
+
+
+def render_scene_segment(
+    *,
+    scenario: Any,
+    tensor_states_by_src: dict[int, Any],
+    frame_to_src,
+    frame_dir: Path,
+    out_start: int,
+    out_end: int,
+    samples: int,
+    device: str,
+) -> None:
+    from metasim.sim.blender.blender import BlenderHandler
+
+    handler = BlenderHandler(scenario)
+    try:
+        handler.launch()
+        configure_blender_for_video(samples=samples, device=device)
+        camera = scenario.cameras[0]
+        for output_frame in range(out_start, out_end):
+            source_index = int(frame_to_src[output_frame])
+            apply_state_to_handler(handler, tensor_states_by_src[source_index])
+            render_png_frame(handler=handler, camera=camera, path=frame_path(frame_dir, output_frame))
+    finally:
+        handler.close()
+
+
+def configure_blender_for_video(*, samples: int, device: str) -> None:
+    import bpy
+
+    scene = bpy.context.scene
+    scene.render.engine = "CYCLES"
+    scene.cycles.samples = int(samples)
+    scene.render.image_settings.file_format = "PNG"
+    scene.render.image_settings.color_mode = "RGB"
+    scene.view_settings.view_transform = "Standard"
+    scene.view_settings.exposure = 0.0
+    scene.view_settings.gamma = 1.0
+
+    requested_device = device.upper()
+    if requested_device == "CPU":
+        scene.cycles.device = "CPU"
+        return
+
+    scene.cycles.device = "GPU"
+    preferences = bpy.context.preferences.addons["cycles"].preferences
+    device_types = ("OPTIX", "CUDA") if requested_device == "AUTO" else (requested_device,)
+    last_error: Exception | None = None
+    for device_type in device_types:
+        try:
+            preferences.compute_device_type = device_type
+            devices = preferences.get_devices()
+            _enable_cycles_devices(preferences, devices)
+            return
+        except Exception as exc:  # pragma: no cover - depends on Blender build/device support
+            last_error = exc
+    if last_error is not None:
+        raise last_error
+
+
+def _enable_cycles_devices(preferences: Any, devices: Any = None) -> None:
+    if devices is None:
+        devices = getattr(preferences, "devices", ())
+    for cycles_device in devices:
+        if isinstance(cycles_device, (list, tuple)):
+            _enable_cycles_devices(preferences, cycles_device)
+        else:
+            cycles_device.use = True
+
+
+def apply_state_to_handler(handler: Any, state: Any) -> None:
+    try:
+        handler.set_states(state)
+    except TypeError:
+        handler.set_states([state])
+    refresh_render = getattr(handler, "refresh_render", None)
+    if callable(refresh_render):
+        refresh_render()
+
+
+def camera_object_for(handler: Any, camera: Any) -> Any:
+    camera_name = getattr(camera, "name", camera)
+    for attr_name in ("camera_objs", "_camera_objs"):
+        camera_objs = getattr(handler, attr_name, None)
+        if camera_objs is not None and camera_name in camera_objs:
+            return camera_objs[camera_name]
+    raise KeyError(f"Camera object not found: {camera_name}")
+
+
+def render_png_frame(*, handler: Any, camera: Any, path: Path) -> None:
+    import bpy
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    scene = bpy.context.scene
+    scene.camera = camera_object_for(handler, camera)
+    scene.render.resolution_x = int(camera.width)
+    scene.render.resolution_y = int(camera.height)
+    scene.render.resolution_percentage = 100
+    scene.render.filepath = str(path)
+    bpy.ops.render.render(write_still=True)
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/scripts/benchmark/rendering/render_box_task_blender_video.py
+++ b/scripts/benchmark/rendering/render_box_task_blender_video.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Sequence
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from scripts.benchmark.rendering.box_task_replay import (
+    DEFAULT_BUNDLE_ROOT,
+    DEFAULT_SRC_TOTAL_FRAMES,
+    BoxTaskBundlePaths,
+    compute_output_frames,
+    frame_to_source_indices,
+    parse_scene_tokens,
+    scene_frame_bounds,
+)
+
+
+def parse_vec3(text: str) -> tuple[float, float, float]:
+    values = [part.strip() for part in text.split(",") if part.strip()]
+    if len(values) != 3:
+        raise argparse.ArgumentTypeError(f"Expected vec3 as x,y,z, got {text!r}")
+    return float(values[0]), float(values[1]), float(values[2])
+
+
+def positive_int(text: str) -> int:
+    value = int(text)
+    if value <= 0:
+        raise argparse.ArgumentTypeError(f"Expected a positive integer, got {text!r}")
+    return value
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render box-task replay video in Blender.")
+    parser.add_argument("--bundle-root", type=Path, default=DEFAULT_BUNDLE_ROOT)
+    parser.add_argument("--traj-path", type=Path, default=None)
+    parser.add_argument("--src-total-frames", type=int, default=DEFAULT_SRC_TOTAL_FRAMES)
+    parser.add_argument("--scenes", default="0021,0022,0024,0025,0031")
+    parser.add_argument("--fps", type=positive_int, default=30)
+    parser.add_argument("--width", type=positive_int, default=800)
+    parser.add_argument("--height", type=positive_int, default=800)
+    parser.add_argument("--samples", type=positive_int, default=64)
+    parser.add_argument("--device", default="OPTIX")
+    parser.add_argument("--duration-sec", type=float, default=None)
+    parser.add_argument("--out-frames", type=positive_int, default=None)
+    parser.add_argument("--camera-pos", type=parse_vec3, default=(1.45, -1.0, 0.95))
+    parser.add_argument("--camera-look-at", type=parse_vec3, default=(0.55, 0.0, 0.38))
+    parser.add_argument("--head-light-intensity", type=float, default=10000.0)
+    parser.add_argument("--out-video", type=Path, required=True)
+    parser.add_argument("--tmp-dir", type=Path, default=None)
+    parser.add_argument("--keep-intermediates", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def build_plan(args: argparse.Namespace) -> dict[str, object]:
+    paths = BoxTaskBundlePaths.from_root(args.bundle_root, traj_path=args.traj_path)
+    scenes = parse_scene_tokens(args.scenes)
+    out_frames = compute_output_frames(
+        src_total_frames=args.src_total_frames,
+        fps=args.fps,
+        duration_sec=args.duration_sec,
+        out_frames=args.out_frames,
+    )
+    source_indices = frame_to_source_indices(src_total_frames=args.src_total_frames, out_frames=out_frames)
+    return {
+        "status": "dry_run" if args.dry_run else "planned",
+        "bundle_root": str(paths.bundle_root),
+        "traj_path": str(paths.traj_path),
+        "scenes": scenes,
+        "out_frames": out_frames,
+        "fps": args.fps,
+        "width": args.width,
+        "height": args.height,
+        "samples": args.samples,
+        "device": args.device,
+        "scene_frame_bounds": [list(pair) for pair in scene_frame_bounds(out_frames=out_frames, scene_count=len(scenes))],
+        "first_source_frame": int(source_indices[0]),
+        "last_source_frame": int(source_indices[-1]),
+        "out_video": str(args.out_video.expanduser().resolve()),
+    }
+
+
+def render_video(args: argparse.Namespace) -> int:
+    raise NotImplementedError("Real rendering is added in the next task")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    plan = build_plan(args)
+    if args.dry_run:
+        print(json.dumps(plan, indent=2))
+        return 0
+    return render_video(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/rendering/run_blender_benchmark_matrix.py
+++ b/scripts/benchmark/rendering/run_blender_benchmark_matrix.py
@@ -1,0 +1,911 @@
+"""Run the planned Blender rendering benchmark matrix serially.
+
+Each benchmark row launches a fresh Python process so Blender/Cycles state and
+persistent data do not leak across rows unless that row explicitly enables it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import shlex
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DEFAULT_ROOT = Path("outputs/rendering_benchmark/blender_2026-05-09_glass_only")
+SCENES = ("complex_glass_cube_reach",)
+SEED_VARIANCE_SEEDS: tuple[int, ...] = tuple(range(2026, 2036))
+SEED_VARIANCE_SPP_LEVELS: tuple[int, ...] = (8, 16, 64, 256, 512, 1024, 4096)
+SEED_VARIANCE_GLASS_PROFILES: tuple[str, ...] = (
+    "glass_default",
+    "glass_fast",
+    "glass_reference",
+    "caustics_off",
+    "clamp_indirect_2",
+)
+
+
+@dataclass(frozen=True)
+class MatrixRun:
+    label: str
+    args: list[str] = field(default_factory=list)
+
+
+def _render_args(
+    *,
+    scene: str,
+    samples: int,
+    denoiser: str,
+    device: str,
+    camera_count: int = 1,
+    frames: int = 1,
+    warmup_frames: int = 0,
+    seed: int = 0,
+    output_root: Path,
+    extra: list[str] | None = None,
+) -> list[str]:
+    args = [
+        "render",
+        "--scene",
+        scene,
+        "--samples",
+        str(samples),
+        "--denoiser",
+        denoiser,
+        "--device",
+        device,
+        "--camera-count",
+        str(camera_count),
+        "--frames",
+        str(frames),
+        "--warmup-frames",
+        str(warmup_frames),
+        "--seed",
+        str(seed),
+        "--output-root",
+        str(output_root),
+    ]
+    if not extra or "--adaptive-sampling" not in extra:
+        args[9:9] = ["--adaptive-sampling", "off"]
+    if extra:
+        args.extend(extra)
+    return args
+
+
+def _stability_args(
+    *,
+    scene: str,
+    device: str,
+    output_root: Path,
+) -> list[str]:
+    return [
+        "stability",
+        "--scene",
+        scene,
+        "--samples",
+        "64",
+        "--denoiser",
+        "on",
+        "--denoiser-engine",
+        "OPTIX",
+        "--denoiser-passes",
+        "RGB_ALBEDO_NORMAL",
+        "--adaptive-sampling",
+        "off",
+        "--device",
+        device,
+        "--camera-count",
+        "1",
+        "--repeats",
+        "20",
+        "--seed",
+        "0",
+        "--output-root",
+        str(output_root),
+    ]
+
+
+def _glass_profile_args() -> dict[str, list[str]]:
+    return {
+        "glass_fast": [
+            "--max-bounces",
+            "4",
+            "--diffuse-bounces",
+            "2",
+            "--glossy-bounces",
+            "2",
+            "--transmission-bounces",
+            "4",
+            "--transparent-bounces",
+            "4",
+            "--caustics-reflective",
+            "off",
+            "--caustics-refractive",
+            "off",
+            "--sample-clamp-indirect",
+            "2.0",
+            "--filter-glossy",
+            "1.0",
+        ],
+        "glass_default": [
+            "--max-bounces",
+            "10",
+            "--diffuse-bounces",
+            "4",
+            "--glossy-bounces",
+            "4",
+            "--transmission-bounces",
+            "10",
+            "--transparent-bounces",
+            "10",
+            "--caustics-reflective",
+            "on",
+            "--caustics-refractive",
+            "on",
+            "--sample-clamp-indirect",
+            "10.0",
+            "--filter-glossy",
+            "1.0",
+        ],
+        "glass_reference": [
+            "--max-bounces",
+            "16",
+            "--diffuse-bounces",
+            "6",
+            "--glossy-bounces",
+            "8",
+            "--transmission-bounces",
+            "16",
+            "--transparent-bounces",
+            "16",
+            "--caustics-reflective",
+            "on",
+            "--caustics-refractive",
+            "on",
+            "--sample-clamp-indirect",
+            "0.0",
+            "--filter-glossy",
+            "0.0",
+        ],
+        "caustics_off": [
+            "--max-bounces",
+            "10",
+            "--diffuse-bounces",
+            "4",
+            "--glossy-bounces",
+            "4",
+            "--transmission-bounces",
+            "10",
+            "--transparent-bounces",
+            "10",
+            "--caustics-reflective",
+            "off",
+            "--caustics-refractive",
+            "off",
+            "--sample-clamp-indirect",
+            "10.0",
+            "--filter-glossy",
+            "1.0",
+        ],
+        "clamp_indirect_2": [
+            "--max-bounces",
+            "10",
+            "--diffuse-bounces",
+            "4",
+            "--glossy-bounces",
+            "4",
+            "--transmission-bounces",
+            "10",
+            "--transparent-bounces",
+            "10",
+            "--caustics-reflective",
+            "on",
+            "--caustics-refractive",
+            "on",
+            "--sample-clamp-indirect",
+            "2.0",
+            "--filter-glossy",
+            "1.0",
+        ],
+    }
+
+
+def _seed_variance_rows(scene: str, output_root: Path, device: str) -> list[MatrixRun]:
+    rows: list[MatrixRun] = []
+    for samples in SEED_VARIANCE_SPP_LEVELS:
+        denoiser = "off" if samples == 4096 else "on"
+        extra: list[str] = []
+        if denoiser == "on":
+            extra = ["--denoiser-engine", "OPTIX", "--denoiser-passes", "RGB_ALBEDO_NORMAL"]
+        for seed in SEED_VARIANCE_SEEDS:
+            rows.append(
+                MatrixRun(
+                    f"{scene}:seed_variance:spp:{samples}spp:seed{seed}",
+                    _render_args(
+                        scene=scene,
+                        samples=samples,
+                        denoiser=denoiser,
+                        device=device,
+                        frames=1,
+                        warmup_frames=0,
+                        seed=seed,
+                        output_root=output_root,
+                        extra=extra,
+                    ),
+                )
+            )
+    for profile in SEED_VARIANCE_GLASS_PROFILES:
+        profile_args = _glass_profile_args()[profile]
+        for seed in SEED_VARIANCE_SEEDS:
+            rows.append(
+                MatrixRun(
+                    f"{scene}:seed_variance:glass:{profile}:seed{seed}",
+                    _render_args(
+                        scene=scene,
+                        samples=256,
+                        denoiser="on",
+                        device=device,
+                        frames=1,
+                        warmup_frames=0,
+                        seed=seed,
+                        output_root=output_root,
+                        extra=[
+                            "--denoiser-engine",
+                            "OPTIX",
+                            "--denoiser-passes",
+                            "RGB_ALBEDO_NORMAL",
+                            *profile_args,
+                        ],
+                    ),
+                )
+            )
+    return rows
+
+
+def build_matrix(scenes: list[str], output_root: Path, device: str, phase: str = "full") -> list[MatrixRun]:
+    matrix: list[MatrixRun] = []
+    for scene in scenes:
+        if phase == "adaptive_low_spp":
+            for samples in (64, 16, 8):
+                matrix.append(
+                    MatrixRun(
+                        f"{scene}:spp_sweep:{samples}spp",
+                        _render_args(
+                            scene=scene,
+                            samples=samples,
+                            denoiser="on",
+                            device=device,
+                            frames=1,
+                            warmup_frames=0,
+                            seed=2026,
+                            output_root=output_root,
+                            extra=["--denoiser-engine", "OPTIX", "--denoiser-passes", "RGB_ALBEDO_NORMAL"],
+                        ),
+                    )
+                )
+            for samples in (64, 16, 8):
+                for threshold in (0.1, 0.03, 0.01, 0.003):
+                    matrix.append(
+                        MatrixRun(
+                            f"{scene}:adaptive:{samples}spp:{threshold}",
+                            _render_args(
+                                scene=scene,
+                                samples=samples,
+                                denoiser="on",
+                                device=device,
+                                frames=1,
+                                warmup_frames=0,
+                                seed=2026,
+                                output_root=output_root,
+                                extra=[
+                                    "--denoiser-engine",
+                                    "OPTIX",
+                                    "--denoiser-passes",
+                                    "RGB_ALBEDO_NORMAL",
+                                    "--adaptive-sampling",
+                                    "on",
+                                    "--adaptive-threshold",
+                                    str(threshold),
+                                    "--adaptive-min-samples",
+                                    "0",
+                                ],
+                            ),
+                        )
+                    )
+            continue
+
+        if phase == "seed_variance":
+            matrix.extend(_seed_variance_rows(scene, output_root, device))
+            continue
+
+        if phase == "glass_quality":
+            matrix.append(
+                MatrixRun(
+                    f"{scene}:reference:4096spp",
+                    _render_args(
+                        scene=scene,
+                        samples=4096,
+                        denoiser="off",
+                        device=device,
+                        frames=1,
+                        warmup_frames=0,
+                        seed=2026,
+                        output_root=output_root,
+                    ),
+                )
+            )
+            for samples in (8, 16, 64, 256, 1024, 4096):
+                matrix.append(
+                    MatrixRun(
+                        f"{scene}:spp_sweep:{samples}spp",
+                        _render_args(
+                            scene=scene,
+                            samples=samples,
+                            denoiser="on",
+                            device=device,
+                            frames=1,
+                            warmup_frames=0,
+                            seed=2026,
+                            output_root=output_root,
+                            extra=["--denoiser-engine", "OPTIX", "--denoiser-passes", "RGB_ALBEDO_NORMAL"],
+                        ),
+                    )
+                )
+            for samples in (64, 16, 8):
+                for threshold in (0.1, 0.03, 0.01, 0.003):
+                    matrix.append(
+                        MatrixRun(
+                            f"{scene}:adaptive:{samples}spp:{threshold}",
+                            _render_args(
+                                scene=scene,
+                                samples=samples,
+                                denoiser="on",
+                                device=device,
+                                frames=1,
+                                warmup_frames=0,
+                                seed=2026,
+                                output_root=output_root,
+                                extra=[
+                                    "--denoiser-engine",
+                                    "OPTIX",
+                                    "--denoiser-passes",
+                                    "RGB_ALBEDO_NORMAL",
+                                    "--adaptive-sampling",
+                                    "on",
+                                    "--adaptive-threshold",
+                                    str(threshold),
+                                    "--adaptive-min-samples",
+                                    "0",
+                                ],
+                            ),
+                        )
+                    )
+            profiles = {
+                "glass_fast": [
+                    "--max-bounces",
+                    "4",
+                    "--diffuse-bounces",
+                    "2",
+                    "--glossy-bounces",
+                    "2",
+                    "--transmission-bounces",
+                    "4",
+                    "--transparent-bounces",
+                    "4",
+                    "--caustics-reflective",
+                    "off",
+                    "--caustics-refractive",
+                    "off",
+                    "--sample-clamp-indirect",
+                    "2.0",
+                    "--filter-glossy",
+                    "1.0",
+                ],
+                "glass_default": [
+                    "--max-bounces",
+                    "10",
+                    "--diffuse-bounces",
+                    "4",
+                    "--glossy-bounces",
+                    "4",
+                    "--transmission-bounces",
+                    "10",
+                    "--transparent-bounces",
+                    "10",
+                    "--caustics-reflective",
+                    "on",
+                    "--caustics-refractive",
+                    "on",
+                    "--sample-clamp-indirect",
+                    "10.0",
+                    "--filter-glossy",
+                    "1.0",
+                ],
+                "glass_reference": [
+                    "--max-bounces",
+                    "16",
+                    "--diffuse-bounces",
+                    "6",
+                    "--glossy-bounces",
+                    "8",
+                    "--transmission-bounces",
+                    "16",
+                    "--transparent-bounces",
+                    "16",
+                    "--caustics-reflective",
+                    "on",
+                    "--caustics-refractive",
+                    "on",
+                    "--sample-clamp-indirect",
+                    "0.0",
+                    "--filter-glossy",
+                    "0.0",
+                ],
+                "caustics_off": [
+                    "--max-bounces",
+                    "10",
+                    "--diffuse-bounces",
+                    "4",
+                    "--glossy-bounces",
+                    "4",
+                    "--transmission-bounces",
+                    "10",
+                    "--transparent-bounces",
+                    "10",
+                    "--caustics-reflective",
+                    "off",
+                    "--caustics-refractive",
+                    "off",
+                    "--sample-clamp-indirect",
+                    "10.0",
+                    "--filter-glossy",
+                    "1.0",
+                ],
+                "clamp_indirect_2": [
+                    "--max-bounces",
+                    "10",
+                    "--diffuse-bounces",
+                    "4",
+                    "--glossy-bounces",
+                    "4",
+                    "--transmission-bounces",
+                    "10",
+                    "--transparent-bounces",
+                    "10",
+                    "--caustics-reflective",
+                    "on",
+                    "--caustics-refractive",
+                    "on",
+                    "--sample-clamp-indirect",
+                    "2.0",
+                    "--filter-glossy",
+                    "1.0",
+                ],
+            }
+            for profile, profile_args in profiles.items():
+                matrix.append(
+                    MatrixRun(
+                        f"{scene}:glass:{profile}",
+                        _render_args(
+                            scene=scene,
+                            samples=256,
+                            denoiser="on",
+                            device=device,
+                            frames=1,
+                            warmup_frames=0,
+                            seed=2026,
+                            output_root=output_root,
+                            extra=[
+                                "--denoiser-engine",
+                                "OPTIX",
+                                "--denoiser-passes",
+                                "RGB_ALBEDO_NORMAL",
+                                *profile_args,
+                            ],
+                        ),
+                    )
+                )
+            continue
+
+        if phase == "full":
+            for samples in (4096, 8192):
+                matrix.append(
+                    MatrixRun(
+                        f"{scene}:reference:{samples}spp",
+                        _render_args(
+                            scene=scene,
+                            samples=samples,
+                            denoiser="off",
+                            device=device,
+                            frames=1,
+                            warmup_frames=1,
+                            seed=0,
+                            output_root=output_root,
+                        ),
+                    )
+                )
+
+        for samples in (1, 4, 16, 64, 256, 1024, 4096):
+            matrix.append(
+                MatrixRun(
+                    f"{scene}:spp_sweep:{samples}spp",
+                    _render_args(
+                        scene=scene,
+                        samples=samples,
+                        denoiser="on",
+                        device=device,
+                        frames=3,
+                        warmup_frames=1,
+                        seed=0,
+                        output_root=output_root,
+                        extra=["--denoiser-engine", "OPTIX", "--denoiser-passes", "RGB_ALBEDO_NORMAL"],
+                    ),
+                )
+            )
+
+        if phase == "full":
+            matrix.append(
+                MatrixRun(
+                    f"{scene}:denoiser:off",
+                    _render_args(
+                        scene=scene,
+                        samples=64,
+                        denoiser="off",
+                        device=device,
+                        frames=5,
+                        warmup_frames=1,
+                        seed=0,
+                        output_root=output_root,
+                    ),
+                )
+            )
+            for engine in ("AUTOMATIC", "OPENIMAGEDENOISE", "OPTIX"):
+                for passes in ("RGB", "RGB_ALBEDO", "RGB_ALBEDO_NORMAL"):
+                    matrix.append(
+                        MatrixRun(
+                            f"{scene}:denoiser:{engine}:{passes}",
+                            _render_args(
+                                scene=scene,
+                                samples=64,
+                                denoiser="on",
+                                device=device,
+                                frames=5,
+                                warmup_frames=1,
+                                seed=0,
+                                output_root=output_root,
+                                extra=[
+                                    "--denoiser-engine",
+                                    engine,
+                                    "--denoiser-passes",
+                                    passes,
+                                    "--denoising-prefilter",
+                                    "ACCURATE",
+                                    "--denoising-quality",
+                                    "HIGH",
+                                ],
+                            ),
+                        )
+                    )
+
+        for threshold in (0.1, 0.03, 0.01, 0.003, 0.001):
+            matrix.append(
+                MatrixRun(
+                    f"{scene}:adaptive:{threshold}",
+                    _render_args(
+                        scene=scene,
+                        samples=4096,
+                        denoiser="on",
+                        device=device,
+                        frames=5,
+                        warmup_frames=1,
+                        seed=0,
+                        output_root=output_root,
+                        extra=[
+                            "--denoiser-engine",
+                            "OPTIX",
+                            "--denoiser-passes",
+                            "RGB_ALBEDO_NORMAL",
+                            "--adaptive-sampling",
+                            "on",
+                            "--adaptive-threshold",
+                            str(threshold),
+                            "--adaptive-min-samples",
+                            "0",
+                        ],
+                    ),
+                )
+            )
+
+        if scene == "complex_glass_cube_reach":
+            profiles = {
+                "glass_fast": [
+                    "--max-bounces",
+                    "4",
+                    "--diffuse-bounces",
+                    "2",
+                    "--glossy-bounces",
+                    "2",
+                    "--transmission-bounces",
+                    "4",
+                    "--transparent-bounces",
+                    "4",
+                    "--caustics-reflective",
+                    "off",
+                    "--caustics-refractive",
+                    "off",
+                    "--sample-clamp-indirect",
+                    "2.0",
+                    "--filter-glossy",
+                    "1.0",
+                ],
+                "glass_default": [
+                    "--max-bounces",
+                    "10",
+                    "--diffuse-bounces",
+                    "4",
+                    "--glossy-bounces",
+                    "4",
+                    "--transmission-bounces",
+                    "10",
+                    "--transparent-bounces",
+                    "10",
+                    "--caustics-reflective",
+                    "on",
+                    "--caustics-refractive",
+                    "on",
+                    "--sample-clamp-indirect",
+                    "10.0",
+                    "--filter-glossy",
+                    "1.0",
+                ],
+                "glass_reference": [
+                    "--max-bounces",
+                    "16",
+                    "--diffuse-bounces",
+                    "6",
+                    "--glossy-bounces",
+                    "8",
+                    "--transmission-bounces",
+                    "16",
+                    "--transparent-bounces",
+                    "16",
+                    "--caustics-reflective",
+                    "on",
+                    "--caustics-refractive",
+                    "on",
+                    "--sample-clamp-indirect",
+                    "0.0",
+                    "--filter-glossy",
+                    "0.0",
+                ],
+                "caustics_off": [
+                    "--max-bounces",
+                    "10",
+                    "--diffuse-bounces",
+                    "4",
+                    "--glossy-bounces",
+                    "4",
+                    "--transmission-bounces",
+                    "10",
+                    "--transparent-bounces",
+                    "10",
+                    "--caustics-reflective",
+                    "off",
+                    "--caustics-refractive",
+                    "off",
+                    "--sample-clamp-indirect",
+                    "10.0",
+                    "--filter-glossy",
+                    "1.0",
+                ],
+                "clamp_indirect_2": [
+                    "--max-bounces",
+                    "10",
+                    "--diffuse-bounces",
+                    "4",
+                    "--glossy-bounces",
+                    "4",
+                    "--transmission-bounces",
+                    "10",
+                    "--transparent-bounces",
+                    "10",
+                    "--caustics-reflective",
+                    "on",
+                    "--caustics-refractive",
+                    "on",
+                    "--sample-clamp-indirect",
+                    "2.0",
+                    "--filter-glossy",
+                    "1.0",
+                ],
+            }
+            for profile, profile_args in profiles.items():
+                matrix.append(
+                    MatrixRun(
+                        f"{scene}:glass:{profile}",
+                        _render_args(
+                            scene=scene,
+                            samples=256,
+                            denoiser="on",
+                            device=device,
+                            frames=5,
+                            warmup_frames=1,
+                            seed=0,
+                            output_root=output_root,
+                            extra=[
+                                "--denoiser-engine",
+                                "OPTIX",
+                                "--denoiser-passes",
+                                "RGB_ALBEDO_NORMAL",
+                                *profile_args,
+                            ],
+                        ),
+                    )
+                )
+
+        for light_tree in ("on", "off"):
+            for threshold in (0.0, 0.001, 0.01, 0.05):
+                matrix.append(
+                    MatrixRun(
+                        f"{scene}:light:{light_tree}:{threshold}",
+                        _render_args(
+                            scene=scene,
+                            samples=256,
+                            denoiser="on",
+                            device=device,
+                            frames=5,
+                            warmup_frames=1,
+                            seed=0,
+                            output_root=output_root,
+                            extra=[
+                                "--denoiser-engine",
+                                "OPTIX",
+                                "--denoiser-passes",
+                                "RGB_ALBEDO_NORMAL",
+                                "--light-tree",
+                                light_tree,
+                                "--light-threshold",
+                                str(threshold),
+                            ],
+                        ),
+                    )
+                )
+
+        for cameras in (1, 2, 4, 8, 16):
+            matrix.append(
+                MatrixRun(
+                    f"{scene}:multi_camera:{cameras}",
+                    _render_args(
+                        scene=scene,
+                        samples=64,
+                        denoiser="on",
+                        device=device,
+                        camera_count=cameras,
+                        frames=100,
+                        warmup_frames=10,
+                        seed=0,
+                        output_root=output_root,
+                        extra=["--denoiser-engine", "OPTIX", "--denoiser-passes", "RGB_ALBEDO_NORMAL"],
+                    ),
+                )
+            )
+
+        matrix.append(
+            MatrixRun(f"{scene}:stability", _stability_args(scene=scene, device=device, output_root=output_root))
+        )
+
+        for persistent in ("on", "off"):
+            matrix.append(
+                MatrixRun(
+                    f"{scene}:persistent:{persistent}",
+                    _render_args(
+                        scene=scene,
+                        samples=64,
+                        denoiser="on",
+                        device=device,
+                        frames=1000,
+                        warmup_frames=50,
+                        seed=0,
+                        output_root=output_root,
+                        extra=[
+                            "--denoiser-engine",
+                            "OPTIX",
+                            "--denoiser-passes",
+                            "RGB_ALBEDO_NORMAL",
+                            "--persistent-data",
+                            persistent,
+                        ],
+                    ),
+                )
+            )
+    return matrix
+
+
+def _arg_value(args: list[str], name: str) -> str:
+    with_value = f"{name}="
+    for index, arg in enumerate(args):
+        if arg == name and index + 1 < len(args):
+            return args[index + 1]
+        if arg.startswith(with_value):
+            return arg[len(with_value) :]
+    return ""
+
+
+def _latest_child_status(output_root: Path, command: list[str], args: list[str], fallback: str) -> str:
+    scene = _arg_value(args, "--scene")
+    if not scene:
+        return fallback
+    runs_path = output_root / scene / "runs.csv"
+    if not runs_path.exists():
+        return fallback
+
+    command_text = shlex.join(command)
+    with runs_path.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    for row in reversed(rows):
+        if row.get("command") == command_text and row.get("status"):
+            return str(row["status"])
+    return fallback
+
+
+def run_matrix(matrix: list[MatrixRun], output_root: Path) -> int:
+    script = Path(__file__).with_name("blender_render_benchmark.py")
+    log_path = output_root / "matrix_driver.log"
+    csv_path = output_root / "matrix_driver.csv"
+    output_root.mkdir(parents=True, exist_ok=True)
+    csv_exists = csv_path.exists()
+    failures = 0
+    with log_path.open("a", encoding="utf-8") as log_file, csv_path.open("a", newline="", encoding="utf-8") as csv_file:
+        writer = csv.DictWriter(csv_file, fieldnames=["label", "command", "return_code", "elapsed_s", "status"])
+        if not csv_exists:
+            writer.writeheader()
+        for index, run in enumerate(matrix, 1):
+            command = [sys.executable, str(script), *run.args]
+            print(f"[{index}/{len(matrix)}] {run.label}", flush=True)
+            log_file.write(f"\n=== {index}/{len(matrix)} {run.label} ===\n")
+            log_file.write(" ".join(command) + "\n")
+            log_file.flush()
+            start = time.perf_counter()
+            proc = subprocess.run(command, stdout=log_file, stderr=subprocess.STDOUT, text=True, check=False)
+            elapsed_s = time.perf_counter() - start
+            fallback_status = "ok" if proc.returncode == 0 else "failed"
+            status = _latest_child_status(output_root, command, run.args, fallback_status)
+            if proc.returncode != 0 or status == "failed":
+                failures += 1
+            writer.writerow({
+                "label": run.label,
+                "command": " ".join(command),
+                "return_code": proc.returncode,
+                "elapsed_s": f"{elapsed_s:.3f}",
+                "status": status,
+            })
+            csv_file.flush()
+            print(f"[{index}/{len(matrix)}] {run.label}: {status} ({elapsed_s:.1f}s)", flush=True)
+    return 1 if failures else 0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the planned Blender benchmark matrix.")
+    parser.add_argument("--output-root", type=Path, default=DEFAULT_ROOT)
+    parser.add_argument("--device", default="OPTIX")
+    parser.add_argument("--scene", choices=(*SCENES, "all"), default="all")
+    parser.add_argument(
+        "--phase",
+        choices=("full", "practical", "glass_quality", "adaptive_low_spp", "seed_variance"),
+        default="full",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    scenes = list(SCENES if args.scene == "all" else (args.scene,))
+    matrix = build_matrix(scenes, args.output_root, args.device, phase=args.phase)
+    raise SystemExit(run_matrix(matrix, args.output_root))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/rendering/seed_stability_metrics.py
+++ b/scripts/benchmark/rendering/seed_stability_metrics.py
@@ -1,0 +1,41 @@
+"""Seed-variance metric computation. Pure functions where possible; render_std_map writes a PNG."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Sequence
+
+import numpy as np
+
+os.environ.setdefault("OPENCV_IO_ENABLE_OPENEXR", "1")
+import cv2
+
+
+def _load_one(path: Path) -> np.ndarray:
+    if not Path(path).exists():
+        raise FileNotFoundError(f"EXR not found: {path}")
+    arr = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+    if arr is None:
+        raise RuntimeError(f"cv2 failed to read EXR: {path}")
+    if arr.dtype != np.float32:
+        arr = arr.astype(np.float32)
+    if arr.ndim != 3 or arr.shape[-1] not in (3, 4):
+        raise ValueError(f"unexpected EXR shape {arr.shape} for {path}")
+    rgb = arr[..., :3][..., ::-1]
+    return np.ascontiguousarray(rgb, dtype=np.float32)
+
+
+def load_exr_stack(paths: Sequence[Path]) -> np.ndarray:
+    if not paths:
+        raise ValueError("load_exr_stack: empty path list")
+    images: list[np.ndarray] = []
+    reference_shape: tuple[int, ...] | None = None
+    for path in paths:
+        img = _load_one(Path(path))
+        if reference_shape is None:
+            reference_shape = img.shape
+        elif img.shape != reference_shape:
+            raise ValueError(f"shape mismatch: expected {reference_shape}, got {img.shape} from {path}")
+        images.append(img)
+    return np.stack(images, axis=0).astype(np.float32, copy=False)

--- a/scripts/benchmark/rendering/seed_stability_metrics.py
+++ b/scripts/benchmark/rendering/seed_stability_metrics.py
@@ -155,3 +155,74 @@ class MetricRunner:
             a.astype(np.float32), b.astype(np.float32), "HDR", applyMagma=False, computeMeanError=True
         )
         return float(mean_error)
+
+
+def _summarize(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {"mean": 0.0, "std": 0.0, "min": 0.0, "max": 0.0, "n_pairs": 0}
+    arr = np.asarray(values, dtype=np.float64)
+    return {
+        "mean": float(arr.mean()),
+        "std": float(arr.std(ddof=0)),
+        "min": float(arr.min()),
+        "max": float(arr.max()),
+        "n_pairs": int(arr.size),
+    }
+
+
+def _metrics_for_pair(runner: MetricRunner, a: np.ndarray, b: np.ndarray) -> dict[str, float | None]:
+    return {
+        "rmse": runner.rmse(a, b),
+        "mae": runner.mae(a, b),
+        "psnr": runner.psnr(a, b),
+        "lpips": runner.lpips(a, b),
+        "flip": runner.flip(a, b),
+    }
+
+
+_METRIC_NAMES: tuple[str, ...] = ("rmse", "mae", "psnr", "lpips", "flip")
+
+
+def pairwise_metrics(
+    stack: np.ndarray,
+    *,
+    runner: MetricRunner,
+    roi_boxes: dict[str, list[int]] | None,
+    roi_grouping: dict[str, list[str]] | None,
+) -> dict[str, dict[str, dict[str, float]]]:
+    if stack.ndim != 4:
+        raise ValueError(f"pairwise_metrics expects (N, H, W, C); got {stack.shape}")
+    n = stack.shape[0]
+    if n < 2:
+        raise ValueError(f"pairwise_metrics requires N >= 2; got N={n}")
+
+    region_pairs: dict[str, dict[str, list[float]]] = {
+        "global": {m: [] for m in _METRIC_NAMES},
+    }
+    if roi_boxes and roi_grouping:
+        for group in roi_grouping:
+            region_pairs[group] = {m: [] for m in _METRIC_NAMES}
+
+    for i in range(n):
+        for j in range(i + 1, n):
+            a, b = stack[i], stack[j]
+            global_metrics = _metrics_for_pair(runner, a, b)
+            for m in _METRIC_NAMES:
+                v = global_metrics[m]
+                if v is not None:
+                    region_pairs["global"][m].append(v)
+            if roi_boxes and roi_grouping:
+                per_roi: dict[str, dict[str, float | None]] = {
+                    name: _metrics_for_pair(runner, crop(a, box), crop(b, box)) for name, box in roi_boxes.items()
+                }
+                for m in _METRIC_NAMES:
+                    per_roi_scalar = {n_: v[m] for n_, v in per_roi.items() if v[m] is not None}
+                    if not per_roi_scalar:
+                        continue
+                    grouped = group_means(per_roi_scalar, roi_grouping)
+                    for group, value in grouped.items():
+                        region_pairs[group][m].append(value)
+
+    return {
+        region: {m: _summarize(values) for m, values in metrics.items()} for region, metrics in region_pairs.items()
+    }

--- a/scripts/benchmark/rendering/seed_stability_metrics.py
+++ b/scripts/benchmark/rendering/seed_stability_metrics.py
@@ -39,3 +39,119 @@ def load_exr_stack(paths: Sequence[Path]) -> np.ndarray:
             raise ValueError(f"shape mismatch: expected {reference_shape}, got {img.shape} from {path}")
         images.append(img)
     return np.stack(images, axis=0).astype(np.float32, copy=False)
+
+
+def per_pixel_stack_stats(stack: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    if stack.ndim != 4:
+        raise ValueError(f"per_pixel_stack_stats expects (N, H, W, C); got {stack.shape}")
+    if stack.shape[0] < 2:
+        raise ValueError(f"per_pixel_stack_stats requires N >= 2; got N={stack.shape[0]}")
+    mean = stack.mean(axis=0).astype(np.float32, copy=False)
+    std = stack.std(axis=0, ddof=0).astype(np.float32, copy=False)
+    return mean, std
+
+
+def crop(image: np.ndarray, box: list[int]) -> np.ndarray:
+    x0, y0, x1, y1 = (int(v) for v in box)
+    if x1 <= x0 or y1 <= y0:
+        raise ValueError(f"empty crop box {box}")
+    return image[y0:y1, x0:x1, :]
+
+
+def group_means(per_roi: dict[str, float], grouping: dict[str, list[str]]) -> dict[str, float]:
+    out: dict[str, float] = {}
+    for group, names in grouping.items():
+        values = [per_roi[name] for name in names if name in per_roi]
+        if not values:
+            continue
+        out[group] = float(sum(values) / len(values))
+    return out
+
+
+class MetricRunner:
+    """Numerical + perceptual metrics. LPIPS and FLIP can be disabled for cheap tests."""
+
+    def __init__(self, *, enable_lpips: bool, enable_flip: bool):
+        self._enable_lpips = enable_lpips
+        self._enable_flip = enable_flip
+        self._lpips_model = None
+        self._flip_module = None
+        self._device = None
+
+    @classmethod
+    def numerical_only(cls) -> MetricRunner:
+        return cls(enable_lpips=False, enable_flip=False)
+
+    @classmethod
+    def full(cls) -> MetricRunner:
+        return cls(enable_lpips=True, enable_flip=True)
+
+    @staticmethod
+    def rmse(a: np.ndarray, b: np.ndarray) -> float:
+        diff = a - b
+        return float(np.sqrt(np.mean(diff * diff)))
+
+    @staticmethod
+    def mae(a: np.ndarray, b: np.ndarray) -> float:
+        return float(np.mean(np.abs(a - b)))
+
+    @staticmethod
+    def psnr(a: np.ndarray, b: np.ndarray) -> float:
+        a_c = np.clip(a, 0.0, 1.0)
+        b_c = np.clip(b, 0.0, 1.0)
+        mse = float(np.mean((a_c - b_c) ** 2))
+        if mse <= 1e-20:
+            return 99.0
+        return float(10.0 * np.log10(1.0 / mse))
+
+    def _ensure_lpips(self):
+        if self._lpips_model is None and self._enable_lpips:
+            try:
+                import lpips  # type: ignore
+                import torch
+
+                self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+                self._lpips_model = lpips.LPIPS(net="alex", verbose=False).to(self._device).eval()
+            except Exception:
+                self._enable_lpips = False
+                self._lpips_model = None
+        return self._lpips_model
+
+    def lpips(self, a: np.ndarray, b: np.ndarray) -> float | None:
+        if not self._enable_lpips:
+            return None
+        import torch
+
+        model = self._ensure_lpips()
+        if model is None:
+            return None
+        a_clip = np.clip(a, 0.0, 1.0).astype(np.float32)
+        b_clip = np.clip(b, 0.0, 1.0).astype(np.float32)
+        a_t = torch.from_numpy(a_clip).permute(2, 0, 1).unsqueeze(0).to(self._device)
+        b_t = torch.from_numpy(b_clip).permute(2, 0, 1).unsqueeze(0).to(self._device)
+        a_t = a_t * 2.0 - 1.0
+        b_t = b_t * 2.0 - 1.0
+        with torch.no_grad():
+            d = model(a_t, b_t)
+        return float(d.detach().cpu().item())
+
+    def _ensure_flip(self):
+        if self._flip_module is None and self._enable_flip:
+            try:
+                import flip_evaluator  # type: ignore
+
+                self._flip_module = flip_evaluator
+            except Exception:
+                self._flip_module = None
+        return self._flip_module
+
+    def flip(self, a: np.ndarray, b: np.ndarray) -> float | None:
+        if not self._enable_flip:
+            return None
+        module = self._ensure_flip()
+        if module is None:
+            return None
+        _, mean_error, _ = module.evaluate(
+            a.astype(np.float32), b.astype(np.float32), "HDR", applyMagma=False, computeMeanError=True
+        )
+        return float(mean_error)

--- a/scripts/benchmark/rendering/seed_stability_metrics.py
+++ b/scripts/benchmark/rendering/seed_stability_metrics.py
@@ -226,3 +226,40 @@ def pairwise_metrics(
     return {
         region: {m: _summarize(values) for m, values in metrics.items()} for region, metrics in region_pairs.items()
     }
+
+
+def vs_reference_metrics(
+    stack: np.ndarray,
+    reference: np.ndarray,
+    *,
+    runner: MetricRunner,
+    roi_boxes: dict[str, list[int]] | None,
+    roi_grouping: dict[str, list[str]] | None,
+) -> list[dict[str, float | int | None]]:
+    if stack.ndim != 4 or reference.ndim != 3:
+        raise ValueError(f"shape error: stack={stack.shape}, reference={reference.shape}")
+    if stack.shape[1:] != reference.shape:
+        raise ValueError(f"shape mismatch: stack frame {stack.shape[1:]} != reference {reference.shape}")
+    out: list[dict[str, float | int | None]] = []
+    for index in range(stack.shape[0]):
+        seed_img = stack[index]
+        global_metrics = _metrics_for_pair(runner, seed_img, reference)
+        row: dict[str, float | int | None] = {
+            "seed_index": index,
+            **{m: global_metrics[m] for m in _METRIC_NAMES},
+        }
+        if roi_boxes and roi_grouping:
+            per_roi_rmse: dict[str, float] = {}
+            per_roi_psnr: dict[str, float] = {}
+            for name, box in roi_boxes.items():
+                a = crop(seed_img, box)
+                b = crop(reference, box)
+                per_roi_rmse[name] = runner.rmse(a, b)
+                per_roi_psnr[name] = runner.psnr(a, b)
+            grouped_rmse = group_means(per_roi_rmse, roi_grouping)
+            grouped_psnr = group_means(per_roi_psnr, roi_grouping)
+            for group, value in grouped_rmse.items():
+                row[f"{group}_rmse"] = value
+                row[f"{group}_psnr"] = grouped_psnr.get(group, 0.0)
+        out.append(row)
+    return out

--- a/scripts/benchmark/rendering/seed_stability_metrics.py
+++ b/scripts/benchmark/rendering/seed_stability_metrics.py
@@ -263,3 +263,26 @@ def vs_reference_metrics(
                 row[f"{group}_psnr"] = grouped_psnr.get(group, 0.0)
         out.append(row)
     return out
+
+
+def render_std_map(std_image: np.ndarray, out_path: Path, *, color_scale: float | None) -> float:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    if std_image.ndim != 3 or std_image.shape[-1] != 3:
+        raise ValueError(f"render_std_map expects (H, W, 3); got {std_image.shape}")
+    intensity = std_image.mean(axis=-1)
+    scale = color_scale if color_scale is not None else float(np.max(intensity))
+    if scale <= 0:
+        scale = 1.0
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(6.4, 3.6), dpi=120)
+    im = ax.imshow(intensity, cmap="magma", vmin=0.0, vmax=scale)
+    ax.set_axis_off()
+    fig.colorbar(im, ax=ax, label="linear-EXR std")
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+    return scale

--- a/scripts/benchmark/rendering/write_blender_analysis.py
+++ b/scripts/benchmark/rendering/write_blender_analysis.py
@@ -1,0 +1,2009 @@
+#!/usr/bin/env python3
+"""Write interpretation-focused Blender benchmark analysis and figures."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import statistics
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable
+
+from scripts.benchmark.rendering import seed_stability_metrics as _seed_metrics
+from scripts.benchmark.rendering import write_seed_stability_section as _seed_section
+
+ROOT_DEFAULT = Path("outputs/rendering_benchmark/blender_2026-05-09_glass_only")
+SCENES = ("complex_glass_cube_reach",)
+SCENE_TITLES = {
+    "complex_glass_cube_reach": "Complex glass cube reach",
+}
+CONTACT_SHEET_LABEL_HEIGHT = 88
+CONTACT_SHEET_FONT_SIZE = 32
+ROI_GROUPS = {
+    "complex_glass_cube_reach": {
+        "glass": {
+            "left_display_case": [45, 325, 430, 615],
+            "center_bottle": [620, 225, 720, 505],
+            "front_hurricane_glass": [600, 420, 775, 695],
+            "rear_tumbler": [880, 200, 985, 295],
+        },
+        "non_glass": {
+            "robot_left_arm": [0, 40, 470, 430],
+            "robot_right_arm": [300, 50, 720, 230],
+            "target_cube": [545, 280, 595, 330],
+            "table_plain_region": [770, 320, 1110, 520],
+        },
+    },
+}
+ROI_BOXES = {
+    scene: {name: box for group in groups.values() for name, box in group.items()}
+    for scene, groups in ROI_GROUPS.items()
+}
+
+
+@dataclass(frozen=True)
+class QualityMetric:
+    key: str
+    label: str
+    ylabel: str
+    log_y: bool = False
+
+
+QUALITY_METRICS = (
+    QualityMetric("rmse", "RMSE", "Linear EXR RMSE vs reference", True),
+    QualityMetric("psnr_clip", "PSNR", "Clipped PSNR (dB)"),
+    QualityMetric("lpips_alex", "LPIPS Alex", "LPIPS Alex vs reference"),
+    QualityMetric("flip_hdr", "HDR FLIP", "HDR FLIP vs reference"),
+)
+
+
+@dataclass(frozen=True)
+class TimedRun:
+    row: dict[str, str]
+    mean_ms: float | None
+    p95_ms: float | None
+    frame_count: int
+    rmse: float | None = None
+    mae: float | None = None
+    psnr_clip: float | None = None
+    lpips_alex: float | None = None
+    flip_hdr: float | None = None
+    roi_rmse_max: float | None = None
+    glass_rmse: float | None = None
+    glass_psnr_clip: float | None = None
+    glass_lpips_alex: float | None = None
+    glass_flip_hdr: float | None = None
+    non_glass_rmse: float | None = None
+    non_glass_psnr_clip: float | None = None
+    non_glass_lpips_alex: float | None = None
+    non_glass_flip_hdr: float | None = None
+    quality_error: str = ""
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+def write_csv(path: Path, header: list[str], rows: Iterable[dict[str, Any]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=header, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({key: row.get(key, "") for key in header})
+
+
+def latest_successful_runs(rows: list[dict[str, str]], key_fields: tuple[str, ...]) -> list[dict[str, str]]:
+    latest: dict[tuple[str, ...], dict[str, str]] = {}
+    for row in rows:
+        if row.get("status") != "ok":
+            continue
+        key = tuple(row.get(field, "") for field in key_fields)
+        latest[key] = row
+    return list(latest.values())
+
+
+def latest_rows_by_run_id(rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    latest: dict[str, dict[str, str]] = {}
+    anonymous = []
+    for row in rows:
+        run_id = row.get("run_id", "")
+        if not run_id:
+            anonymous.append(row)
+            continue
+        latest[run_id] = row
+    return list(latest.values()) + anonymous
+
+
+def _float_values(rows: list[dict[str, str]], run_id: str) -> list[float]:
+    latest_by_frame: dict[tuple[str, str], tuple[int, float]] = {}
+    for index, row in enumerate(rows):
+        if row.get("run_id") != run_id or row.get("status") != "ok":
+            continue
+        try:
+            value = float(row.get("elapsed_ms", ""))
+        except ValueError:
+            continue
+        frame = row.get("frame", "")
+        camera = row.get("camera", "")
+        key = (frame, camera) if frame or camera else (str(index), "")
+        latest_by_frame[key] = (index, value)
+    return [value for _, value in sorted(latest_by_frame.values(), key=lambda pair: pair[0])]
+
+
+def mean_frame_ms(frame_time_path: Path, run_id: str) -> float | None:
+    values = _float_values(read_csv(frame_time_path), run_id)
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    index = (len(ordered) - 1) * pct / 100.0
+    lo = math.floor(index)
+    hi = math.ceil(index)
+    if lo == hi:
+        return ordered[int(index)]
+    return ordered[lo] * (hi - index) + ordered[hi] * (index - lo)
+
+
+def _timed_run(row: dict[str, str], frame_rows: list[dict[str, str]]) -> TimedRun:
+    values = _float_values(frame_rows, row.get("run_id", ""))
+    mean_ms = sum(values) / len(values) if values else None
+    p95_ms = percentile(values, 95.0)
+    return TimedRun(row=row, mean_ms=mean_ms, p95_ms=p95_ms, frame_count=len(values))
+
+
+class QualityComputer:
+    def __init__(self) -> None:
+        self._cache: dict[str, Any] = {}
+        self._metric_cache: dict[tuple[str, str, tuple[int, ...]], tuple[dict[str, float], str]] = {}
+        self._lpips_model: Any | None = None
+        self._lpips_error = ""
+        self._flip_module: Any | None = None
+        self._flip_error = ""
+        self.error = ""
+
+    def _load(self, path: str) -> Any:
+        if path in self._cache:
+            return self._cache[path]
+        os.environ.setdefault("OPENCV_IO_ENABLE_OPENEXR", "1")
+        import cv2  # type: ignore
+        import numpy as np
+
+        image = cv2.imread(path, cv2.IMREAD_UNCHANGED)
+        if image is None:
+            raise RuntimeError(f"could not read EXR: {path}")
+        image = image.astype("float32")
+        if image.ndim == 3 and image.shape[2] >= 3:
+            image = image[:, :, :3][:, :, ::-1]
+        elif image.ndim == 2:
+            image = np.repeat(image[:, :, None], 3, axis=2)
+        self._cache[path] = image
+        return image
+
+    def _lpips(self) -> Any | None:
+        if self._lpips_model is not None or self._lpips_error:
+            return self._lpips_model
+        try:
+            os.environ.setdefault("TORCH_HOME", "/tmp/torch_home")
+            import lpips  # type: ignore
+
+            self._lpips_model = lpips.LPIPS(net="alex", verbose=False)
+            self._lpips_model.eval()
+        except Exception as exc:  # pragma: no cover - depends on local model cache/network
+            self._lpips_error = repr(exc)
+        return self._lpips_model
+
+    def _flip(self) -> Any | None:
+        if self._flip_module is not None or self._flip_error:
+            return self._flip_module
+        try:
+            import flip_evaluator  # type: ignore
+
+            self._flip_module = flip_evaluator
+        except Exception as exc:  # pragma: no cover - depends on local optional package
+            self._flip_error = repr(exc)
+        return self._flip_module
+
+    def _crop(self, image: Any, box: list[int] | None) -> Any:
+        if not box:
+            return image
+        x0, y0, x1, y1 = [int(value) for value in box]
+        return image[y0:y1, x0:x1, :]
+
+    def _lpips_metric(self, reference: Any, test: Any) -> tuple[float | None, str]:
+        model = self._lpips()
+        if model is None:
+            return None, f"LPIPS unavailable: {self._lpips_error}"
+        try:
+            import numpy as np
+            import torch
+
+            ref = np.clip(reference, 0.0, 1.0)
+            tst = np.clip(test, 0.0, 1.0)
+            ref_tensor = torch.from_numpy(ref).permute(2, 0, 1).unsqueeze(0).float() * 2.0 - 1.0
+            tst_tensor = torch.from_numpy(tst).permute(2, 0, 1).unsqueeze(0).float() * 2.0 - 1.0
+            with torch.no_grad():
+                return float(model(ref_tensor, tst_tensor).item()), ""
+        except Exception as exc:  # pragma: no cover - depends on local torch/lpips stack
+            return None, repr(exc)
+
+    def _flip_metric(self, reference: Any, test: Any) -> tuple[float | None, str]:
+        module = self._flip()
+        if module is None:
+            return None, f"FLIP unavailable: {self._flip_error}"
+        try:
+            _errormap, mean_error, _params = module.evaluate(
+                reference,
+                test,
+                "HDR",
+                inputsRGB=True,
+                applyMagma=False,
+                computeMeanError=True,
+            )
+            return float(mean_error), ""
+        except Exception as exc:  # pragma: no cover - depends on local flip stack
+            return None, repr(exc)
+
+    def metrics(self, reference: str, test: str, box: list[int] | None = None) -> tuple[dict[str, float], str]:
+        if not reference or not test:
+            return {}, "missing reference or test path"
+        if not Path(reference).exists() or not Path(test).exists():
+            return {}, "missing reference or test EXR"
+        key = (reference, test, tuple(box or ()))
+        if key in self._metric_cache:
+            return self._metric_cache[key]
+        try:
+            import numpy as np
+
+            ref = self._load(reference)
+            tst = self._load(test)
+            if ref.shape != tst.shape:
+                return {}, f"shape mismatch: reference={ref.shape}, test={tst.shape}"
+            ref = self._crop(ref, box)
+            tst = self._crop(tst, box)
+            diff = tst - ref
+            mse = float(np.mean(diff * diff))
+            rmse = math.sqrt(max(mse, 0.0))
+            mae = float(np.mean(np.abs(diff)))
+            clipped = np.clip(tst, 0.0, 1.0) - np.clip(ref, 0.0, 1.0)
+            clipped_mse = float(np.mean(clipped * clipped))
+            psnr = 99.0 if clipped_mse <= 1e-12 else 20.0 * math.log10(1.0 / math.sqrt(clipped_mse))
+            result = {"rmse": rmse, "mae": mae, "psnr_clip": psnr}
+            errors = []
+            lpips_value, lpips_error = self._lpips_metric(ref, tst)
+            if lpips_value is not None:
+                result["lpips_alex"] = lpips_value
+            elif lpips_error:
+                errors.append(lpips_error)
+            flip_value, flip_error = self._flip_metric(ref, tst)
+            if flip_value is not None:
+                result["flip_hdr"] = flip_value
+            elif flip_error:
+                errors.append(flip_error)
+            response = (result, "; ".join(dict.fromkeys(errors)))
+            self._metric_cache[key] = response
+            return response
+        except Exception as exc:  # pragma: no cover - depends on local EXR stack
+            return {}, repr(exc)
+
+
+def _reference_for_scene(root: Path, scene: str) -> str:
+    path = root / scene / "reference" / "blender_4096spp_denoise_off.exr"
+    return str(path) if path.exists() else ""
+
+
+def render_preview_relpath(scene: str) -> Path:
+    return Path(scene) / "analysis" / "render_result.png"
+
+
+def write_render_preview(root: Path, scene: str) -> Path | None:
+    target = root / render_preview_relpath(scene)
+    curated_exr = root / scene / "analysis" / "render_result_source.exr"
+    source = curated_exr if curated_exr.exists() else Path(_reference_for_scene(root, scene))
+    if not source.exists():
+        return None
+    return write_exr_preview(source, target)
+
+
+def write_exr_preview(source: Path, target: Path) -> Path | None:
+    os.environ.setdefault("OPENCV_IO_ENABLE_OPENEXR", "1")
+    import cv2  # type: ignore
+    import numpy as np
+
+    image = cv2.imread(str(source), cv2.IMREAD_UNCHANGED)
+    if image is None:
+        return None
+    image = image.astype("float32")
+    if image.ndim == 2:
+        image = np.repeat(image[:, :, None], 3, axis=2)
+    elif image.ndim == 3 and image.shape[2] >= 3:
+        image = image[:, :, :3][:, :, ::-1]
+    image = np.nan_to_num(image, nan=0.0, posinf=0.0, neginf=0.0)
+    image = np.maximum(image, 0.0)
+
+    finite_positive = image[np.isfinite(image) & (image > 0.0)]
+    white = float(np.percentile(finite_positive, 99.5)) if finite_positive.size else 1.0
+    if white <= 1e-6:
+        white = 1.0
+    preview = np.clip(image / white, 0.0, 1.0)
+    preview = np.power(preview, 1.0 / 2.2)
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    preview_bgr = (preview[:, :, ::-1] * 255.0 + 0.5).astype("uint8")
+    cv2.imwrite(str(target), preview_bgr)
+    return target
+
+
+def _load_rgb_image(path: Path) -> Any | None:
+    os.environ.setdefault("OPENCV_IO_ENABLE_OPENEXR", "1")
+    import cv2  # type: ignore
+    import numpy as np
+
+    image = cv2.imread(str(path), cv2.IMREAD_UNCHANGED)
+    if image is None:
+        return None
+    image = image.astype("float32")
+    if image.ndim == 2:
+        image = np.repeat(image[:, :, None], 3, axis=2)
+    elif image.ndim == 3 and image.shape[2] >= 3:
+        image = image[:, :, :3][:, :, ::-1]
+    return np.nan_to_num(image, nan=0.0, posinf=0.0, neginf=0.0)
+
+
+def _difference_map(reference: Path, source: Path) -> Any | None:
+    import numpy as np
+
+    ref = _load_rgb_image(reference)
+    test = _load_rgb_image(source)
+    if ref is None or test is None or ref.shape != test.shape:
+        return None
+
+    return np.mean(np.abs(test - ref), axis=2)
+
+
+def _difference_scale(reference: Path, sources: list[Path]) -> float:
+    import numpy as np
+
+    values = []
+    for source in sources:
+        diff = _difference_map(reference, source)
+        if diff is None:
+            continue
+        positive = diff[np.isfinite(diff) & (diff > 0.0)]
+        if positive.size:
+            values.append(positive)
+    if not values:
+        return 1.0
+    scale = float(np.percentile(np.concatenate(values), 99.5))
+    if scale <= 1e-8:
+        return 1.0
+    return scale
+
+
+def write_difference_preview(reference: Path, source: Path, target: Path, *, scale: float | None = None) -> Path | None:
+    import cv2  # type: ignore
+    import numpy as np
+
+    diff = _difference_map(reference, source)
+    if diff is None:
+        return None
+
+    diff_scale = scale if scale is not None and scale > 1e-8 else _difference_scale(reference, [source])
+    normalized = np.clip(diff / diff_scale, 0.0, 1.0)
+    heat = cv2.applyColorMap((normalized * 255.0 + 0.5).astype("uint8"), cv2.COLORMAP_INFERNO)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(str(target), heat)
+    return target
+
+
+def _safe_label(row: dict[str, str]) -> str:
+    for field in ("profile", "adaptive_threshold", "samples"):
+        value = row.get(field, "")
+        if value:
+            return str(value).replace(".", "p")
+    return row.get("run_id", "run")
+
+
+def _contact_sheet_font():
+    from PIL import ImageFont
+
+    for font_path in (
+        "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+        "/usr/share/fonts/truetype/liberation2/LiberationSans-Regular.ttf",
+    ):
+        if Path(font_path).exists():
+            return ImageFont.truetype(font_path, CONTACT_SHEET_FONT_SIZE)
+    return ImageFont.load_default()
+
+
+def _write_contact_sheet(paths: list[Path], labels: list[str], target: Path) -> None:
+    if not paths:
+        return
+    try:
+        from PIL import Image, ImageDraw
+
+        panels = [Image.open(path).convert("RGB") for path in paths]
+        panel_width = max(image.width for image in panels)
+        panel_height = max(image.height for image in panels)
+        tile_height = panel_height + CONTACT_SHEET_LABEL_HEIGHT
+        columns = min(3, len(panels))
+        rows = math.ceil(len(panels) / columns)
+        sheet = Image.new("RGB", (columns * panel_width, rows * tile_height), "white")
+        draw = ImageDraw.Draw(sheet)
+        font = _contact_sheet_font()
+        for index, panel in enumerate(panels):
+            x = (index % columns) * panel_width
+            y = (index // columns) * tile_height
+            sheet.paste(panel, (x, y))
+            draw.text((x + 18, y + panel_height + 20), labels[index][:96], fill="black", font=font)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        sheet.save(target)
+    except Exception:
+        return
+
+
+def write_comparison_previews(root: Path, analysis: dict[str, Any]) -> None:
+    scene = analysis["scene"]
+    out_dir = root / scene / "analysis" / "previews"
+    reference_text = analysis.get("reference", "")
+    reference = Path(reference_text) if reference_text else None
+    groups = {
+        "spp": analysis["spp"],
+        "adaptive": analysis["adaptive"],
+        "glass": analysis["glass"],
+    }
+    for group, items in groups.items():
+        paths = []
+        labels = []
+        source_paths: list[Path] = []
+        for item in items:
+            source = item.row.get("output_path", "")
+            source_path = Path(source) if source else None
+            if source_path is None or not source_path.exists():
+                continue
+            label = _safe_label(item.row)
+            if group == "spp":
+                label = f"{item.row.get('samples')} spp"
+            elif group == "adaptive":
+                label = f"{item.row.get('samples')} spp, adaptive {item.row.get('adaptive_threshold')}"
+            elif group == "glass":
+                label = item.row.get("profile", "profile")
+            target = out_dir / group / f"{label.replace(' ', '_').replace('.', 'p')}.png"
+            if write_exr_preview(source_path, target) is not None:
+                paths.append(target)
+                labels.append(label)
+                source_paths.append(source_path)
+        _write_contact_sheet(paths, labels, out_dir / f"{group}_contact_sheet.png")
+        diff_paths = []
+        diff_labels = []
+        if reference is not None and reference.exists() and source_paths:
+            scale = _difference_scale(reference, source_paths)
+            for source_path, preview_path, label in zip(source_paths, paths, labels, strict=False):
+                diff_target = out_dir / f"{group}_difference" / preview_path.name
+                if write_difference_preview(reference, source_path, diff_target, scale=scale) is not None:
+                    diff_paths.append(diff_target)
+                    diff_labels.append(f"{label} diff vs 4096 spp denoiser off")
+        _write_contact_sheet(diff_paths, diff_labels, out_dir / f"{group}_difference_contact_sheet.png")
+
+
+def _attach_quality(
+    timed: list[TimedRun],
+    scene: str,
+    reference: str,
+    boxes: dict[str, list[int]],
+    quality: QualityComputer,
+) -> list[TimedRun]:
+    enriched = []
+    for item in timed:
+        output = item.row.get("output_path", "")
+        metrics, error = quality.metrics(reference, output)
+        roi_values = []
+        for box in boxes.values():
+            roi_metrics, roi_error = quality.metrics(reference, output, box)
+            if roi_error:
+                error = error or roi_error
+                continue
+            roi_values.append(roi_metrics["rmse"])
+        glass_metrics, glass_error = _group_metrics(scene, "glass", reference, output, quality)
+        non_glass_metrics, non_glass_error = _group_metrics(scene, "non_glass", reference, output, quality)
+        error = error or glass_error or non_glass_error
+        enriched.append(
+            TimedRun(
+                row=item.row,
+                mean_ms=item.mean_ms,
+                p95_ms=item.p95_ms,
+                frame_count=item.frame_count,
+                rmse=metrics.get("rmse"),
+                mae=metrics.get("mae"),
+                psnr_clip=metrics.get("psnr_clip"),
+                lpips_alex=metrics.get("lpips_alex"),
+                flip_hdr=metrics.get("flip_hdr"),
+                roi_rmse_max=max(roi_values) if roi_values else None,
+                glass_rmse=glass_metrics.get("rmse"),
+                glass_psnr_clip=glass_metrics.get("psnr_clip"),
+                glass_lpips_alex=glass_metrics.get("lpips_alex"),
+                glass_flip_hdr=glass_metrics.get("flip_hdr"),
+                non_glass_rmse=non_glass_metrics.get("rmse"),
+                non_glass_psnr_clip=non_glass_metrics.get("psnr_clip"),
+                non_glass_lpips_alex=non_glass_metrics.get("lpips_alex"),
+                non_glass_flip_hdr=non_glass_metrics.get("flip_hdr"),
+                quality_error=error,
+            )
+        )
+    return enriched
+
+
+def _mean_metric(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def json_box(box: list[int]) -> str:
+    return "[" + ", ".join(str(int(value)) for value in box) + "]"
+
+
+def _group_metrics(
+    scene: str,
+    group: str,
+    reference: str,
+    output: str,
+    quality: QualityComputer,
+) -> tuple[dict[str, float], str]:
+    collected: dict[str, list[float]] = defaultdict(list)
+    errors = []
+    for box in ROI_GROUPS.get(scene, {}).get(group, {}).values():
+        metrics, error = quality.metrics(reference, output, box)
+        if error:
+            errors.append(error)
+        for key, value in metrics.items():
+            collected[key].append(float(value))
+    return (
+        {key: value for key, values in collected.items() if (value := _mean_metric(values)) is not None},
+        "; ".join(dict.fromkeys(errors)),
+    )
+
+
+def roi_detail_rows(
+    scene: str,
+    runs: list[dict[str, str]],
+    *,
+    reference: str,
+    quality: QualityComputer,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for run in runs:
+        if run.get("status") != "ok":
+            continue
+        output = run.get("output_path", "")
+        for group, group_boxes in ROI_GROUPS.get(scene, {}).items():
+            for roi_name, box in group_boxes.items():
+                metrics, error = quality.metrics(reference, output, box)
+                rows.append({
+                    "scene": scene,
+                    "kind": run.get("kind", ""),
+                    "run_id": run.get("run_id", ""),
+                    "samples": run.get("samples", ""),
+                    "profile": run.get("profile", ""),
+                    "adaptive_threshold": run.get("adaptive_threshold", ""),
+                    "roi_group": group,
+                    "roi_name": roi_name,
+                    "box": json_box(box),
+                    "rmse_linear": fmt(metrics.get("rmse"), 8),
+                    "mae_linear": fmt(metrics.get("mae"), 8),
+                    "psnr_clip_db": fmt(metrics.get("psnr_clip"), 3),
+                    "lpips_alex": fmt(metrics.get("lpips_alex"), 6),
+                    "flip_hdr": fmt(metrics.get("flip_hdr"), 6),
+                    "metric_error": error,
+                })
+    return rows
+
+
+def region_summary_rows(
+    scene: str, runs: list[dict[str, str]], *, reference: str, quality: QualityComputer
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for run in runs:
+        if run.get("status") != "ok":
+            continue
+        output = run.get("output_path", "")
+        for group in ("glass", "non_glass"):
+            metrics, error = _group_metrics(scene, group, reference, output, quality)
+            rows.append({
+                "scene": scene,
+                "kind": run.get("kind", ""),
+                "run_id": run.get("run_id", ""),
+                "samples": run.get("samples", ""),
+                "profile": run.get("profile", ""),
+                "adaptive_threshold": run.get("adaptive_threshold", ""),
+                "roi_group": group,
+                "rmse_linear": fmt(metrics.get("rmse"), 8),
+                "mae_linear": fmt(metrics.get("mae"), 8),
+                "psnr_clip_db": fmt(metrics.get("psnr_clip"), 3),
+                "lpips_alex": fmt(metrics.get("lpips_alex"), 6),
+                "flip_hdr": fmt(metrics.get("flip_hdr"), 6),
+                "metric_error": error,
+            })
+    return rows
+
+
+def _ok_runs_by_kind(root: Path, scene: str, kind: str) -> list[dict[str, str]]:
+    rows = latest_rows_by_run_id(read_csv(root / scene / "runs.csv"))
+    return [row for row in rows if row.get("status") == "ok" and row.get("kind") == kind]
+
+
+def _scene_timed_runs(root: Path, scene: str, kind: str) -> list[TimedRun]:
+    frame_rows = read_csv(root / scene / "overhead" / "frame_time.csv")
+    return [_timed_run(row, frame_rows) for row in _ok_runs_by_kind(root, scene, kind)]
+
+
+def scene_analysis(root: Path, scene: str) -> dict[str, Any]:
+    all_rows = read_csv(root / scene / "runs.csv")
+    rows = [
+        row
+        for row in latest_rows_by_run_id(all_rows)
+        if row.get("kind") != "adaptive_sampling" or row.get("samples") in {"8", "16", "64"}
+    ]
+    quality = QualityComputer()
+    reference = _reference_for_scene(root, scene)
+    boxes = ROI_BOXES[scene]
+
+    spp_candidates = [
+        row
+        for row in rows
+        if row.get("status") == "ok"
+        and row.get("kind") == "spp_sweep"
+        and row.get("camera_count") == "1"
+        and row.get("denoiser") in {"on", "off"}
+    ]
+    spp_rows = latest_successful_runs(spp_candidates, ("samples", "denoiser", "denoiser_engine"))
+    frame_rows = read_csv(root / scene / "overhead" / "frame_time.csv")
+    spp = _attach_quality([_timed_run(row, frame_rows) for row in spp_rows], scene, reference, boxes, quality)
+    spp.sort(key=lambda item: (int(item.row.get("samples", "0")), item.row.get("denoiser", "")))
+
+    reference_rows = _attach_quality(
+        [_timed_run(row, frame_rows) for row in _ok_runs_by_kind(root, scene, "reference")],
+        scene,
+        reference,
+        boxes,
+        quality,
+    )
+    reference_rows.sort(key=lambda item: int(item.row.get("samples", "0")))
+
+    multi = _scene_timed_runs(root, scene, "multi_camera")
+    multi.sort(key=lambda item: int(item.row.get("camera_count", "0")))
+    denoiser = _attach_quality(_scene_timed_runs(root, scene, "denoiser_matrix"), scene, reference, boxes, quality)
+    adaptive = _attach_quality(
+        [
+            item
+            for item in _scene_timed_runs(root, scene, "adaptive_sampling")
+            if item.row.get("samples") in {"8", "16", "64"}
+        ],
+        scene,
+        reference,
+        boxes,
+        quality,
+    )
+    light = _attach_quality(_scene_timed_runs(root, scene, "light_sampling"), scene, reference, boxes, quality)
+    glass = _attach_quality(_scene_timed_runs(root, scene, "glass_light_paths"), scene, reference, boxes, quality)
+    stability = _scene_timed_runs(root, scene, "stability")
+    included_run_ids = {row.get("run_id", "") for row in rows if row.get("run_id")}
+    vram = [
+        row
+        for row in read_csv(root / scene / "overhead" / "vram_breakdown.csv")
+        if not row.get("run_id") or row.get("run_id") in included_run_ids
+    ]
+    roi_source_runs = {
+        item.row.get("run_id", ""): item.row
+        for collection in (spp, reference_rows, adaptive, glass)
+        for item in collection
+        if item.row.get("run_id")
+    }
+    roi_detail = roi_detail_rows(scene, list(roi_source_runs.values()), reference=reference, quality=quality)
+    region_summary = region_summary_rows(scene, list(roi_source_runs.values()), reference=reference, quality=quality)
+
+    return {
+        "scene": scene,
+        "runs": rows,
+        "status_counts": Counter(row.get("status", "") for row in rows),
+        "kind_counts": Counter(row.get("kind", "") for row in rows if row.get("status") == "ok"),
+        "reference": reference,
+        "spp": spp,
+        "reference_rows": reference_rows,
+        "multi": multi,
+        "denoiser": denoiser,
+        "adaptive": adaptive,
+        "light": light,
+        "glass": glass,
+        "stability": stability,
+        "vram": vram,
+        "roi_detail": roi_detail,
+        "region_summary": region_summary,
+    }
+
+
+def fmt(value: float | None, digits: int = 2) -> str:
+    if value is None:
+        return ""
+    return f"{value:.{digits}f}"
+
+
+def fmt_ms(value: float | None) -> str:
+    if value is None:
+        return ""
+    if value >= 1000.0:
+        return f"{value / 1000.0:.2f} s"
+    return f"{value:.0f} ms"
+
+
+def markdown_table(headers: list[str], rows: list[list[str]]) -> str:
+    lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join("---" for _ in headers) + " |"]
+    lines.extend("| " + " | ".join(row) + " |" for row in rows)
+    return "\n".join(lines)
+
+
+def timed_rows_for_csv(scene: str, items: list[TimedRun]) -> list[dict[str, Any]]:
+    rows = []
+    for item in items:
+        row = item.row
+        rows.append({
+            "scene": scene,
+            "kind": row.get("kind", ""),
+            "run_id": row.get("run_id", ""),
+            "samples": row.get("samples", ""),
+            "denoiser": row.get("denoiser", ""),
+            "denoiser_engine": row.get("denoiser_engine", ""),
+            "camera_count": row.get("camera_count", ""),
+            "frames": row.get("frames", ""),
+            "profile": row.get("profile", ""),
+            "adaptive_threshold": row.get("adaptive_threshold", ""),
+            "light_tree": row.get("light_tree", ""),
+            "light_threshold": row.get("light_threshold", ""),
+            "mean_ms": fmt(item.mean_ms, 3),
+            "p95_ms": fmt(item.p95_ms, 3),
+            "frame_count": item.frame_count,
+            "rmse_linear": fmt(item.rmse, 8),
+            "mae_linear": fmt(item.mae, 8),
+            "psnr_clip_db": fmt(item.psnr_clip, 3),
+            "lpips_alex": fmt(item.lpips_alex, 6),
+            "flip_hdr": fmt(item.flip_hdr, 6),
+            "roi_rmse_max": fmt(item.roi_rmse_max, 8),
+            "glass_rmse_linear": fmt(item.glass_rmse, 8),
+            "glass_psnr_clip_db": fmt(item.glass_psnr_clip, 3),
+            "glass_lpips_alex": fmt(item.glass_lpips_alex, 6),
+            "glass_flip_hdr": fmt(item.glass_flip_hdr, 6),
+            "non_glass_rmse_linear": fmt(item.non_glass_rmse, 8),
+            "non_glass_psnr_clip_db": fmt(item.non_glass_psnr_clip, 3),
+            "non_glass_lpips_alex": fmt(item.non_glass_lpips_alex, 6),
+            "non_glass_flip_hdr": fmt(item.non_glass_flip_hdr, 6),
+            "quality_error": item.quality_error,
+        })
+    return rows
+
+
+def write_analysis_csvs(root: Path, analyses: dict[str, dict[str, Any]]) -> None:
+    header = [
+        "scene",
+        "kind",
+        "run_id",
+        "samples",
+        "denoiser",
+        "denoiser_engine",
+        "camera_count",
+        "frames",
+        "profile",
+        "adaptive_threshold",
+        "light_tree",
+        "light_threshold",
+        "mean_ms",
+        "p95_ms",
+        "frame_count",
+        "rmse_linear",
+        "mae_linear",
+        "psnr_clip_db",
+        "lpips_alex",
+        "flip_hdr",
+        "roi_rmse_max",
+        "glass_rmse_linear",
+        "glass_psnr_clip_db",
+        "glass_lpips_alex",
+        "glass_flip_hdr",
+        "non_glass_rmse_linear",
+        "non_glass_psnr_clip_db",
+        "non_glass_lpips_alex",
+        "non_glass_flip_hdr",
+        "quality_error",
+    ]
+    roi_header = [
+        "scene",
+        "kind",
+        "run_id",
+        "samples",
+        "profile",
+        "adaptive_threshold",
+        "roi_group",
+        "roi_name",
+        "box",
+        "rmse_linear",
+        "mae_linear",
+        "psnr_clip_db",
+        "lpips_alex",
+        "flip_hdr",
+        "metric_error",
+    ]
+    region_header = [
+        "scene",
+        "kind",
+        "run_id",
+        "samples",
+        "profile",
+        "adaptive_threshold",
+        "roi_group",
+        "rmse_linear",
+        "mae_linear",
+        "psnr_clip_db",
+        "lpips_alex",
+        "flip_hdr",
+        "metric_error",
+    ]
+    for scene, analysis in analyses.items():
+        rows = []
+        for key in ("spp", "reference_rows", "adaptive", "glass"):
+            rows.extend(timed_rows_for_csv(scene, analysis[key]))
+        write_csv(root / scene / "analysis" / "analysis_metrics.csv", header, rows)
+        write_csv(root / scene / "analysis" / "roi_quality_detailed.csv", roi_header, analysis["roi_detail"])
+        write_csv(root / scene / "analysis" / "region_quality_summary.csv", region_header, analysis["region_summary"])
+
+
+def _setup_matplotlib():
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    plt.rcParams.update({
+        "axes.grid": True,
+        "grid.alpha": 0.25,
+        "figure.dpi": 140,
+        "savefig.dpi": 160,
+        "font.size": 9,
+    })
+    return plt
+
+
+def _save_no_data(path: Path, title: str, message: str) -> None:
+    plt = _setup_matplotlib()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(7.2, 4.4))
+    ax.text(0.5, 0.55, title, ha="center", va="center", fontsize=13, weight="bold")
+    ax.text(0.5, 0.42, message, ha="center", va="center", wrap=True)
+    ax.set_axis_off()
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def _positive(values: Iterable[float | None]) -> list[float]:
+    return [float(value) for value in values if value is not None and value > 0.0]
+
+
+def _metric(item: TimedRun, metric: QualityMetric) -> float | None:
+    return getattr(item, metric.key)
+
+
+def _region_metric(item: TimedRun, region: str, metric: QualityMetric) -> float | None:
+    suffix = {
+        "rmse": "rmse",
+        "psnr_clip": "psnr_clip",
+        "lpips_alex": "lpips_alex",
+        "flip_hdr": "flip_hdr",
+    }[metric.key]
+    return getattr(item, f"{region}_{suffix}")
+
+
+def _quality_axes(path: Path, title: str):
+    plt = _setup_matplotlib()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig, axes = plt.subplots(2, 2, figsize=(10.8, 7.2))
+    fig.suptitle(title)
+    return plt, fig, list(axes.ravel())
+
+
+def _finish_quality_axes(fig, axes: list[Any]) -> None:
+    for ax in axes:
+        handles, _labels = ax.get_legend_handles_labels()
+        if handles:
+            ax.legend(fontsize=8)
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+
+
+def plot_time_to_quality(path: Path, title: str, items: list[TimedRun]) -> None:
+    valid = [
+        item
+        for item in items
+        if item.mean_ms is not None and any(_metric(item, metric) is not None for metric in QUALITY_METRICS)
+    ]
+    if not valid:
+        _save_no_data(path, title, "No successful rows with both timing and image quality metrics.")
+        return
+    plt, fig, axes = _quality_axes(path, title)
+    for ax, metric in zip(axes, QUALITY_METRICS, strict=True):
+        for denoiser, marker in (("off", "s"), ("on", "o")):
+            subset = [
+                item for item in valid if item.row.get("denoiser") == denoiser and _metric(item, metric) is not None
+            ]
+            if not subset:
+                continue
+            x = [item.mean_ms for item in subset]
+            y = [max(_metric(item, metric) or 0.0, 1e-8) if metric.log_y else _metric(item, metric) for item in subset]
+            ax.scatter(x, y, label=f"denoiser {denoiser}", marker=marker, s=44)
+            for item in subset:
+                value = max(_metric(item, metric) or 0.0, 1e-8) if metric.log_y else _metric(item, metric)
+                ax.annotate(
+                    f"{item.row.get('samples')} spp",
+                    (item.mean_ms, value),
+                    xytext=(4, 4),
+                    textcoords="offset points",
+                    fontsize=7,
+                )
+        if _positive(item.mean_ms for item in valid):
+            ax.set_xscale("log")
+        if metric.log_y and _positive(_metric(item, metric) for item in valid):
+            ax.set_yscale("log")
+        ax.set_title(metric.label)
+        ax.set_xlabel("Mean camera-frame time (ms)")
+        ax.set_ylabel(metric.ylabel)
+    _finish_quality_axes(fig, axes)
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_spp_quality_metrics(path: Path, title: str, items: list[TimedRun]) -> None:
+    valid = [
+        item
+        for item in items
+        if item.row.get("denoiser", "on") == "on"
+        and item.row.get("samples")
+        and any(_metric(item, metric) is not None for metric in QUALITY_METRICS)
+    ]
+    if not valid:
+        _save_no_data(path, title, "No SPP rows with image quality metrics.")
+        return
+    plt, fig, axes = _quality_axes(path, title)
+    ordered = sorted(valid, key=lambda item: int(item.row.get("samples", "0") or 0))
+    spp = [int(item.row.get("samples", "0") or 0) for item in ordered]
+    for ax, metric in zip(axes, QUALITY_METRICS, strict=True):
+        y = [max(_metric(item, metric) or 0.0, 1e-8) if metric.log_y else _metric(item, metric) for item in ordered]
+        ax.plot(spp, y, marker="o")
+        ax.set_xscale("log")
+        if metric.log_y and _positive(_metric(item, metric) for item in ordered):
+            ax.set_yscale("log")
+        ax.set_title(metric.label)
+        ax.set_xlabel("Samples per pixel")
+        ax.set_ylabel(metric.ylabel)
+    _finish_quality_axes(fig, axes)
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_reference(path: Path, title: str, items: list[TimedRun]) -> None:
+    valid = [item for item in items if item.mean_ms is not None]
+    if not valid:
+        _save_no_data(path, title, "No successful reference rows.")
+        return
+    plt = _setup_matplotlib()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    labels = [f"{item.row.get('samples')} spp" for item in valid]
+    times = [item.mean_ms / 1000.0 for item in valid]
+    fig, ax = plt.subplots(figsize=(7.2, 4.4))
+    bars = ax.bar(labels, times, color="#4c78a8")
+    for bar, item in zip(bars, valid, strict=False):
+        label = "ref" if item.rmse == 0 else f"RMSE {fmt(item.rmse, 4)}"
+        ax.text(bar.get_x() + bar.get_width() / 2.0, bar.get_height(), label, ha="center", va="bottom", fontsize=8)
+    ax.set_title(title)
+    ax.set_ylabel("Render time (s)")
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_roi_quality(path: Path, title: str, items: list[TimedRun]) -> None:
+    valid = [
+        item
+        for item in items
+        if any(
+            _region_metric(item, region, metric) is not None
+            for region in ("glass", "non_glass")
+            for metric in QUALITY_METRICS
+        )
+    ]
+    if not valid:
+        _save_no_data(path, title, "No glass/non-glass ROI quality values were available.")
+        return
+    plt, fig, axes = _quality_axes(path, title)
+    labels = [f"{item.row.get('samples')} spp" for item in valid]
+    x = list(range(len(valid)))
+    for ax, metric in zip(axes, QUALITY_METRICS, strict=True):
+        glass_values = [_region_metric(item, "glass", metric) or 0.0 for item in valid]
+        non_glass_values = [_region_metric(item, "non_glass", metric) or 0.0 for item in valid]
+        ax.bar([i - 0.18 for i in x], glass_values, width=0.36, label="glass")
+        ax.bar([i + 0.18 for i in x], non_glass_values, width=0.36, label="non-glass")
+        ax.set_xticks(x, labels, rotation=35, ha="right")
+        if metric.log_y and _positive(glass_values + non_glass_values):
+            ax.set_yscale("log")
+        ax.set_title(metric.label)
+        ax.set_ylabel(metric.ylabel)
+    _finish_quality_axes(fig, axes)
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_multi_camera(path: Path, title: str, items: list[TimedRun]) -> None:
+    valid = [item for item in items if item.mean_ms is not None]
+    if not valid:
+        _save_no_data(path, title, "No successful multi-camera timing rows.")
+        return
+    plt = _setup_matplotlib()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(7.4, 4.6))
+    cameras = [int(item.row.get("camera_count", "0")) for item in valid]
+    per_camera = [item.mean_ms for item in valid]
+    batch = [item.mean_ms * int(item.row.get("camera_count", "0")) / 1000.0 for item in valid]
+    ax.plot(cameras, per_camera, marker="o", label="per camera frame")
+    ax.set_xlabel("Camera count")
+    ax.set_ylabel("Mean per-camera render time (ms)")
+    ax2 = ax.twinx()
+    ax2.plot(cameras, batch, marker="s", color="#f58518", label="per full frame batch")
+    ax2.set_ylabel("Estimated full multi-camera frame time (s)")
+    lines, labels = ax.get_legend_handles_labels()
+    lines2, labels2 = ax2.get_legend_handles_labels()
+    ax.legend(lines + lines2, labels + labels2, loc="upper left")
+    ax.set_title(title)
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_bar_metric(
+    path: Path, title: str, items: list[TimedRun], label_fn, *, ylabel: str = "Mean camera-frame time (ms)"
+) -> None:
+    valid = [item for item in items if item.mean_ms is not None]
+    if not valid:
+        _save_no_data(path, title, "No successful rows for this axis.")
+        return
+    plt = _setup_matplotlib()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    labels = [label_fn(item) for item in valid]
+    values = [item.mean_ms for item in valid]
+    fig_width = max(7.2, min(12.0, 0.42 * len(labels) + 4.0))
+    fig, ax = plt.subplots(figsize=(fig_width, 4.8))
+    bars = ax.bar(range(len(labels)), values, color="#54a24b")
+    for bar, item in zip(bars, valid, strict=False):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2.0,
+            bar.get_height(),
+            fmt_ms(item.mean_ms),
+            ha="center",
+            va="bottom",
+            fontsize=7,
+        )
+    ax.set_xticks(range(len(labels)), labels, rotation=35, ha="right")
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_adaptive(path: Path, title: str, items: list[TimedRun], unsupported_rows: list[dict[str, str]]) -> None:
+    valid = [item for item in items if item.mean_ms is not None and item.row.get("adaptive_threshold")]
+    if not valid:
+        thresholds = [row.get("adaptive_threshold", "") for row in unsupported_rows if row.get("adaptive_threshold")]
+        if thresholds:
+            counts = Counter(thresholds)
+            plt = _setup_matplotlib()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            labels = list(counts)
+            fig, ax = plt.subplots(figsize=(7.2, 4.4))
+            ax.bar(labels, [counts[label] for label in labels], color="#e45756")
+            ax.set_title(title)
+            ax.set_ylabel("Unsupported rows")
+            ax.set_xlabel("Adaptive threshold")
+            ax.text(
+                0.5,
+                0.92,
+                "No successful adaptive rows; chart shows unsupported coverage.",
+                transform=ax.transAxes,
+                ha="center",
+            )
+            fig.tight_layout()
+            fig.savefig(path)
+            plt.close(fig)
+            return
+        _save_no_data(path, title, "No adaptive rows.")
+        return
+    plt = _setup_matplotlib()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(7.4, 4.6))
+    for samples in sorted({item.row.get("samples", "") for item in valid}, key=lambda value: int(value or 0)):
+        subset = sorted(
+            [item for item in valid if item.row.get("samples") == samples],
+            key=lambda item: float(item.row.get("adaptive_threshold", "0")),
+        )
+        x = [float(item.row.get("adaptive_threshold", "0")) for item in subset]
+        y = [item.mean_ms for item in subset]
+        ax.plot(x, y, marker="o", label=f"{samples} spp")
+    ax.set_xscale("log")
+    ax.invert_xaxis()
+    ax.set_title(title)
+    ax.set_xlabel("Adaptive threshold (looser to tighter)")
+    ax.set_ylabel("Mean camera-frame time (ms)")
+    ax.legend(title="Max SPP")
+    fig.tight_layout()
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_adaptive_quality_metrics(path: Path, title: str, items: list[TimedRun]) -> None:
+    valid = [
+        item
+        for item in items
+        if item.row.get("adaptive_threshold")
+        and item.row.get("samples")
+        and any(_metric(item, metric) is not None for metric in QUALITY_METRICS)
+    ]
+    if not valid:
+        _save_no_data(path, title, "No adaptive rows with image quality metrics.")
+        return
+    plt, fig, axes = _quality_axes(path, title)
+    for ax, metric in zip(axes, QUALITY_METRICS, strict=True):
+        for samples in sorted({item.row.get("samples", "") for item in valid}, key=lambda value: int(value or 0)):
+            subset = sorted(
+                [item for item in valid if item.row.get("samples") == samples and _metric(item, metric) is not None],
+                key=lambda item: float(item.row.get("adaptive_threshold", "0")),
+            )
+            if not subset:
+                continue
+            x = [float(item.row.get("adaptive_threshold", "0")) for item in subset]
+            y = [max(_metric(item, metric) or 0.0, 1e-8) if metric.log_y else _metric(item, metric) for item in subset]
+            ax.plot(x, y, marker="o", label=f"{samples} spp")
+        ax.set_xscale("log")
+        ax.invert_xaxis()
+        if metric.log_y and _positive(_metric(item, metric) for item in valid):
+            ax.set_yscale("log")
+        ax.set_title(metric.label)
+        ax.set_xlabel("Adaptive threshold (looser to tighter)")
+        ax.set_ylabel(metric.ylabel)
+    _finish_quality_axes(fig, axes)
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_profile_quality_metrics(path: Path, title: str, items: list[TimedRun], label_fn) -> None:
+    valid = [item for item in items if any(_metric(item, metric) is not None for metric in QUALITY_METRICS)]
+    if not valid:
+        _save_no_data(path, title, "No profile rows with image quality metrics.")
+        return
+    plt, fig, axes = _quality_axes(path, title)
+    labels = [label_fn(item) for item in valid]
+    x = list(range(len(valid)))
+    for ax, metric in zip(axes, QUALITY_METRICS, strict=True):
+        values = [max(_metric(item, metric) or 0.0, 1e-8) if metric.log_y else _metric(item, metric) for item in valid]
+        ax.bar(x, values, color="#72b7b2")
+        ax.set_xticks(x, labels, rotation=35, ha="right")
+        if metric.log_y and _positive(_metric(item, metric) for item in valid):
+            ax.set_yscale("log")
+        ax.set_title(metric.label)
+        ax.set_ylabel(metric.ylabel)
+    _finish_quality_axes(fig, axes)
+    fig.savefig(path)
+    plt.close(fig)
+
+
+def plot_scene_figures(root: Path, analysis: dict[str, Any]) -> None:
+    scene = analysis["scene"]
+    scene_root = root / scene
+    title = SCENE_TITLES[scene]
+    plot_time_to_quality(
+        scene_root / "core" / "time_to_quality.png", f"{title}: time to proxy quality", analysis["spp"]
+    )
+    plot_spp_quality_metrics(
+        scene_root / "core" / "spp_quality_metrics.png", f"{title}: SPP quality metrics", analysis["spp"]
+    )
+    plot_reference(
+        scene_root / "core" / "reference_convergence.png", f"{title}: reference render cost", analysis["reference_rows"]
+    )
+    plot_roi_quality(scene_root / "core" / "roi_quality.png", f"{title}: ROI proxy quality", analysis["spp"])
+    plot_multi_camera(scene_root / "core" / "multi_camera.png", f"{title}: multi-camera scaling", analysis["multi"])
+    plot_time_to_quality(
+        scene_root / "core" / "pareto.png", f"{title}: timing/quality envelope", analysis["spp"] + analysis["denoiser"]
+    )
+    plot_bar_metric(
+        scene_root / "controls" / "denoiser_matrix.png",
+        f"{title}: denoiser matrix",
+        analysis["denoiser"],
+        lambda item: (
+            "off"
+            if item.row.get("denoiser") == "off"
+            else f"{item.row.get('denoiser_engine')}\n{item.row.get('denoiser_passes')}"
+        ),
+    )
+    unsupported_adaptive = [
+        row for row in analysis["runs"] if row.get("kind") == "adaptive_sampling" and row.get("status") != "ok"
+    ]
+    plot_adaptive(
+        scene_root / "controls" / "adaptive_sampling.png",
+        f"{title}: adaptive sampling",
+        analysis["adaptive"],
+        unsupported_adaptive,
+    )
+    plot_adaptive_quality_metrics(
+        scene_root / "controls" / "adaptive_sampling_quality.png",
+        f"{title}: adaptive sampling quality metrics",
+        analysis["adaptive"],
+    )
+    plot_bar_metric(
+        scene_root / "controls" / "light_sampling.png",
+        f"{title}: light sampling",
+        analysis["light"],
+        lambda item: f"tree {item.row.get('light_tree')}\nthr {item.row.get('light_threshold')}",
+    )
+    if scene == "complex_glass_cube_reach":
+        plot_bar_metric(
+            scene_root / "controls" / "glass_light_paths.png",
+            f"{title}: glass light-path profiles",
+            analysis["glass"],
+            lambda item: item.row.get("profile", "profile"),
+        )
+        plot_profile_quality_metrics(
+            scene_root / "controls" / "glass_light_paths_quality.png",
+            f"{title}: glass light-path quality metrics",
+            analysis["glass"],
+            lambda item: item.row.get("profile", "profile"),
+        )
+    else:
+        _save_no_data(
+            scene_root / "controls" / "glass_light_paths.png",
+            f"{title}: glass light-path profiles",
+            "Not applicable: the normal task1 scenario is not the glass stress scene.",
+        )
+        _save_no_data(
+            scene_root / "controls" / "glass_light_paths_quality.png",
+            f"{title}: glass light-path quality metrics",
+            "Not applicable: the normal task1 scenario is not the glass stress scene.",
+        )
+
+
+def plot_root_figures(root: Path, analyses: dict[str, dict[str, Any]]) -> None:
+    plt = _setup_matplotlib()
+    figures = root / "analysis_figures"
+    figures.mkdir(parents=True, exist_ok=True)
+
+    fig, ax = plt.subplots(figsize=(7.6, 4.8))
+    for scene, analysis in analyses.items():
+        valid = [item for item in analysis["spp"] if item.mean_ms is not None and item.row.get("denoiser") == "on"]
+        if not valid:
+            continue
+        ax.plot(
+            [int(item.row["samples"]) for item in valid],
+            [item.mean_ms for item in valid],
+            marker="o",
+            label=SCENE_TITLES[scene],
+        )
+    ax.set_xscale("log")
+    ax.set_yscale("log")
+    ax.set_xlabel("Samples per pixel")
+    ax.set_ylabel("Mean camera-frame time (ms)")
+    ax.set_title("SPP timing comparison")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(figures / "spp_timing_comparison.png")
+    plt.close(fig)
+
+    fig, axes = plt.subplots(2, 2, figsize=(10.8, 7.2))
+    axes_list = list(axes.ravel())
+    fig.suptitle("SPP quality metric comparison")
+    for ax, metric in zip(axes_list, QUALITY_METRICS, strict=True):
+        plotted_metric = False
+        for scene, analysis in analyses.items():
+            valid = [
+                item
+                for item in analysis["spp"]
+                if item.row.get("denoiser") == "on" and item.row.get("samples") and _metric(item, metric) is not None
+            ]
+            if not valid:
+                continue
+            ordered = sorted(valid, key=lambda item: int(item.row.get("samples", "0") or 0))
+            ax.plot(
+                [int(item.row["samples"]) for item in ordered],
+                [
+                    max(_metric(item, metric) or 0.0, 1e-8) if metric.log_y else _metric(item, metric)
+                    for item in ordered
+                ],
+                marker="o",
+                label=SCENE_TITLES[scene],
+            )
+            plotted_metric = True
+        ax.set_xscale("log")
+        if metric.log_y:
+            ax.set_yscale("log")
+        ax.set_xlabel("Samples per pixel")
+        ax.set_ylabel(metric.ylabel)
+        ax.set_title(metric.label)
+        if plotted_metric:
+            ax.legend(fontsize=8)
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    fig.savefig(figures / "spp_quality_metrics_comparison.png")
+    fig.savefig(figures / "spp_proxy_quality_comparison.png")
+    plt.close(fig)
+
+    fig, ax = plt.subplots(figsize=(7.6, 4.8))
+    plotted = False
+    for scene, analysis in analyses.items():
+        valid = [item for item in analysis["multi"] if item.mean_ms is not None]
+        if not valid:
+            continue
+        ax.plot(
+            [int(item.row["camera_count"]) for item in valid],
+            [item.mean_ms for item in valid],
+            marker="o",
+            label=SCENE_TITLES[scene],
+        )
+        plotted = True
+    ax.set_xlabel("Camera count")
+    ax.set_ylabel("Mean per-camera render time (ms)")
+    ax.set_title("Multi-camera per-camera timing")
+    if plotted:
+        ax.legend()
+        fig.tight_layout()
+        fig.savefig(figures / "multi_camera_comparison.png")
+        plt.close(fig)
+    else:
+        plt.close(fig)
+        _save_no_data(
+            figures / "multi_camera_comparison.png",
+            "Multi-camera per-camera timing",
+            "No multi-camera rows in this reduced rerun.",
+        )
+
+    fig, ax = plt.subplots(figsize=(7.4, 4.6))
+    labels = []
+    peaks = []
+    for scene, analysis in analyses.items():
+        values = []
+        for row in analysis["vram"]:
+            try:
+                values.append(float(row.get("peak_mb", "")))
+            except ValueError:
+                continue
+        if values:
+            labels.append(SCENE_TITLES[scene])
+            peaks.append(max(values))
+    if labels:
+        ax.bar(labels, peaks, color="#b279a2")
+        ax.set_ylabel("Peak VRAM observed (MB)")
+        ax.set_title("Observed peak VRAM by scene")
+        for label_index, value in enumerate(peaks):
+            ax.text(label_index, value, f"{value:.0f} MB", ha="center", va="bottom")
+        fig.tight_layout()
+        fig.savefig(figures / "vram_peak_by_scene.png")
+    else:
+        plt.close(fig)
+        _save_no_data(figures / "vram_peak_by_scene.png", "Observed peak VRAM by scene", "No VRAM rows available.")
+        return
+    plt.close(fig)
+
+
+def _scene_summary_rows(analyses: dict[str, dict[str, Any]]) -> list[list[str]]:
+    rows = []
+    for scene, analysis in analyses.items():
+        rows.append([
+            SCENE_TITLES[scene],
+            str(len(analysis["runs"])),
+            ", ".join(f"{key}={value}" for key, value in sorted(analysis["status_counts"].items())),
+            ", ".join(f"{key}={value}" for key, value in sorted(analysis["kind_counts"].items())),
+        ])
+    return rows
+
+
+def _timing_table(items: list[TimedRun], *, limit: int | None = None) -> list[list[str]]:
+    rows = []
+    for item in items[:limit]:
+        row = item.row
+        rows.append([
+            row.get("kind", ""),
+            row.get("samples", ""),
+            row.get("denoiser", ""),
+            row.get("denoiser_engine", ""),
+            row.get("camera_count", ""),
+            row.get("frames", ""),
+            str(item.frame_count),
+            fmt_ms(item.mean_ms),
+            fmt(item.rmse, 5),
+            fmt(item.lpips_alex, 4),
+            fmt(item.flip_hdr, 4),
+            fmt(item.roi_rmse_max, 5),
+            fmt(item.glass_psnr_clip, 2),
+            fmt(item.non_glass_psnr_clip, 2),
+        ])
+    return rows
+
+
+def _roi_box_table(scene: str) -> list[list[str]]:
+    rows = []
+    for group, boxes in ROI_GROUPS.get(scene, {}).items():
+        for name, box in boxes.items():
+            rows.append([group, name, json_box(box)])
+    return rows
+
+
+TIMING_HEADERS = [
+    "Kind",
+    "SPP",
+    "Denoiser",
+    "Engine",
+    "Cameras",
+    "Frames",
+    "Timed frames",
+    "Mean time",
+    "RMSE",
+    "LPIPS",
+    "FLIP",
+    "ROI max RMSE",
+    "Glass PSNR",
+    "Non-glass PSNR",
+]
+
+
+def _multi_table(items: list[TimedRun]) -> list[list[str]]:
+    rows = []
+    for item in items:
+        cameras = int(item.row.get("camera_count", "0") or 0)
+        batch_ms = item.mean_ms * cameras if item.mean_ms is not None else None
+        rows.append([
+            item.row.get("camera_count", ""),
+            item.row.get("frames", ""),
+            str(item.frame_count),
+            fmt_ms(item.mean_ms),
+            fmt_ms(batch_ms),
+            fmt(item.p95_ms, 1),
+        ])
+    return rows
+
+
+def _denoiser_table(items: list[TimedRun]) -> list[list[str]]:
+    rows = []
+    for item in items:
+        row = item.row
+        rows.append([
+            row.get("denoiser", ""),
+            row.get("denoiser_engine", ""),
+            row.get("denoiser_passes", ""),
+            row.get("denoising_prefilter", ""),
+            row.get("denoising_quality", ""),
+            fmt_ms(item.mean_ms),
+            fmt(item.rmse, 5),
+            fmt(item.roi_rmse_max, 5),
+        ])
+    return rows
+
+
+def _adaptive_table(items: list[TimedRun]) -> list[list[str]]:
+    rows = []
+    for item in sorted(
+        items,
+        key=lambda run: (int(run.row.get("samples", "0") or 0), float(run.row.get("adaptive_threshold", "0") or 0)),
+    ):
+        row = item.row
+        rows.append([
+            row.get("samples", ""),
+            row.get("adaptive_threshold", ""),
+            row.get("adaptive_min_samples", ""),
+            row.get("frames", ""),
+            fmt_ms(item.mean_ms),
+            fmt(item.rmse, 5),
+            fmt(item.roi_rmse_max, 5),
+        ])
+    return rows
+
+
+def _region_metric_bundle(rmse: float | None, psnr: float | None, lpips: float | None, flip: float | None) -> str:
+    return f"{fmt(rmse, 5)} / {fmt(psnr, 2)} dB / {fmt(lpips, 4)} / {fmt(flip, 4)}"
+
+
+def _lower_owner(glass: float | None, non_glass: float | None, *, tolerance: float = 1e-9) -> str:
+    if glass is None or non_glass is None:
+        return "unavailable"
+    if math.isclose(glass, non_glass, abs_tol=tolerance):
+        return "tie"
+    return "glass" if glass < non_glass else "non-glass"
+
+
+def _region_reading(item: TimedRun) -> str:
+    rmse_owner = _lower_owner(item.glass_rmse, item.non_glass_rmse, tolerance=5e-6)
+    flip_owner = _lower_owner(item.glass_flip_hdr, item.non_glass_flip_hdr, tolerance=5e-6)
+    if rmse_owner == "unavailable" or flip_owner == "unavailable":
+        return "region metrics unavailable"
+    if rmse_owner == flip_owner:
+        return f"{rmse_owner} has lower RMSE and FLIP"
+    return f"{rmse_owner} has lower RMSE, {flip_owner} has lower FLIP"
+
+
+def _spp_region_table(items: list[TimedRun]) -> list[list[str]]:
+    denoised = [item for item in items if item.row.get("denoiser", "on") == "on"]
+    selected = denoised or items
+    rows = []
+    for item in sorted(selected, key=lambda run: int(run.row.get("samples", "0") or 0)):
+        rows.append([
+            item.row.get("samples", ""),
+            fmt_ms(item.mean_ms),
+            _region_metric_bundle(item.glass_rmse, item.glass_psnr_clip, item.glass_lpips_alex, item.glass_flip_hdr),
+            _region_metric_bundle(
+                item.non_glass_rmse,
+                item.non_glass_psnr_clip,
+                item.non_glass_lpips_alex,
+                item.non_glass_flip_hdr,
+            ),
+            _region_reading(item),
+        ])
+    return rows
+
+
+def _glass_region_table(items: list[TimedRun]) -> list[list[str]]:
+    rows = []
+    for item in items:
+        rows.append([
+            item.row.get("profile", ""),
+            fmt_ms(item.mean_ms),
+            _region_metric_bundle(item.glass_rmse, item.glass_psnr_clip, item.glass_lpips_alex, item.glass_flip_hdr),
+            _region_metric_bundle(
+                item.non_glass_rmse,
+                item.non_glass_psnr_clip,
+                item.non_glass_lpips_alex,
+                item.non_glass_flip_hdr,
+            ),
+            _region_reading(item),
+        ])
+    return rows
+
+
+def _metric_spread(values: list[float | None], digits: int) -> str:
+    numbers = [float(value) for value in values if value is not None]
+    if not numbers:
+        return ""
+    return fmt(max(numbers) - min(numbers), digits)
+
+
+def _metric_range(values: list[float | None], digits: int) -> str:
+    numbers = [float(value) for value in values if value is not None]
+    if not numbers:
+        return ""
+    return f"{fmt(min(numbers), digits)}-{fmt(max(numbers), digits)}"
+
+
+def _adaptive_spread_bundle(items: list[TimedRun], prefix: str) -> str:
+    return " / ".join([
+        _metric_spread([getattr(item, f"{prefix}_rmse") for item in items], 5),
+        f"{_metric_spread([getattr(item, f'{prefix}_psnr_clip') for item in items], 3)} dB",
+        _metric_spread([getattr(item, f"{prefix}_lpips_alex") for item in items], 4),
+        _metric_spread([getattr(item, f"{prefix}_flip_hdr") for item in items], 4),
+    ])
+
+
+def _adaptive_region_spread_table(items: list[TimedRun]) -> list[list[str]]:
+    by_spp: dict[str, list[TimedRun]] = defaultdict(list)
+    for item in items:
+        if item.row.get("samples"):
+            by_spp[item.row.get("samples", "")].append(item)
+    rows = []
+    for samples, group in sorted(by_spp.items(), key=lambda pair: int(pair[0] or 0)):
+        ordered = sorted(group, key=lambda run: float(run.row.get("adaptive_threshold", "0") or 0))
+        thresholds = ", ".join(item.row.get("adaptive_threshold", "") for item in ordered)
+        best = min(ordered, key=lambda item: item.rmse if item.rmse is not None else float("inf"))
+        glass_rmse_spread = max((item.glass_rmse or 0.0) for item in ordered) - min(
+            (item.glass_rmse or 0.0) for item in ordered
+        )
+        non_glass_rmse_spread = max((item.non_glass_rmse or 0.0) for item in ordered) - min(
+            (item.non_glass_rmse or 0.0) for item in ordered
+        )
+        reading = (
+            "threshold changes are negligible"
+            if max(glass_rmse_spread, non_glass_rmse_spread) < 1e-4
+            else "threshold changes are visible"
+        )
+        rows.append([
+            samples,
+            thresholds,
+            _adaptive_spread_bundle(ordered, "glass"),
+            _adaptive_spread_bundle(ordered, "non_glass"),
+            _metric_range([item.rmse for item in ordered], 5),
+            best.row.get("adaptive_threshold", ""),
+            reading,
+        ])
+    return rows
+
+
+def _light_table(items: list[TimedRun]) -> list[list[str]]:
+    rows = []
+    for item in sorted(
+        items, key=lambda run: (run.row.get("light_tree", ""), float(run.row.get("light_threshold", "0") or 0))
+    ):
+        row = item.row
+        rows.append([
+            row.get("light_tree", ""),
+            row.get("light_threshold", ""),
+            row.get("samples", ""),
+            row.get("frames", ""),
+            fmt_ms(item.mean_ms),
+            fmt(item.rmse, 5),
+            fmt(item.roi_rmse_max, 5),
+        ])
+    return rows
+
+
+def _glass_table(items: list[TimedRun]) -> list[list[str]]:
+    rows = []
+    for item in items:
+        row = item.row
+        caustics = f"R:{row.get('caustics_reflective', '')} / T:{row.get('caustics_refractive', '')}"
+        rows.append([
+            row.get("profile", ""),
+            row.get("max_bounces", ""),
+            row.get("transmission_bounces", ""),
+            row.get("transparent_bounces", ""),
+            caustics,
+            row.get("sample_clamp_indirect", ""),
+            row.get("filter_glossy", ""),
+            fmt_ms(item.mean_ms),
+            fmt(item.rmse, 5),
+            fmt(item.roi_rmse_max, 5),
+        ])
+    return rows
+
+
+def _find_spp(items: list[TimedRun], samples: str) -> TimedRun | None:
+    for item in items:
+        if item.row.get("samples") == samples and item.row.get("denoiser") == "on":
+            return item
+    return None
+
+
+def _find_adaptive(items: list[TimedRun], threshold: str) -> TimedRun | None:
+    for item in items:
+        if item.row.get("adaptive_threshold") == threshold:
+            return item
+    return None
+
+
+def _find_glass_profile(items: list[TimedRun], profile: str) -> TimedRun | None:
+    for item in items:
+        if item.row.get("profile") == profile:
+            return item
+    return None
+
+
+def _interpretation_rows(analysis: dict[str, Any]) -> list[list[str]]:
+    rows: list[list[str]] = []
+    spp_64 = _find_spp(analysis["spp"], "64")
+    spp_256 = _find_spp(analysis["spp"], "256")
+    spp_4096 = _find_spp(analysis["spp"], "4096")
+    if spp_64 and spp_4096:
+        speedup = (spp_4096.mean_ms / spp_64.mean_ms) if spp_4096.mean_ms and spp_64.mean_ms else None
+        rows.append([
+            "64 SPP baseline",
+            f"64 spp is {fmt_ms(spp_64.mean_ms)} with RMSE {fmt(spp_64.rmse, 5)}, LPIPS {fmt(spp_64.lpips_alex, 4)}, and FLIP {fmt(spp_64.flip_hdr, 4)}; 4096 spp is {fmt_ms(spp_4096.mean_ms)} with RMSE {fmt(spp_4096.rmse, 5)}.",
+            f"4096 spp costs {fmt(speedup, 1)}x more time than the 64 spp baseline for a {fmt((spp_64.rmse or 0) - (spp_4096.rmse or 0), 5)} RMSE reduction.",
+        ])
+    adaptive_64 = [item for item in analysis["adaptive"] if item.row.get("samples") == "64"]
+    loose = next((item for item in adaptive_64 if item.row.get("adaptive_threshold") == "0.1"), None)
+    mid = next((item for item in adaptive_64 if item.row.get("adaptive_threshold") == "0.03"), None)
+    tight = next((item for item in adaptive_64 if item.row.get("adaptive_threshold") == "0.003"), None)
+    if loose and mid and tight:
+        rows.append([
+            "Adaptive sampling",
+            f"At 64 spp, threshold 0.1 is {fmt_ms(loose.mean_ms)} / RMSE {fmt(loose.rmse, 5)}; threshold 0.03 is {fmt_ms(mid.mean_ms)} / RMSE {fmt(mid.rmse, 5)}; threshold 0.003 is {fmt_ms(tight.mean_ms)} / RMSE {fmt(tight.rmse, 5)}.",
+            "The adaptive comparison is now bounded by the practical 64/16/8 spp regimes instead of near-reference 4096 spp adaptive rows.",
+        ])
+    default = _find_glass_profile(analysis["glass"], "glass_default")
+    fast = _find_glass_profile(analysis["glass"], "glass_fast")
+    caustics_off = _find_glass_profile(analysis["glass"], "caustics_off")
+    clamp = _find_glass_profile(analysis["glass"], "clamp_indirect_2")
+    if default and fast and caustics_off and clamp:
+        rows.append([
+            "Glass paths",
+            f"default is {fmt_ms(default.mean_ms)} / RMSE {fmt(default.rmse, 5)}; fast is {fmt_ms(fast.mean_ms)} / RMSE {fmt(fast.rmse, 5)}; caustics-off is {fmt_ms(caustics_off.mean_ms)} / RMSE {fmt(caustics_off.rmse, 5)}; clamp-2 is {fmt_ms(clamp.mean_ms)} / RMSE {fmt(clamp.rmse, 5)}.",
+            "The fast and caustics-off rows reduce path complexity but visibly and numerically damage glass-heavy regions; clamp-2 is the smaller degradation among the tested shortcuts.",
+        ])
+    if spp_64:
+        rows.append([
+            "ROI split",
+            f"At the 64 spp baseline, glass PSNR/LPIPS/FLIP are {fmt(spp_64.glass_psnr_clip, 2)} dB / {fmt(spp_64.glass_lpips_alex, 4)} / {fmt(spp_64.glass_flip_hdr, 4)}; non-glass PSNR/LPIPS/FLIP are {fmt(spp_64.non_glass_psnr_clip, 2)} dB / {fmt(spp_64.non_glass_lpips_alex, 4)} / {fmt(spp_64.non_glass_flip_hdr, 4)}.",
+            "This split prevents transparent-object errors from being hidden by easier robot/table regions.",
+        ])
+    return rows
+
+
+def _vram_table(analysis: dict[str, Any]) -> list[list[str]]:
+    grouped: dict[str, list[float]] = defaultdict(list)
+    for row in analysis["vram"]:
+        try:
+            grouped[row.get("run_id", "")].append(float(row.get("peak_mb", "")))
+        except ValueError:
+            continue
+    values = [max(v) for v in grouped.values() if v]
+    if not values:
+        return [["Peak VRAM", "not available"]]
+    return [
+        ["rows", str(len(values))],
+        ["min peak", f"{min(values):.0f} MB"],
+        ["median peak", f"{statistics.median(values):.0f} MB"],
+        ["max peak", f"{max(values):.0f} MB"],
+    ]
+
+
+SEED_STABILITY_REFERENCE_FALLBACK = Path(
+    "outputs/rendering_benchmark/blender_2026-05-09_glass_only/complex_glass_cube_reach/reference/blender_4096spp_denoise_off.exr"
+)
+
+
+def _seed_stability_reference_for(scene: str) -> Path | None:
+    if scene != "complex_glass_cube_reach":
+        return None
+    if SEED_STABILITY_REFERENCE_FALLBACK.exists():
+        return SEED_STABILITY_REFERENCE_FALLBACK
+    return None
+
+
+def _seed_stability_grouping(scene: str) -> tuple[dict[str, list[int]] | None, dict[str, list[str]] | None]:
+    groups = ROI_GROUPS.get(scene)
+    if not groups:
+        return None, None
+    boxes: dict[str, list[int]] = {}
+    grouping: dict[str, list[str]] = {}
+    for group_name, group_boxes in groups.items():
+        grouping[group_name] = list(group_boxes.keys())
+        boxes.update(group_boxes)
+    return boxes, grouping
+
+
+def write_markdown(root: Path, analyses: dict[str, dict[str, Any]]) -> None:
+    lines = [
+        "# Blender Rendering Benchmark Analysis",
+        "",
+        f"This is an interpretation report for the Blender/Cycles benchmark runs under `{root}`.",
+        "It is scoped to the complex glass cube-reach scenario only.",
+        "",
+        "## Scope And Validity",
+        "",
+        "- Scenario: `complex_glass_cube_reach`, derived from the cube-reach benchmark path with glass-heavy props and the recorded `cube_reach_default_initial.pt` state replay.",
+        "- Renderer/runtime: Blender 5.0.1 through the `isaacsim` Python environment, Cycles/OptiX on the host GPU.",
+        "- Quality metrics: global and ROI-split linear EXR RMSE/MAE, clipped PSNR, LPIPS Alex, and HDR FLIP.",
+        "- ROI split: several glass boxes cover the display case, bottle, hurricane glass, and rear tumbler; non-glass boxes cover robot arms, cube, and plain table regions.",
+        "- Time tradeoff: this rerun focuses on the 64 SPP baseline plus low-SPP adaptive sampling at 64, 16, and 8 SPP; other benchmark axes are intentionally excluded.",
+        "",
+        "## Coverage",
+        "",
+        markdown_table(["Scene", "Runs", "Status counts", "Successful kind counts"], _scene_summary_rows(analyses)),
+        "",
+        "## Overall Figures",
+        "",
+        "![SPP timing comparison](analysis_figures/spp_timing_comparison.png)",
+        "",
+        "![SPP quality metric comparison](analysis_figures/spp_quality_metrics_comparison.png)",
+        "",
+        "![Observed peak VRAM](analysis_figures/vram_peak_by_scene.png)",
+        "",
+        "## Main Interpretation",
+        "",
+        "- Read the SPP, adaptive, and glass-profile tables below as separate quality/cost axes against the retained `4096 spp, denoiser off` reference. The practical baseline row is `64 spp, denoiser on`.",
+        "- Glass and non-glass quality can diverge. Glass ROIs include refraction-heavy transparent surfaces, while non-glass ROIs track ordinary robot/table/cube regions.",
+        "- The PNG previews and contact sheets are generated from the same EXR outputs used for metrics, so visual comparison and numerical rows share provenance.",
+        "",
+    ]
+
+    for scene, analysis in analyses.items():
+        scene_dir = Path(scene)
+        lines.extend([
+            f"## {SCENE_TITLES[scene]}",
+            "",
+            "### Rendering Result",
+            "",
+            f"![{SCENE_TITLES[scene]} rendering result]({render_preview_relpath(scene).as_posix()})",
+            "",
+            "Visual preview for the scenario; timing and quality tables below use the same EXR render family.",
+            "",
+            "### ROI Boxes",
+            "",
+            markdown_table(["Group", "ROI", "Pixel box [x0, y0, x1, y1]"], _roi_box_table(scene)),
+            "",
+            "### Glass Vs Non-Glass Region Summary",
+            "",
+            "Metric bundles are ordered as `RMSE / PSNR / LPIPS / FLIP`. Lower is better for RMSE, LPIPS, and FLIP; higher is better for PSNR.",
+            f"The complete raw per-run split remains in `{scene_dir}/analysis/region_quality_summary.csv`, and per-box values remain in `{scene_dir}/analysis/roi_quality_detailed.csv`.",
+            "",
+            "#### SPP Sweep Region Split",
+            "",
+            markdown_table(
+                ["SPP", "Mean time", "Glass metrics", "Non-glass metrics", "Reading"],
+                _spp_region_table(analysis["spp"]),
+            ),
+            "",
+            "#### Adaptive Threshold Sensitivity By Region",
+            "",
+            "This table collapses the four adaptive thresholds into metric spreads at each SPP. Near-zero spreads mean the repeated threshold rows are numerically indistinguishable for the selected ROIs.",
+            "",
+            markdown_table(
+                [
+                    "SPP",
+                    "Thresholds",
+                    "Glass spread",
+                    "Non-glass spread",
+                    "Global RMSE range",
+                    "Best threshold",
+                    "Reading",
+                ],
+                _adaptive_region_spread_table(analysis["adaptive"]),
+            ),
+            "",
+            "#### Glass Path Profile Region Split",
+            "",
+            markdown_table(
+                ["Profile", "Mean time", "Glass metrics", "Non-glass metrics", "Reading"],
+                _glass_region_table(analysis["glass"]),
+            ),
+            "",
+            "### Human-Readable Comparison Sheets",
+            "",
+            "Normal comparison sheets show tone-mapped render previews at the original 1280x720 panel resolution. Difference sheets show mean absolute RGB EXR error against the retained `4096 spp, denoiser off` reference. The heatmap color scale is shared within each sheet, so colors are comparable inside one sheet but not across different sheets.",
+            "",
+            f"![SPP comparison]({scene_dir}/analysis/previews/spp_contact_sheet.png)",
+            "",
+            f"![SPP difference vs reference]({scene_dir}/analysis/previews/spp_difference_contact_sheet.png)",
+            "",
+            f"![Adaptive comparison]({scene_dir}/analysis/previews/adaptive_contact_sheet.png)",
+            "",
+            f"![Adaptive difference vs reference]({scene_dir}/analysis/previews/adaptive_difference_contact_sheet.png)",
+            "",
+            f"![Glass profile comparison]({scene_dir}/analysis/previews/glass_contact_sheet.png)",
+            "",
+            f"![Glass profile difference vs reference]({scene_dir}/analysis/previews/glass_difference_contact_sheet.png)",
+            "",
+            "### Key Figures",
+            "",
+            f"![Time to proxy quality]({scene_dir}/core/time_to_quality.png)",
+            "",
+            f"![SPP quality metrics]({scene_dir}/core/spp_quality_metrics.png)",
+            "",
+            f"![Glass/non-glass ROI quality]({scene_dir}/core/roi_quality.png)",
+            "",
+            f"![Adaptive sampling]({scene_dir}/controls/adaptive_sampling.png)",
+            "",
+            f"![Adaptive sampling quality metrics]({scene_dir}/controls/adaptive_sampling_quality.png)",
+            "",
+        ])
+        if scene == "complex_glass_cube_reach":
+            lines.extend([
+                f"![Glass light paths]({scene_dir}/controls/glass_light_paths.png)",
+                "",
+                f"![Glass light-path quality metrics]({scene_dir}/controls/glass_light_paths_quality.png)",
+                "",
+            ])
+
+        lines.extend([
+            "### Interpretation",
+            "",
+            markdown_table(["Axis", "Measured result", "Interpretation"], _interpretation_rows(analysis)),
+            "",
+            "### SPP Timing And Proxy Quality",
+            "",
+            markdown_table(
+                TIMING_HEADERS,
+                _timing_table(analysis["spp"]),
+            ),
+            "",
+            "### Reference Rows",
+            "",
+            markdown_table(
+                TIMING_HEADERS,
+                _timing_table(analysis["reference_rows"]),
+            ),
+            "",
+        ])
+        if analysis["adaptive"]:
+            lines.extend([
+                "### Adaptive Sampling Rows",
+                "",
+                markdown_table(
+                    ["Max SPP", "Threshold", "Min samples", "Frames", "Mean time", "RMSE", "ROI max RMSE"],
+                    _adaptive_table(analysis["adaptive"]),
+                ),
+                "",
+            ])
+        if analysis["glass"]:
+            lines.extend([
+                "### Glass Light-Path Rows",
+                "",
+                markdown_table(
+                    [
+                        "Profile",
+                        "Max bounces",
+                        "Transmission",
+                        "Transparent",
+                        "Caustics",
+                        "Indirect clamp",
+                        "Glossy filter",
+                        "Mean time",
+                        "RMSE",
+                        "ROI max RMSE",
+                    ],
+                    _glass_table(analysis["glass"]),
+                ),
+                "",
+            ])
+        lines.extend([
+            "### VRAM Summary",
+            "",
+            markdown_table(["Metric", "Value"], _vram_table(analysis)),
+            "",
+        ])
+        boxes, grouping = _seed_stability_grouping(scene)
+        if not (root / "matrix_driver.csv").exists():
+            seed_md = ""
+        else:
+            try:
+                seed_md = _seed_section.write_section(
+                    root=root,
+                    scene=scene,
+                    reference_exr=_seed_stability_reference_for(scene),
+                    roi_boxes=boxes,
+                    roi_grouping=grouping,
+                    runner=_seed_metrics.MetricRunner.full(),
+                )
+            except Exception as exc:
+                seed_md = f"## Seed Stability\n\nSection generation failed: `{type(exc).__name__}: {exc}`. See logs for details.\n"
+        if seed_md.strip():
+            lines.append(seed_md)
+
+    (root / "ANALYSIS.md").write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def write_all(root: Path) -> None:
+    analyses = {scene: scene_analysis(root, scene) for scene in SCENES}
+    write_analysis_csvs(root, analyses)
+    for analysis in analyses.values():
+        plot_scene_figures(root, analysis)
+        write_render_preview(root, analysis["scene"])
+        write_comparison_previews(root, analysis)
+    plot_root_figures(root, analyses)
+    write_markdown(root, analyses)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Write analysis report and meaningful figures for Blender benchmark outputs."
+    )
+    parser.add_argument("--root", type=Path, default=ROOT_DEFAULT)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    write_all(args.root)
+    print(args.root / "ANALYSIS.md")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/rendering/write_seed_stability_section.py
+++ b/scripts/benchmark/rendering/write_seed_stability_section.py
@@ -1,0 +1,393 @@
+"""Discover seed-variance runs, compute metrics, write CSVs/figures, return a markdown block."""
+
+from __future__ import annotations
+
+import csv
+import re
+import shlex
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from scripts.benchmark.rendering import seed_stability_metrics as ssm
+
+_LABEL_RE = re.compile(
+    r"^(?P<scene>[^:]+):seed_variance:(?P<group>spp|glass):(?P<key>[A-Za-z0-9_]+):seed(?P<seed>\d+)$"
+)
+
+
+def _parse_label(label: str) -> dict[str, str] | None:
+    m = _LABEL_RE.match(label)
+    if not m:
+        return None
+    return m.groupdict()
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    if not path.exists():
+        return []
+    with path.open(newline="", encoding="utf-8") as fh:
+        return list(csv.DictReader(fh))
+
+
+def _canon(cmd: str) -> str:
+    try:
+        return shlex.join(shlex.split(cmd))
+    except ValueError:
+        return cmd
+
+
+def discover_seed_variance_runs(*, root: Path, scene: str) -> dict[str, list[dict[str, Any]]]:
+    matrix_rows = _read_csv(root / "matrix_driver.csv")
+    runs_rows = _read_csv(root / scene / "runs.csv")
+
+    runs_by_command: dict[str, dict[str, str]] = {}
+    for row in runs_rows:
+        if row.get("status") != "ok":
+            continue
+        cmd = row.get("command", "")
+        if cmd:
+            runs_by_command[_canon(cmd)] = row
+
+    by_key: dict[tuple[str, int], dict[str, Any]] = {}
+    for row in matrix_rows:
+        if row.get("status") != "ok":
+            continue
+        parsed = _parse_label(row.get("label", ""))
+        if not parsed or parsed["scene"] != scene:
+            continue
+        cmd = row.get("command", "")
+        run_row = runs_by_command.get(_canon(cmd))
+        if run_row is None:
+            continue
+        exr = run_row.get("output_path", "")
+        if not exr:
+            continue
+        exr_path = Path(exr)
+        if not exr_path.exists():
+            continue
+        setting_key = f"{parsed['group']}_{parsed['key']}"
+        seed = int(parsed["seed"])
+        by_key[(setting_key, seed)] = {
+            "seed": seed,
+            "exr": exr_path,
+            "label": row["label"],
+            "run_row": run_row,
+        }
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for (setting_key, _seed), entry in by_key.items():
+        grouped.setdefault(setting_key, []).append(entry)
+    for entries in grouped.values():
+        entries.sort(key=lambda e: e["seed"])
+    return grouped
+
+
+def compute_setting_metrics(
+    *,
+    root: Path,
+    scene: str,
+    reference_exr: Path | None,
+    roi_boxes: dict[str, list[int]] | None,
+    roi_grouping: dict[str, list[str]] | None,
+    runner: ssm.MetricRunner,
+) -> Path:
+    grouped = discover_seed_variance_runs(root=root, scene=scene)
+    out_dir = root / scene / "analysis" / "seed_stability"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    reference_array: np.ndarray | None = None
+    if reference_exr is not None and Path(reference_exr).exists():
+        reference_array = ssm.load_exr_stack([Path(reference_exr)])[0]
+
+    pairwise_rows: list[dict[str, Any]] = []
+    vs_reference_rows: list[dict[str, Any]] = []
+    std_rows: list[dict[str, Any]] = []
+    skipped_settings: list[tuple[str, int]] = []
+
+    for setting_key, entries in sorted(grouped.items()):
+        if len(entries) < 3:
+            skipped_settings.append((setting_key, len(entries)))
+            continue
+        exrs = [entry["exr"] for entry in entries]
+        stack = ssm.load_exr_stack(exrs)
+
+        pairwise = ssm.pairwise_metrics(stack, runner=runner, roi_boxes=roi_boxes, roi_grouping=roi_grouping)
+        flat = {"setting": setting_key, "n_seeds": stack.shape[0]}
+        for region, metrics in pairwise.items():
+            for metric_name, summary in metrics.items():
+                if summary["n_pairs"] == 0:
+                    continue
+                flat[f"{region}_{metric_name}_mean"] = summary["mean"]
+                flat[f"{region}_{metric_name}_std"] = summary["std"]
+                flat[f"{region}_{metric_name}_max"] = summary["max"]
+        pairwise_rows.append(flat)
+
+        if reference_array is not None and reference_array.shape == stack.shape[1:]:
+            vs_ref = ssm.vs_reference_metrics(
+                stack, reference_array, runner=runner, roi_boxes=roi_boxes, roi_grouping=roi_grouping
+            )
+            for r in vs_ref:
+                vs_reference_rows.append({"setting": setting_key, **r})
+
+        _, std_image = ssm.per_pixel_stack_stats(stack)
+        std_path = out_dir / f"{setting_key}_std_map.png"
+        max_intensity = ssm.render_std_map(std_image, std_path, color_scale=None)
+        std_summary = {
+            "setting": setting_key,
+            "global_std_mean": float(np.mean(std_image)),
+            "max_intensity": max_intensity,
+            "std_map": std_path.name,
+        }
+        if roi_boxes and roi_grouping:
+            per_roi: dict[str, float] = {}
+            for name, box in roi_boxes.items():
+                per_roi[name] = float(np.mean(ssm.crop(std_image, box)))
+            grouped_std = ssm.group_means(per_roi, roi_grouping)
+            for region, value in grouped_std.items():
+                std_summary[f"{region}_std_mean"] = value
+        std_rows.append(std_summary)
+
+    _write_csv(out_dir / "pairwise_summary.csv", pairwise_rows)
+    _write_csv(out_dir / "vs_reference_summary.csv", vs_reference_rows)
+    _write_csv(out_dir / "std_summary.csv", std_rows)
+    if skipped_settings:
+        _write_csv(out_dir / "skipped_settings.csv", [{"setting": k, "n_seeds": n} for k, n in skipped_settings])
+    return out_dir
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        path.write_text("", encoding="utf-8")
+        return
+    field = sorted({k for row in rows for k in row.keys()})
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=field)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in field})
+
+
+def write_contact_sheet(out_dir: Path) -> Path:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.image as mpimg
+    import matplotlib.pyplot as plt
+
+    panels = sorted(out_dir.glob("*_std_map.png"))
+    if not panels:
+        target = out_dir / "seed_stability_contact_sheet.png"
+        target.write_bytes(b"")
+        return target
+    cols = min(4, len(panels))
+    rows = (len(panels) + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(cols * 4.0, rows * 2.5), dpi=120, squeeze=False)
+    for ax in axes.flat:
+        ax.set_axis_off()
+    for ax, panel in zip(axes.flat, panels):
+        try:
+            img = mpimg.imread(panel)
+            ax.imshow(img)
+        except Exception:
+            ax.text(0.5, 0.5, panel.name, ha="center", va="center")
+        ax.set_title(panel.stem.replace("_std_map", ""), fontsize=8)
+    target = out_dir / "seed_stability_contact_sheet.png"
+    fig.tight_layout()
+    fig.savefig(target)
+    plt.close(fig)
+    return target
+
+
+_SPP_KEY_RE = re.compile(r"^spp_(\d+)spp$")
+
+
+def write_rmse_vs_spp_plot(pairs: dict[str, tuple[float, float | None]], out_path: Path) -> Path:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    spp_pairs = []
+    for setting, (pw, vr) in pairs.items():
+        m = _SPP_KEY_RE.match(setting)
+        if not m:
+            continue
+        spp_pairs.append((int(m.group(1)), pw, vr))
+    spp_pairs.sort()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fig, ax = plt.subplots(figsize=(6.4, 4.0), dpi=120)
+    if spp_pairs:
+        spp_x = [s[0] for s in spp_pairs]
+        ax.plot(spp_x, [s[1] for s in spp_pairs], marker="o", label="pairwise RMSE (precision)")
+        vr_x = [s[0] for s in spp_pairs if s[2] is not None]
+        vr_y = [s[2] for s in spp_pairs if s[2] is not None]
+        if vr_x:
+            ax.plot(vr_x, vr_y, marker="s", label="vs-reference RMSE (accuracy)")
+        ax.set_xscale("log", base=2)
+        ax.set_yscale("log")
+        ax.set_xlabel("samples per pixel")
+        ax.set_ylabel("linear-EXR RMSE")
+        ax.set_title("Seed noise vs structural bias")
+        ax.legend()
+        ax.grid(True, which="both", linestyle=":", alpha=0.5)
+    else:
+        ax.text(0.5, 0.5, "no SPP rows", ha="center", va="center")
+        ax.set_axis_off()
+    fig.tight_layout()
+    fig.savefig(out_path)
+    plt.close(fig)
+    return out_path
+
+
+def interpret_setting(*, setting_key: str, pairwise_rmse: float, vs_reference_rmse: float) -> str:
+    if vs_reference_rmse <= 1e-9:
+        return f"{setting_key}: vs-reference RMSE ≈ 0; the only residual is seed noise."
+    ratio = pairwise_rmse / vs_reference_rmse
+    if ratio > 0.8:
+        verdict = "residual error is dominated by seed noise; more samples would help."
+    elif ratio < 0.3:
+        verdict = "residual error is structural; seed-averaging will not fix it."
+    else:
+        verdict = "mixed regime — both seed noise and structural bias contribute."
+    return f"{setting_key}: pairwise/vs-ref RMSE ratio = {ratio:.2f}; {verdict}"
+
+
+def _format_table(header: list[str], rows: list[list[str]]) -> str:
+    lines = ["| " + " | ".join(header) + " |", "| " + " | ".join("---" for _ in header) + " |"]
+    for row in rows:
+        lines.append("| " + " | ".join(row) + " |")
+    return "\n".join(lines)
+
+
+def _fmt(value: Any, digits: int = 5) -> str:
+    if value is None or value == "":
+        return ""
+    try:
+        return f"{float(value):.{digits}f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def write_section(
+    *,
+    root: Path,
+    scene: str,
+    reference_exr: Path | None,
+    roi_boxes: dict[str, list[int]] | None,
+    roi_grouping: dict[str, list[str]] | None,
+    runner: ssm.MetricRunner,
+) -> str:
+    out_dir = compute_setting_metrics(
+        root=root,
+        scene=scene,
+        reference_exr=reference_exr,
+        roi_boxes=roi_boxes,
+        roi_grouping=roi_grouping,
+        runner=runner,
+    )
+    pairwise_rows = (
+        list(csv.DictReader((out_dir / "pairwise_summary.csv").open(encoding="utf-8")))
+        if (out_dir / "pairwise_summary.csv").read_text(encoding="utf-8").strip()
+        else []
+    )
+    vs_ref_rows = (
+        list(csv.DictReader((out_dir / "vs_reference_summary.csv").open(encoding="utf-8")))
+        if (out_dir / "vs_reference_summary.csv").read_text(encoding="utf-8").strip()
+        else []
+    )
+    std_rows = (
+        list(csv.DictReader((out_dir / "std_summary.csv").open(encoding="utf-8")))
+        if (out_dir / "std_summary.csv").read_text(encoding="utf-8").strip()
+        else []
+    )
+    skipped_rows = (
+        list(csv.DictReader((out_dir / "skipped_settings.csv").open(encoding="utf-8")))
+        if (out_dir / "skipped_settings.csv").exists()
+        else []
+    )
+
+    write_contact_sheet(out_dir)
+
+    rmse_pairs: dict[str, tuple[float, float | None]] = {}
+    for row in pairwise_rows:
+        setting = row.get("setting", "")
+        pw = float(row.get("global_rmse_mean", 0.0) or 0.0)
+        vr_values = [float(v.get("rmse", 0.0) or 0.0) for v in vs_ref_rows if v.get("setting") == setting]
+        vr_mean = sum(vr_values) / len(vr_values) if vr_values else None
+        rmse_pairs[setting] = (pw, vr_mean)
+    write_rmse_vs_spp_plot(rmse_pairs, out_dir / "rmse_vs_spp.png")
+
+    md_lines = [
+        "## Seed Stability",
+        "",
+        "Seed-stability tables decompose residual error into pairwise spread (precision), per-seed bias against the high-sample reference (accuracy), and per-pixel std (where in the image variance lives).",
+        "",
+        "### Table 1 — Pairwise stability across seeds",
+        "",
+    ]
+    if pairwise_rows:
+        cols = ["setting", "n_seeds", "global_rmse_mean", "global_psnr_mean", "global_lpips_mean", "global_flip_mean"]
+        for region in ("glass", "non_glass"):
+            if any(f"{region}_rmse_mean" in r for r in pairwise_rows):
+                cols.append(f"{region}_rmse_mean")
+        rows = [
+            [_fmt(r.get(c), digits=5 if "rmse" in c or "lpips" in c or "flip" in c else 2) for c in cols]
+            for r in pairwise_rows
+        ]
+        md_lines.append(_format_table(cols, rows))
+    else:
+        md_lines.append("(no settings with ≥ 3 seeds found)")
+    md_lines.append("")
+
+    md_lines.append("### Table 2 — Per-seed vs reference")
+    md_lines.append("")
+    if vs_ref_rows:
+        cols = ["setting", "seed_index", "rmse", "psnr", "lpips", "flip"]
+        rows = [[_fmt(r.get(c), digits=5 if c in ("rmse", "lpips", "flip") else 2) for c in cols] for r in vs_ref_rows]
+        md_lines.append(_format_table(cols, rows))
+    elif reference_exr is None or not Path(reference_exr).exists():
+        md_lines.append("vs-reference block skipped (reference not available).")
+    else:
+        md_lines.append("(no rows)")
+    md_lines.append("")
+
+    md_lines.append("### Table 3 — Per-pixel std summary")
+    md_lines.append("")
+    if std_rows:
+        cols = ["setting", "global_std_mean"]
+        for region in ("glass", "non_glass"):
+            if any(f"{region}_std_mean" in r for r in std_rows):
+                cols.append(f"{region}_std_mean")
+        cols.append("std_map")
+        rows = [
+            [_fmt(r.get(c), digits=5 if "std_mean" in c else 0) if c != "std_map" else r.get(c, "") for c in cols]
+            for r in std_rows
+        ]
+        md_lines.append(_format_table(cols, rows))
+        md_lines.append("")
+        md_lines.append(f"![Seed-stability std maps]({scene}/analysis/seed_stability/seed_stability_contact_sheet.png)")
+        md_lines.append("")
+        md_lines.append(f"![Pairwise vs vs-reference RMSE]({scene}/analysis/seed_stability/rmse_vs_spp.png)")
+    md_lines.append("")
+
+    md_lines.append("### Interpretation")
+    md_lines.append("")
+    if pairwise_rows:
+        for row in pairwise_rows:
+            setting = row.get("setting", "")
+            pw, vr = rmse_pairs.get(setting, (0.0, None))
+            if vr is None:
+                md_lines.append(f"- {setting}: vs-reference unavailable; pairwise RMSE = {pw:.5f}")
+            else:
+                md_lines.append(f"- {interpret_setting(setting_key=setting, pairwise_rmse=pw, vs_reference_rmse=vr)}")
+    md_lines.append("")
+
+    if skipped_rows:
+        md_lines.append("### Notes")
+        for row in skipped_rows:
+            md_lines.append(f"- {row.get('setting', '')}: insufficient seeds (n={row.get('n_seeds', '?')}, needs ≥ 3)")
+        md_lines.append("")
+
+    return "\n".join(md_lines)

--- a/tests/fixtures/usd_materials/omnipbr_alias_matrix.usda
+++ b/tests/fixtures/usd_materials/omnipbr_alias_matrix.usda
@@ -1,0 +1,195 @@
+#usda 1.0
+
+def Xform "World"
+{
+    def Scope "Looks"
+    {
+        def Material "BaseColorColor"
+        {
+            token outputs:surface.connect = </World/Looks/BaseColorColor/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                color3f inputs:BaseColor_Color = (0.2, 0.3, 0.4)
+                token outputs:surface
+            }
+        }
+
+        def Material "DiffuseColorConstant"
+        {
+            token outputs:surface.connect = </World/Looks/DiffuseColorConstant/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                color3f inputs:diffuse_color_constant = (0.4, 0.3, 0.2)
+                token outputs:surface
+            }
+        }
+
+        def Material "BaseColorTex"
+        {
+            token outputs:surface.connect = </World/Looks/BaseColorTex/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                asset inputs:BaseColor_Tex = @./textures/base.png@
+                token outputs:surface
+            }
+        }
+
+        def Material "DiffuseTexture"
+        {
+            token outputs:surface.connect = </World/Looks/DiffuseTexture/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                asset inputs:diffuse_texture = @./textures/diffuse.png@
+                token outputs:surface
+            }
+        }
+
+        def Material "ReflectionRoughness"
+        {
+            token outputs:surface.connect = </World/Looks/ReflectionRoughness/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                float inputs:reflection_roughness_constant = 0.31
+                token outputs:surface
+            }
+        }
+
+        def Material "RoughnessAlias"
+        {
+            token outputs:surface.connect = </World/Looks/RoughnessAlias/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                float inputs:roughness = 0.62
+                token outputs:surface
+            }
+        }
+
+        def Material "MetallicConstant"
+        {
+            token outputs:surface.connect = </World/Looks/MetallicConstant/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                float inputs:metallic_constant = 0.73
+                token outputs:surface
+            }
+        }
+
+        def Material "MetallicAlias"
+        {
+            token outputs:surface.connect = </World/Looks/MetallicAlias/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                float inputs:metallic = 0.84
+                token outputs:surface
+            }
+        }
+
+        def Material "OpacityConstant"
+        {
+            token outputs:surface.connect = </World/Looks/OpacityConstant/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                float inputs:opacity_constant = 0.45
+                token outputs:surface
+            }
+        }
+
+        def Material "OpacityAlias"
+        {
+            token outputs:surface.connect = </World/Looks/OpacityAlias/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                float inputs:opacity = 0.56
+                token outputs:surface
+            }
+        }
+
+        def Material "EmissiveColorOmni"
+        {
+            token outputs:surface.connect = </World/Looks/EmissiveColorOmni/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                color3f inputs:Emissive_Color = (0.1, 0.2, 0.3)
+                token outputs:surface
+            }
+        }
+
+        def Material "EmissiveColorAlias"
+        {
+            token outputs:surface.connect = </World/Looks/EmissiveColorAlias/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                color3f inputs:emissiveColor = (0.3, 0.2, 0.1)
+                token outputs:surface
+            }
+        }
+
+        def Material "WallPanel"
+        {
+            token outputs:surface.connect = </World/Looks/WallPanel/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                token outputs:surface
+            }
+        }
+
+        def Material "FloorTile"
+        {
+            token outputs:surface.connect = </World/Looks/FloorTile/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                token outputs:surface
+            }
+        }
+
+        def Material "CabinetDoor"
+        {
+            token outputs:surface.connect = </World/Looks/CabinetDoor/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                token outputs:surface
+            }
+        }
+
+        def Material "GlassFallback"
+        {
+            token outputs:surface.connect = </World/Looks/GlassFallback/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                token outputs:surface
+            }
+        }
+    }
+}

--- a/tests/fixtures/usd_materials/omnipbr_basecolor_scalar.usda
+++ b/tests/fixtures/usd_materials/omnipbr_basecolor_scalar.usda
@@ -1,0 +1,23 @@
+#usda 1.0
+
+def Xform "World"
+{
+    def Scope "Looks"
+    {
+        def Material "Paint"
+        {
+            token outputs:surface.connect = </World/Looks/Paint/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                color3f inputs:BaseColor_Color = (0.2, 0.3, 0.4)
+                color3f inputs:Emissive_Color = (0, 0, 0)
+                float inputs:metallic_constant = 0
+                float inputs:opacity_constant = 1
+                float inputs:reflection_roughness_constant = 0.25
+                token outputs:surface
+            }
+        }
+    }
+}

--- a/tests/fixtures/usd_materials/omnipbr_basecolor_texture.usda
+++ b/tests/fixtures/usd_materials/omnipbr_basecolor_texture.usda
@@ -1,0 +1,32 @@
+#usda 1.0
+
+def Xform "World"
+{
+    def Scope "Looks"
+    {
+        def Material "Wood"
+        {
+            token outputs:surface.connect = </World/Looks/Wood/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                asset inputs:BaseColor_Tex = @./textures/wood.png@
+                float inputs:Gloss_Color = 0.7
+                int inputs:IsBaseColorTex = 1
+                token outputs:surface
+            }
+        }
+    }
+
+    def Mesh "Board"
+    {
+        int[] faceVertexCounts = [4]
+        int[] faceVertexIndices = [0, 1, 2, 3]
+        rel material:binding = </World/Looks/Wood>
+        point3f[] points = [(-1, -1, 0), (1, -1, 0), (1, 1, 0), (-1, 1, 0)]
+        texCoord2f[] primvars:st = [(0, 0), (1, 0), (1, 1), (0, 1)] (
+            interpolation = "faceVarying"
+        )
+    }
+}

--- a/tests/fixtures/usd_materials/omnipbr_glass_scalar.usda
+++ b/tests/fixtures/usd_materials/omnipbr_glass_scalar.usda
@@ -1,0 +1,22 @@
+#usda 1.0
+
+def Xform "World"
+{
+    def Scope "Looks"
+    {
+        def Material "GlassPane"
+        {
+            token outputs:surface.connect = </World/Looks/GlassPane/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "OmniPBR"
+                color3f inputs:BaseColor_Color = (0.8, 0.9, 1.0)
+                float inputs:SwitchRefraction = 1
+                float inputs:ior = 1.45
+                float inputs:opacity_constant = 0.35
+                token outputs:surface
+            }
+        }
+    }
+}

--- a/tests/fixtures/usd_materials/preview_surface_existing.usda
+++ b/tests/fixtures/usd_materials/preview_surface_existing.usda
@@ -1,0 +1,20 @@
+#usda 1.0
+
+def Xform "World"
+{
+    def Scope "Looks"
+    {
+        def Material "Previewed"
+        {
+            token outputs:surface.connect = </World/Looks/Previewed/Shader.outputs:surface>
+
+            def Shader "Shader"
+            {
+                uniform token info:id = "UsdPreviewSurface"
+                color3f inputs:diffuseColor = (0.1, 0.2, 0.3)
+                float inputs:roughness = 0.4
+                token outputs:surface
+            }
+        }
+    }
+}

--- a/tests/test_blender_benchmark_matrix_driver.py
+++ b/tests/test_blender_benchmark_matrix_driver.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import csv
+import shlex
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+
+from scripts.benchmark.rendering import blender_render_benchmark as render_benchmark
+from scripts.benchmark.rendering import run_blender_benchmark_matrix as matrix_driver
+
+
+@dataclass
+class FakeRobotState:
+    joint_pos: object
+    joint_pos_target: object
+    body_state: object
+    body_names: list[str]
+    root_state: object = "root"
+
+
+@dataclass
+class FakeTensorState:
+    robots: dict[str, FakeRobotState]
+
+
+def test_run_matrix_records_semantic_child_status(tmp_path, monkeypatch) -> None:
+    scene_root = tmp_path / "normal_hand_traj_task1"
+
+    class Completed:
+        returncode = 0
+
+    def fake_run(command, stdout, stderr, text, check):
+        scene_root.mkdir(parents=True)
+        with (scene_root / "runs.csv").open("w", newline="", encoding="utf-8") as handle:
+            writer = csv.DictWriter(handle, fieldnames=["command", "status"])
+            writer.writeheader()
+            writer.writerow({"command": shlex.join(command), "status": "unsupported"})
+        stdout.write('{"status": "unsupported"}\n')
+        return Completed()
+
+    monkeypatch.setattr(matrix_driver.subprocess, "run", fake_run)
+
+    exit_code = matrix_driver.run_matrix(
+        [
+            matrix_driver.MatrixRun(
+                "normal_hand_traj_task1:denoiser:AUTOMATIC:RGB",
+                [
+                    "render",
+                    "--scene",
+                    "normal_hand_traj_task1",
+                    "--output-root",
+                    str(tmp_path),
+                ],
+            )
+        ],
+        tmp_path,
+    )
+
+    rows = list(csv.DictReader((tmp_path / "matrix_driver.csv").open(encoding="utf-8")))
+    assert exit_code == 0
+    assert rows[0]["status"] == "unsupported"
+
+
+def test_complex_render_uses_recorded_default_initial_pose_state(tmp_path, monkeypatch) -> None:
+    import torch
+
+    state_path = tmp_path / "complex_glass_cube_reach" / "states" / "cube_reach_default_initial.pt"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_bytes(b"state")
+
+    applied = []
+
+    class FakeHandler:
+        robots = [
+            SimpleNamespace(
+                name="openarm_bimanual_wuji",
+            )
+        ]
+
+        def get_states(self, mode):
+            raise AssertionError(
+                "default initial pose must come from the recorded state, not Blender's stale body state"
+            )
+
+        def _apply_tensor_state(self, state):
+            applied.append(state)
+
+        def refresh_render(self):  # pragma: no cover - must not be called by the fast path
+            raise AssertionError("state application should not trigger an extra pre-render")
+
+    def fake_load(path, weights_only=False):
+        assert path == state_path
+        assert weights_only is False
+        return {
+            "states": [
+                FakeTensorState(
+                    robots={
+                        "openarm_bimanual_wuji": FakeRobotState(
+                            root_state=torch.tensor([[10.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]]),
+                            body_names=["base", "arm"],
+                            body_state=torch.tensor([
+                                [
+                                    [10.0, 2.0, 3.0, 1.0, 0.0, 0.0, 0.0],
+                                    [13.0, 5.0, 6.0, 1.0, 0.0, 0.0, 0.0],
+                                ]
+                            ]),
+                            joint_pos=torch.tensor([[0.0, -0.7854, 1.5708]]),
+                            joint_pos_target=torch.tensor([[0.0, -0.7854, 1.5708]]),
+                        )
+                    }
+                ),
+                "target",
+            ]
+        }
+
+    monkeypatch.setattr(render_benchmark, "_torch_load_state_file", fake_load)
+
+    selected = render_benchmark._apply_recorded_scene_state(
+        FakeHandler(),
+        root=tmp_path,
+        scene="complex_glass_cube_reach",
+    )
+
+    assert selected == state_path
+    robot_state = applied[0].robots["openarm_bimanual_wuji"]
+    assert robot_state.root_state.tolist() == [[10.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]]
+    assert robot_state.body_state[:, :, :3].tolist() == [[[10.0, 2.0, 3.0], [13.0, 5.0, 6.0]]]
+    assert robot_state.joint_pos.tolist() == [[pytest.approx(0.0), pytest.approx(-0.7854), pytest.approx(1.5708)]]
+
+
+def test_complex_render_fails_when_recorded_cube_reach_state_is_missing(tmp_path) -> None:
+    try:
+        render_benchmark._apply_recorded_scene_state(
+            object(),
+            root=tmp_path,
+            scene="complex_glass_cube_reach",
+        )
+    except FileNotFoundError as exc:
+        assert "refusing to render without the default initial robot pose" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("missing cube-reach state must not silently render default placement")
+
+
+def test_glass_quality_matrix_reruns_adaptive_at_low_spp_levels(tmp_path) -> None:
+    matrix = matrix_driver.build_matrix(
+        ["complex_glass_cube_reach"],
+        tmp_path,
+        "OPTIX",
+        phase="glass_quality",
+    )
+
+    adaptive_args = [run.args for run in matrix if run.label.startswith("complex_glass_cube_reach:adaptive:")]
+    adaptive_spp = sorted({matrix_driver._arg_value(args, "--samples") for args in adaptive_args})
+
+    assert adaptive_spp == ["16", "64", "8"]
+    assert all(matrix_driver._arg_value(args, "--adaptive-sampling") == "on" for args in adaptive_args)
+
+
+def test_adaptive_low_spp_phase_skips_reference_and_glass_profiles(tmp_path) -> None:
+    matrix = matrix_driver.build_matrix(
+        ["complex_glass_cube_reach"],
+        tmp_path,
+        "OPTIX",
+        phase="adaptive_low_spp",
+    )
+
+    labels = [run.label for run in matrix]
+
+    assert len(labels) == 15
+    assert not any(":reference:" in label for label in labels)
+    assert not any(":glass:" in label for label in labels)
+
+
+def test_seed_variance_phase_emits_one_hundred_twenty_rows(tmp_path) -> None:
+    matrix = matrix_driver.build_matrix(
+        ["complex_glass_cube_reach"],
+        tmp_path,
+        "OPTIX",
+        phase="seed_variance",
+    )
+    assert len(matrix) == 120
+
+
+def test_seed_variance_uses_fixed_seed_list(tmp_path) -> None:
+    matrix = matrix_driver.build_matrix(
+        ["complex_glass_cube_reach"],
+        tmp_path,
+        "OPTIX",
+        phase="seed_variance",
+    )
+    seeds = sorted({matrix_driver._arg_value(run.args, "--seed") for run in matrix})
+    assert seeds == [str(s) for s in range(2026, 2036)]
+
+
+def test_seed_variance_glass_profiles_use_256_spp(tmp_path) -> None:
+    matrix = matrix_driver.build_matrix(
+        ["complex_glass_cube_reach"],
+        tmp_path,
+        "OPTIX",
+        phase="seed_variance",
+    )
+    glass_runs = [run for run in matrix if ":seed_variance:glass:" in run.label]
+    assert len(glass_runs) == 50
+    assert {matrix_driver._arg_value(run.args, "--samples") for run in glass_runs} == {"256"}
+
+
+def test_seed_variance_4096spp_uses_denoiser_off(tmp_path) -> None:
+    matrix = matrix_driver.build_matrix(
+        ["complex_glass_cube_reach"],
+        tmp_path,
+        "OPTIX",
+        phase="seed_variance",
+    )
+    rows_4096 = [run for run in matrix if matrix_driver._arg_value(run.args, "--samples") == "4096"]
+    assert len(rows_4096) == 10
+    assert {matrix_driver._arg_value(run.args, "--denoiser") for run in rows_4096} == {"off"}
+
+
+def test_seed_variance_label_is_setting_plus_seed(tmp_path) -> None:
+    matrix = matrix_driver.build_matrix(
+        ["complex_glass_cube_reach"],
+        tmp_path,
+        "OPTIX",
+        phase="seed_variance",
+    )
+    labels = {run.label for run in matrix}
+    assert "complex_glass_cube_reach:seed_variance:spp:64spp:seed2026" in labels
+    assert "complex_glass_cube_reach:seed_variance:glass:glass_default:seed2031" in labels
+    setting_to_seeds: dict[str, set[str]] = {}
+    for run in matrix:
+        prefix, _, seed_part = run.label.rpartition(":seed")
+        setting_to_seeds.setdefault(prefix, set()).add(seed_part)
+    for prefix, seed_set in setting_to_seeds.items():
+        assert len(seed_set) == 10, prefix

--- a/tests/test_blender_seed_stability_metrics.py
+++ b/tests/test_blender_seed_stability_metrics.py
@@ -177,3 +177,49 @@ def test_pairwise_metrics_raises_for_fewer_than_two_images() -> None:
     stack = np.stack([img], axis=0)
     with pytest.raises(ValueError):
         ssm.pairwise_metrics(stack, runner=ssm.MetricRunner.numerical_only(), roi_boxes=None, roi_grouping=None)
+
+
+def test_vs_reference_metrics_returns_n_rows() -> None:
+    rng = np.random.default_rng(3)
+    stack = rng.random((4, 8, 8, 3), dtype=np.float32)
+    reference = rng.random((8, 8, 3), dtype=np.float32)
+    rows = ssm.vs_reference_metrics(
+        stack, reference, runner=ssm.MetricRunner.numerical_only(), roi_boxes=None, roi_grouping=None
+    )
+    assert len(rows) == 4
+    for index, row in enumerate(rows):
+        assert row["seed_index"] == index
+        for m in ("rmse", "mae", "psnr"):
+            assert m in row
+
+
+def test_vs_reference_metrics_zero_when_seed_equals_reference() -> None:
+    img = np.full((4, 4, 3), 0.25, dtype=np.float32)
+    stack = np.stack([img, img], axis=0)
+    rows = ssm.vs_reference_metrics(
+        stack, img, runner=ssm.MetricRunner.numerical_only(), roi_boxes=None, roi_grouping=None
+    )
+    assert rows[0]["rmse"] == pytest.approx(0.0)
+    assert rows[1]["rmse"] == pytest.approx(0.0)
+
+
+def test_vs_reference_metrics_raises_on_shape_mismatch() -> None:
+    stack = np.zeros((2, 4, 4, 3), dtype=np.float32)
+    reference = np.zeros((8, 8, 3), dtype=np.float32)
+    with pytest.raises(ValueError):
+        ssm.vs_reference_metrics(
+            stack, reference, runner=ssm.MetricRunner.numerical_only(), roi_boxes=None, roi_grouping=None
+        )
+
+
+def test_vs_reference_metrics_emits_grouped_roi_columns() -> None:
+    img = np.full((8, 8, 3), 0.3, dtype=np.float32)
+    stack = np.stack([img, img], axis=0)
+    boxes = {"glass_a": [0, 0, 4, 4], "non_glass_a": [4, 4, 8, 8]}
+    grouping = {"glass": ["glass_a"], "non_glass": ["non_glass_a"]}
+    rows = ssm.vs_reference_metrics(
+        stack, img, runner=ssm.MetricRunner.numerical_only(), roi_boxes=boxes, roi_grouping=grouping
+    )
+    assert "glass_rmse" in rows[0]
+    assert "non_glass_rmse" in rows[0]
+    assert rows[0]["glass_rmse"] == pytest.approx(0.0)

--- a/tests/test_blender_seed_stability_metrics.py
+++ b/tests/test_blender_seed_stability_metrics.py
@@ -63,3 +63,81 @@ def test_load_exr_stack_raises_on_missing_file(tmp_path) -> None:
     with pytest.raises(FileNotFoundError) as excinfo:
         ssm.load_exr_stack([a, missing])
     assert "missing.exr" in str(excinfo.value)
+
+
+def test_per_pixel_stack_stats_shape_and_dtype() -> None:
+    rng = np.random.default_rng(0)
+    stack = rng.random((5, 4, 4, 3), dtype=np.float32)
+    mean, std = ssm.per_pixel_stack_stats(stack)
+    assert mean.dtype == np.float32 and std.dtype == np.float32
+    assert mean.shape == (4, 4, 3) and std.shape == (4, 4, 3)
+
+
+def test_per_pixel_stack_stats_zero_for_identical_inputs() -> None:
+    base = np.full((4, 4, 3), 0.42, dtype=np.float32)
+    stack = np.stack([base, base, base, base], axis=0)
+    mean, std = ssm.per_pixel_stack_stats(stack)
+    assert np.allclose(mean, 0.42)
+    assert np.allclose(std, 0.0)
+
+
+def test_per_pixel_stack_stats_matches_numpy_population_std() -> None:
+    rng = np.random.default_rng(7)
+    stack = rng.random((6, 3, 3, 3), dtype=np.float32)
+    _, std = ssm.per_pixel_stack_stats(stack)
+    assert np.allclose(std, np.std(stack, axis=0, ddof=0), atol=1e-6)
+
+
+def test_crop_returns_a_view_into_the_image() -> None:
+    image = np.zeros((10, 10, 3), dtype=np.float32)
+    image[2:5, 3:6, :] = 0.7
+    crop = ssm.crop(image, [3, 2, 6, 5])
+    assert crop.shape == (3, 3, 3)
+    assert np.allclose(crop, 0.7)
+
+
+def test_crop_raises_on_empty_box() -> None:
+    image = np.zeros((10, 10, 3), dtype=np.float32)
+    with pytest.raises(ValueError):
+        ssm.crop(image, [3, 3, 3, 3])
+
+
+def test_group_means_collapses_named_rois() -> None:
+    per_roi = {
+        "left_display_case": 0.10,
+        "center_bottle": 0.20,
+        "robot_left_arm": 0.30,
+        "target_cube": 0.40,
+    }
+    grouping = {
+        "glass": ["left_display_case", "center_bottle"],
+        "non_glass": ["robot_left_arm", "target_cube"],
+    }
+    grouped = ssm.group_means(per_roi, grouping)
+    assert np.isclose(grouped["glass"], 0.15)
+    assert np.isclose(grouped["non_glass"], 0.35)
+
+
+def test_metric_runner_rmse_mae_psnr_zero_for_identical_inputs() -> None:
+    runner = ssm.MetricRunner.numerical_only()
+    a = np.full((8, 8, 3), 0.4, dtype=np.float32)
+    b = a.copy()
+    assert runner.rmse(a, b) == pytest.approx(0.0)
+    assert runner.mae(a, b) == pytest.approx(0.0)
+    assert runner.psnr(a, b) >= 99.0
+
+
+def test_metric_runner_psnr_clipping() -> None:
+    runner = ssm.MetricRunner.numerical_only()
+    a = np.zeros((4, 4, 3), dtype=np.float32)
+    b = np.full((4, 4, 3), 0.5, dtype=np.float32)
+    psnr = runner.psnr(a, b)
+    assert 5.0 < psnr < 15.0
+
+
+def test_metric_runner_skips_lpips_and_flip_when_disabled() -> None:
+    runner = ssm.MetricRunner.numerical_only()
+    a = np.zeros((4, 4, 3), dtype=np.float32)
+    b = np.zeros((4, 4, 3), dtype=np.float32)
+    assert runner.lpips(a, b) is None
+    assert runner.flip(a, b) is None

--- a/tests/test_blender_seed_stability_metrics.py
+++ b/tests/test_blender_seed_stability_metrics.py
@@ -223,3 +223,16 @@ def test_vs_reference_metrics_emits_grouped_roi_columns() -> None:
     assert "glass_rmse" in rows[0]
     assert "non_glass_rmse" in rows[0]
     assert rows[0]["glass_rmse"] == pytest.approx(0.0)
+
+
+def test_render_std_map_writes_png_and_returns_max(tmp_path) -> None:
+    rng = np.random.default_rng(4)
+    std_image = rng.random((16, 16, 3), dtype=np.float32) * 0.05
+    out = tmp_path / "std.png"
+    max_value = ssm.render_std_map(std_image, out, color_scale=None)
+    assert out.exists()
+    assert max_value > 0.0
+    second = tmp_path / "std2.png"
+    second_max = ssm.render_std_map(std_image, second, color_scale=max_value)
+    assert second.exists()
+    assert second_max == pytest.approx(max_value)

--- a/tests/test_blender_seed_stability_metrics.py
+++ b/tests/test_blender_seed_stability_metrics.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+from scripts.benchmark.rendering import seed_stability_metrics as ssm
+
+
+def _write_constant_exr(path: Path, value: float, shape: tuple[int, int, int] = (8, 8, 3)) -> None:
+    arr = np.full(shape, value, dtype=np.float32)
+    bgr = arr[..., ::-1]  # cv2 expects BGR
+    path.parent.mkdir(parents=True, exist_ok=True)
+    ok = cv2.imwrite(str(path), bgr)
+    assert ok, f"cv2.imwrite failed for {path}"
+
+
+def test_load_exr_stack_returns_float32_rgb_stack(tmp_path) -> None:
+    paths = []
+    for index, value in enumerate([0.1, 0.2, 0.3]):
+        p = tmp_path / f"img_{index}.exr"
+        _write_constant_exr(p, value)
+        paths.append(p)
+    stack = ssm.load_exr_stack(paths)
+    assert stack.dtype == np.float32
+    assert stack.shape == (3, 8, 8, 3)
+    assert np.allclose(stack[0], 0.1, atol=1e-3)
+    assert np.allclose(stack[2], 0.3, atol=1e-3)
+
+
+def test_load_exr_stack_preserves_rgb_channel_order(tmp_path) -> None:
+    arr = np.zeros((4, 4, 3), dtype=np.float32)
+    arr[..., 0] = 0.9  # R
+    arr[..., 1] = 0.5  # G
+    arr[..., 2] = 0.1  # B
+    path = tmp_path / "rgb.exr"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    bgr = arr[..., ::-1]
+    assert cv2.imwrite(str(path), bgr)
+    stack = ssm.load_exr_stack([path])
+    assert np.allclose(stack[0, ..., 0], 0.9, atol=1e-3)
+    assert np.allclose(stack[0, ..., 1], 0.5, atol=1e-3)
+    assert np.allclose(stack[0, ..., 2], 0.1, atol=1e-3)
+
+
+def test_load_exr_stack_raises_on_shape_mismatch(tmp_path) -> None:
+    a = tmp_path / "a.exr"
+    b = tmp_path / "b.exr"
+    _write_constant_exr(a, 0.1, shape=(8, 8, 3))
+    _write_constant_exr(b, 0.1, shape=(16, 16, 3))
+    with pytest.raises(ValueError) as excinfo:
+        ssm.load_exr_stack([a, b])
+    assert "shape mismatch" in str(excinfo.value).lower()
+    assert "b.exr" in str(excinfo.value)
+
+
+def test_load_exr_stack_raises_on_missing_file(tmp_path) -> None:
+    a = tmp_path / "a.exr"
+    _write_constant_exr(a, 0.1)
+    missing = tmp_path / "missing.exr"
+    with pytest.raises(FileNotFoundError) as excinfo:
+        ssm.load_exr_stack([a, missing])
+    assert "missing.exr" in str(excinfo.value)

--- a/tests/test_blender_seed_stability_metrics.py
+++ b/tests/test_blender_seed_stability_metrics.py
@@ -141,3 +141,39 @@ def test_metric_runner_skips_lpips_and_flip_when_disabled() -> None:
     b = np.zeros((4, 4, 3), dtype=np.float32)
     assert runner.lpips(a, b) is None
     assert runner.flip(a, b) is None
+
+
+def test_pairwise_metrics_zero_rmse_for_identical_inputs() -> None:
+    img = np.full((4, 4, 3), 0.5, dtype=np.float32)
+    stack = np.stack([img, img, img], axis=0)
+    summary = ssm.pairwise_metrics(stack, runner=ssm.MetricRunner.numerical_only(), roi_boxes=None, roi_grouping=None)
+    assert summary["global"]["rmse"]["mean"] == pytest.approx(0.0)
+    assert summary["global"]["mae"]["mean"] == pytest.approx(0.0)
+    assert summary["global"]["rmse"]["std"] == pytest.approx(0.0)
+
+
+def test_pairwise_metrics_counts_unordered_pairs() -> None:
+    rng = np.random.default_rng(1)
+    stack = rng.random((4, 4, 4, 3), dtype=np.float32)
+    summary = ssm.pairwise_metrics(stack, runner=ssm.MetricRunner.numerical_only(), roi_boxes=None, roi_grouping=None)
+    assert summary["global"]["rmse"]["n_pairs"] == 6
+
+
+def test_pairwise_metrics_emits_grouped_roi_keys() -> None:
+    rng = np.random.default_rng(2)
+    stack = rng.random((3, 8, 8, 3), dtype=np.float32)
+    boxes = {"glass_a": [0, 0, 4, 4], "non_glass_a": [4, 4, 8, 8]}
+    grouping = {"glass": ["glass_a"], "non_glass": ["non_glass_a"]}
+    summary = ssm.pairwise_metrics(
+        stack, runner=ssm.MetricRunner.numerical_only(), roi_boxes=boxes, roi_grouping=grouping
+    )
+    assert "glass" in summary
+    assert "non_glass" in summary
+    assert summary["glass"]["rmse"]["n_pairs"] == 3
+
+
+def test_pairwise_metrics_raises_for_fewer_than_two_images() -> None:
+    img = np.zeros((4, 4, 3), dtype=np.float32)
+    stack = np.stack([img], axis=0)
+    with pytest.raises(ValueError):
+        ssm.pairwise_metrics(stack, runner=ssm.MetricRunner.numerical_only(), roi_boxes=None, roi_grouping=None)

--- a/tests/test_blender_seed_stability_section.py
+++ b/tests/test_blender_seed_stability_section.py
@@ -1,0 +1,439 @@
+from __future__ import annotations
+
+import csv
+import shlex
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+from scripts.benchmark.rendering import seed_stability_metrics as ssm
+from scripts.benchmark.rendering import write_seed_stability_section as section
+
+
+def _write_constant_exr(path: Path, value: float, shape: tuple[int, int, int] = (8, 8, 3)) -> None:
+    arr = np.full(shape, value, dtype=np.float32)
+    bgr = arr[..., ::-1]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cv2.imwrite(str(path), bgr)
+
+
+def _write_runs_csv(scene_dir: Path, rows: list[dict[str, str]]) -> None:
+    fieldnames = list(rows[0].keys())
+    scene_dir.mkdir(parents=True, exist_ok=True)
+    with (scene_dir / "runs.csv").open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _write_matrix_driver_csv(root: Path, rows: list[dict[str, str]]) -> None:
+    with (root / "matrix_driver.csv").open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=["label", "command", "return_code", "elapsed_s", "status"])
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _command_with_seed(seed: int, samples: int, output_root: Path, scene: str = "complex_glass_cube_reach") -> str:
+    args = [
+        "/usr/bin/python",
+        "render_benchmark.py",
+        "render",
+        "--scene",
+        scene,
+        "--samples",
+        str(samples),
+        "--denoiser",
+        "off" if samples == 4096 else "on",
+        "--seed",
+        str(seed),
+        "--output-root",
+        str(output_root),
+    ]
+    return shlex.join(args)
+
+
+def test_discover_seed_variance_runs_groups_by_setting(tmp_path) -> None:
+    scene = "complex_glass_cube_reach"
+    scene_dir = tmp_path / scene
+    runs_rows = []
+    driver_rows = []
+    for samples in (64, 4096):
+        for seed in range(2026, 2029):
+            cmd = _command_with_seed(seed, samples, tmp_path)
+            run_id = f"run_{samples}_{seed}"
+            exr = scene_dir / "runs" / run_id / "overview_00" / "frame_000000.exr"
+            _write_constant_exr(exr, 0.3)
+            kind = "reference" if samples == 4096 else "spp_sweep"
+            runs_rows.append({
+                "scene": scene,
+                "run_id": run_id,
+                "kind": kind,
+                "status": "ok",
+                "samples": str(samples),
+                "denoiser": "off" if samples == 4096 else "on",
+                "seed": str(seed),
+                "profile": "",
+                "output_path": str(exr),
+                "command": cmd,
+            })
+            label = f"{scene}:seed_variance:spp:{samples}spp:seed{seed}"
+            driver_rows.append({"label": label, "command": cmd, "return_code": "0", "elapsed_s": "1.0", "status": "ok"})
+    _write_runs_csv(scene_dir, runs_rows)
+    _write_matrix_driver_csv(tmp_path, driver_rows)
+
+    grouped = section.discover_seed_variance_runs(root=tmp_path, scene=scene)
+
+    assert "spp_64spp" in grouped
+    assert "spp_4096spp" in grouped
+    assert len(grouped["spp_64spp"]) == 3
+    assert len(grouped["spp_4096spp"]) == 3
+    for entry in grouped["spp_64spp"]:
+        assert entry["seed"] in {2026, 2027, 2028}
+        assert entry["exr"].exists()
+
+
+def test_discover_dedupes_same_setting_seed_pair(tmp_path) -> None:
+    scene = "complex_glass_cube_reach"
+    scene_dir = tmp_path / scene
+    runs_rows = []
+    driver_rows = []
+    cmd = _command_with_seed(2026, 64, tmp_path)
+    for run_index in range(2):
+        run_id = f"r_dup_{run_index}"
+        exr = scene_dir / "runs" / run_id / "overview_00" / "frame_000000.exr"
+        _write_constant_exr(exr, 0.3)
+        runs_rows.append({
+            "scene": scene,
+            "run_id": run_id,
+            "kind": "spp_sweep",
+            "status": "ok",
+            "samples": "64",
+            "denoiser": "on",
+            "seed": "2026",
+            "profile": "",
+            "output_path": str(exr),
+            "command": cmd,
+        })
+        driver_rows.append({
+            "label": f"{scene}:seed_variance:spp:64spp:seed2026",
+            "command": cmd,
+            "return_code": "0",
+            "elapsed_s": "1.0",
+            "status": "ok",
+        })
+    _write_runs_csv(scene_dir, runs_rows)
+    _write_matrix_driver_csv(tmp_path, driver_rows)
+
+    grouped = section.discover_seed_variance_runs(root=tmp_path, scene=scene)
+    assert len(grouped["spp_64spp"]) == 1
+    assert grouped["spp_64spp"][0]["run_row"]["run_id"] == "r_dup_1"
+
+
+def test_discover_skips_failed_rows(tmp_path) -> None:
+    scene = "complex_glass_cube_reach"
+    scene_dir = tmp_path / scene
+    runs_rows = []
+    driver_rows = []
+    for seed in range(2026, 2029):
+        cmd = _command_with_seed(seed, 64, tmp_path)
+        run_id = f"run_{seed}"
+        exr = scene_dir / "runs" / run_id / "overview_00" / "frame_000000.exr"
+        if seed != 2027:
+            _write_constant_exr(exr, 0.3)
+        runs_rows.append({
+            "scene": scene,
+            "run_id": run_id,
+            "kind": "spp_sweep",
+            "status": "ok" if seed != 2027 else "failed",
+            "samples": "64",
+            "denoiser": "on",
+            "seed": str(seed),
+            "profile": "",
+            "output_path": str(exr) if seed != 2027 else "",
+            "command": cmd,
+        })
+        driver_rows.append({
+            "label": f"{scene}:seed_variance:spp:64spp:seed{seed}",
+            "command": cmd,
+            "return_code": "0",
+            "elapsed_s": "1.0",
+            "status": "ok",
+        })
+    _write_runs_csv(scene_dir, runs_rows)
+    _write_matrix_driver_csv(tmp_path, driver_rows)
+
+    grouped = section.discover_seed_variance_runs(root=tmp_path, scene=scene)
+    assert len(grouped["spp_64spp"]) == 2
+    assert {entry["seed"] for entry in grouped["spp_64spp"]} == {2026, 2028}
+
+
+def test_compute_setting_metrics_writes_pairwise_and_vs_reference_csvs(tmp_path) -> None:
+    scene = "complex_glass_cube_reach"
+    scene_dir = tmp_path / scene
+    runs_rows = []
+    driver_rows = []
+    for seed in range(2026, 2030):
+        cmd = _command_with_seed(seed, 64, tmp_path)
+        run_id = f"r_{seed}"
+        exr = scene_dir / "runs" / run_id / "overview_00" / "frame_000000.exr"
+        rng = np.random.default_rng(seed)
+        arr = np.full((8, 8, 3), 0.3, dtype=np.float32) + rng.normal(0, 0.005, (8, 8, 3)).astype(np.float32)
+        exr.parent.mkdir(parents=True, exist_ok=True)
+        assert cv2.imwrite(str(exr), arr[..., ::-1])
+        runs_rows.append({
+            "scene": scene,
+            "run_id": run_id,
+            "kind": "spp_sweep",
+            "status": "ok",
+            "samples": "64",
+            "denoiser": "on",
+            "seed": str(seed),
+            "profile": "",
+            "output_path": str(exr),
+            "command": cmd,
+        })
+        driver_rows.append({
+            "label": f"{scene}:seed_variance:spp:64spp:seed{seed}",
+            "command": cmd,
+            "return_code": "0",
+            "elapsed_s": "1.0",
+            "status": "ok",
+        })
+    _write_runs_csv(scene_dir, runs_rows)
+    _write_matrix_driver_csv(tmp_path, driver_rows)
+
+    reference = tmp_path / "ref.exr"
+    _write_constant_exr(reference, 0.3)
+
+    boxes = {"glass_a": [0, 0, 4, 4], "non_glass_a": [4, 4, 8, 8]}
+    grouping = {"glass": ["glass_a"], "non_glass": ["non_glass_a"]}
+
+    out_dir = section.compute_setting_metrics(
+        root=tmp_path,
+        scene=scene,
+        reference_exr=reference,
+        roi_boxes=boxes,
+        roi_grouping=grouping,
+        runner=ssm.MetricRunner.numerical_only(),
+    )
+
+    pairwise = list(csv.DictReader((out_dir / "pairwise_summary.csv").open(encoding="utf-8")))
+    assert any(row["setting"] == "spp_64spp" for row in pairwise)
+    vs_ref = list(csv.DictReader((out_dir / "vs_reference_summary.csv").open(encoding="utf-8")))
+    assert len(vs_ref) == 4
+
+
+def test_contact_sheet_collects_all_std_maps(tmp_path) -> None:
+    out_dir = tmp_path / "complex_glass_cube_reach" / "analysis" / "seed_stability"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for name in ("spp_8spp", "spp_64spp", "glass_glass_default"):
+        (out_dir / f"{name}_std_map.png").write_bytes(b"\x89PNG\r\n\x1a\n")  # placeholder
+    sheet = section.write_contact_sheet(out_dir)
+    assert sheet.exists()
+    assert sheet.name == "seed_stability_contact_sheet.png"
+
+
+def test_rmse_vs_spp_plot_writes_png(tmp_path) -> None:
+    out = tmp_path / "rmse_vs_spp.png"
+    pairs = {
+        "spp_8spp": (0.020, 0.022),
+        "spp_64spp": (0.005, 0.010),
+        "spp_256spp": (0.002, 0.007),
+        "spp_1024spp": (0.001, 0.005),
+    }
+    section.write_rmse_vs_spp_plot(pairs, out)
+    assert out.exists()
+
+
+def test_rmse_vs_spp_plot_handles_missing_vs_reference(tmp_path) -> None:
+    out = tmp_path / "rmse_vs_spp.png"
+    pairs = {"spp_8spp": (0.020, None), "spp_64spp": (0.005, None)}
+    section.write_rmse_vs_spp_plot(pairs, out)
+    assert out.exists()
+
+
+def test_interpret_setting_classifies_noise_dominated() -> None:
+    text = section.interpret_setting(setting_key="spp_8spp", pairwise_rmse=0.020, vs_reference_rmse=0.022)
+    assert "noise" in text.lower() or "more samples" in text.lower()
+
+
+def test_interpret_setting_classifies_structural() -> None:
+    text = section.interpret_setting(setting_key="glass_glass_fast", pairwise_rmse=0.005, vs_reference_rmse=0.067)
+    assert "structural" in text.lower()
+
+
+def test_interpret_setting_handles_zero_reference() -> None:
+    text = section.interpret_setting(setting_key="spp_4096spp", pairwise_rmse=0.001, vs_reference_rmse=0.0)
+    assert text
+
+
+def test_write_section_returns_markdown_with_three_tables_and_interpretation(tmp_path) -> None:
+    scene = "complex_glass_cube_reach"
+    scene_dir = tmp_path / scene
+    runs_rows = []
+    driver_rows = []
+    for samples in (8, 64, 256):
+        for seed in range(2026, 2029):
+            cmd = _command_with_seed(seed, samples, tmp_path)
+            run_id = f"r_{samples}_{seed}"
+            exr = scene_dir / "runs" / run_id / "overview_00" / "frame_000000.exr"
+            rng = np.random.default_rng(seed * samples)
+            noise = 0.05 / np.sqrt(samples)
+            arr = np.full((8, 8, 3), 0.3, dtype=np.float32) + rng.normal(0, noise, (8, 8, 3)).astype(np.float32)
+            exr.parent.mkdir(parents=True, exist_ok=True)
+            assert cv2.imwrite(str(exr), arr[..., ::-1])
+            runs_rows.append({
+                "scene": scene,
+                "run_id": run_id,
+                "kind": "spp_sweep",
+                "status": "ok",
+                "samples": str(samples),
+                "denoiser": "on",
+                "seed": str(seed),
+                "profile": "",
+                "output_path": str(exr),
+                "command": cmd,
+            })
+            driver_rows.append({
+                "label": f"{scene}:seed_variance:spp:{samples}spp:seed{seed}",
+                "command": cmd,
+                "return_code": "0",
+                "elapsed_s": "1.0",
+                "status": "ok",
+            })
+    _write_runs_csv(scene_dir, runs_rows)
+    _write_matrix_driver_csv(tmp_path, driver_rows)
+
+    reference = tmp_path / "ref.exr"
+    _write_constant_exr(reference, 0.3)
+
+    md = section.write_section(
+        root=tmp_path,
+        scene=scene,
+        reference_exr=reference,
+        roi_boxes=None,
+        roi_grouping=None,
+        runner=ssm.MetricRunner.numerical_only(),
+    )
+    assert "## Seed Stability" in md
+    assert "Table 1" in md or "Pairwise" in md
+    assert "Table 2" in md or "vs reference" in md.lower()
+    assert "Table 3" in md or "Per-pixel std" in md
+    assert "Interpretation" in md
+    out_dir = scene_dir / "analysis" / "seed_stability"
+    assert (out_dir / "seed_stability_contact_sheet.png").exists()
+    assert (out_dir / "rmse_vs_spp.png").exists()
+
+
+def test_write_section_handles_missing_reference(tmp_path) -> None:
+    scene = "complex_glass_cube_reach"
+    scene_dir = tmp_path / scene
+    runs_rows = []
+    driver_rows = []
+    for seed in range(2026, 2029):
+        cmd = _command_with_seed(seed, 64, tmp_path)
+        run_id = f"r_{seed}"
+        exr = scene_dir / "runs" / run_id / "overview_00" / "frame_000000.exr"
+        _write_constant_exr(exr, 0.3)
+        runs_rows.append({
+            "scene": scene,
+            "run_id": run_id,
+            "kind": "spp_sweep",
+            "status": "ok",
+            "samples": "64",
+            "denoiser": "on",
+            "seed": str(seed),
+            "profile": "",
+            "output_path": str(exr),
+            "command": cmd,
+        })
+        driver_rows.append({
+            "label": f"{scene}:seed_variance:spp:64spp:seed{seed}",
+            "command": cmd,
+            "return_code": "0",
+            "elapsed_s": "1.0",
+            "status": "ok",
+        })
+    _write_runs_csv(scene_dir, runs_rows)
+    _write_matrix_driver_csv(tmp_path, driver_rows)
+
+    md = section.write_section(
+        root=tmp_path,
+        scene=scene,
+        reference_exr=tmp_path / "missing.exr",
+        roi_boxes=None,
+        roi_grouping=None,
+        runner=ssm.MetricRunner.numerical_only(),
+    )
+    assert "Seed Stability" in md
+    assert "vs-reference block skipped" in md.lower() or "reference not available" in md.lower()
+
+
+def test_write_section_skips_settings_with_fewer_than_three_seeds(tmp_path) -> None:
+    scene = "complex_glass_cube_reach"
+    scene_dir = tmp_path / scene
+    runs_rows = []
+    driver_rows = []
+    for seed in (2026, 2027):
+        cmd = _command_with_seed(seed, 64, tmp_path)
+        run_id = f"r_{seed}"
+        exr = scene_dir / "runs" / run_id / "overview_00" / "frame_000000.exr"
+        _write_constant_exr(exr, 0.3)
+        runs_rows.append({
+            "scene": scene,
+            "run_id": run_id,
+            "kind": "spp_sweep",
+            "status": "ok",
+            "samples": "64",
+            "denoiser": "on",
+            "seed": str(seed),
+            "profile": "",
+            "output_path": str(exr),
+            "command": cmd,
+        })
+        driver_rows.append({
+            "label": f"{scene}:seed_variance:spp:64spp:seed{seed}",
+            "command": cmd,
+            "return_code": "0",
+            "elapsed_s": "1.0",
+            "status": "ok",
+        })
+    for seed in range(2026, 2029):
+        cmd = _command_with_seed(seed, 256, tmp_path)
+        run_id = f"r2_{seed}"
+        exr = scene_dir / "runs" / run_id / "overview_00" / "frame_000000.exr"
+        _write_constant_exr(exr, 0.3)
+        runs_rows.append({
+            "scene": scene,
+            "run_id": run_id,
+            "kind": "spp_sweep",
+            "status": "ok",
+            "samples": "256",
+            "denoiser": "on",
+            "seed": str(seed),
+            "profile": "",
+            "output_path": str(exr),
+            "command": cmd,
+        })
+        driver_rows.append({
+            "label": f"{scene}:seed_variance:spp:256spp:seed{seed}",
+            "command": cmd,
+            "return_code": "0",
+            "elapsed_s": "1.0",
+            "status": "ok",
+        })
+    _write_runs_csv(scene_dir, runs_rows)
+    _write_matrix_driver_csv(tmp_path, driver_rows)
+
+    md = section.write_section(
+        root=tmp_path,
+        scene=scene,
+        reference_exr=None,
+        roi_boxes=None,
+        roi_grouping=None,
+        runner=ssm.MetricRunner.numerical_only(),
+    )
+    assert "insufficient seeds" in md.lower() or "needs ≥ 3" in md.lower() or "skipped" in md.lower()

--- a/tests/test_blender_usd_compat.py
+++ b/tests/test_blender_usd_compat.py
@@ -1,0 +1,115 @@
+import json
+from pathlib import Path
+
+from roboverse_pack.blender.usd import compat
+
+
+def test_blender_overlay_paths_are_adjacent_and_cache_mirrors_parent(tmp_path):
+    source = tmp_path / "rooms" / "kitchen.usda"
+    source.parent.mkdir()
+    source.write_text("#usda 1.0\n", encoding="utf-8")
+
+    paths = compat.blender_overlay_paths(source)
+    cache_suffix = Path(*source.parent.parts[1:])
+
+    assert paths.source == source
+    assert paths.overlay == source.with_suffix(".blender_materials.usda")
+    assert paths.root == source.with_suffix(".blender_root.usda")
+    assert paths.cache == Path("roboverse_data/material_cache") / cache_suffix
+    assert paths.manifest == paths.cache / "kitchen.blender_overlay_manifest.json"
+
+
+def test_manifest_currentness_uses_source_hash_and_required_outputs(tmp_path):
+    source = tmp_path / "scene.usda"
+    overlay = tmp_path / "scene.blender_materials.usda"
+    root = tmp_path / "scene.blender_root.usda"
+    manifest = tmp_path / "manifest.json"
+    source.write_text("one", encoding="utf-8")
+    overlay.write_text("overlay", encoding="utf-8")
+    root.write_text("root", encoding="utf-8")
+
+    compat.write_manifest(manifest, source=source, overlay=overlay, root=root)
+    assert compat.is_overlay_current(source, overlay, root, manifest)
+
+    source.write_text("two", encoding="utf-8")
+    assert not compat.is_overlay_current(source, overlay, root, manifest)
+
+    manifest.write_text(json.dumps({"schema_version": 2}), encoding="utf-8")
+    assert not compat.is_overlay_current(source, overlay, root, manifest)
+
+
+def test_ensure_blender_material_overlay_reuses_current_manifest(tmp_path, monkeypatch):
+    source = tmp_path / "scene.usda"
+    source.write_text("#usda 1.0\n", encoding="utf-8")
+    paths = compat.blender_overlay_paths(source)
+    paths.cache.mkdir(parents=True, exist_ok=True)
+    paths.overlay.write_text("overlay", encoding="utf-8")
+    paths.root.write_text("root", encoding="utf-8")
+    compat.write_manifest(
+        paths.manifest,
+        source=source,
+        overlay=paths.overlay,
+        root=paths.root,
+        converter_settings={"resolution": 2048, "samples": 16},
+    )
+
+    def fail_generate(*args, **kwargs):
+        raise AssertionError("generate_blender_overlay should not be called")
+
+    monkeypatch.setattr(compat, "generate_blender_overlay", fail_generate)
+
+    assert compat.ensure_blender_material_overlay(source) == paths.root
+
+
+def test_ensure_blender_material_overlay_generates_when_forced(tmp_path, monkeypatch):
+    source = tmp_path / "scene.usda"
+    source.write_text("#usda 1.0\n", encoding="utf-8")
+    calls = []
+
+    def fake_generate(input_path, overlay_path, root_path, texture_cache, resolution, samples):
+        calls.append((input_path, overlay_path, root_path, texture_cache, resolution, samples))
+        overlay_path.write_text("overlay", encoding="utf-8")
+        root_path.write_text("root", encoding="utf-8")
+        return {"materials": {}}
+
+    monkeypatch.setattr(compat, "generate_blender_overlay", fake_generate)
+
+    root = compat.ensure_blender_material_overlay(source, force=True, resolution=1024, samples=4)
+    paths = compat.blender_overlay_paths(source)
+
+    assert root == paths.root
+    assert paths.manifest.exists()
+    assert calls == [(source, paths.overlay, paths.root, paths.cache, 1024, 4)]
+
+
+def test_manifest_currentness_compares_converter_settings(tmp_path):
+    source = tmp_path / "scene.usda"
+    overlay = tmp_path / "scene.blender_materials.usda"
+    root = tmp_path / "scene.blender_root.usda"
+    manifest = tmp_path / "manifest.json"
+    source.write_text("#usda 1.0\n", encoding="utf-8")
+    overlay.write_text("overlay", encoding="utf-8")
+    root.write_text("root", encoding="utf-8")
+
+    compat.write_manifest(
+        manifest,
+        source=source,
+        overlay=overlay,
+        root=root,
+        converter_settings={"resolution": 1024, "samples": 4},
+    )
+
+    assert compat.is_overlay_current(
+        source,
+        overlay,
+        root,
+        manifest,
+        converter_settings={"resolution": 1024, "samples": 4},
+    )
+    assert not compat.is_overlay_current(
+        source,
+        overlay,
+        root,
+        manifest,
+        converter_settings={"resolution": 2048, "samples": 4},
+    )

--- a/tests/test_box_task_replay.py
+++ b/tests/test_box_task_replay.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from scripts.benchmark.rendering import box_task_replay as replay
+
+
+def test_normalize_scene_token_accepts_supported_forms() -> None:
+    assert replay.normalize_scene_token("009") == "kujiale_scene_0009"
+    assert replay.normalize_scene_token("0009") == "kujiale_scene_0009"
+    assert replay.normalize_scene_token("usd_021") == "kujiale_scene_0021"
+    assert replay.normalize_scene_token("kujiale_scene_0031") == "kujiale_scene_0031"
+    assert replay.normalize_scene_token("kujiale_scene_0031.usda") == "kujiale_scene_0031"
+
+
+def test_normalize_scene_token_rejects_unknown_form() -> None:
+    with pytest.raises(ValueError, match="Scene token must be 3 or 4 digits"):
+        replay.normalize_scene_token("21")
+    with pytest.raises(ValueError, match="Invalid scene token"):
+        replay.normalize_scene_token("kitchen")
+
+
+def test_parse_scene_tokens_preserves_order() -> None:
+    assert replay.parse_scene_tokens("0021,0022,0031") == [
+        "kujiale_scene_0021",
+        "kujiale_scene_0022",
+        "kujiale_scene_0031",
+    ]
+
+
+def test_compute_output_frames_uses_one_source_when_duration_absent() -> None:
+    assert replay.compute_output_frames(src_total_frames=849, fps=30, duration_sec=None, out_frames=None) == 849
+
+
+def test_compute_output_frames_rejects_ambiguous_length() -> None:
+    with pytest.raises(ValueError, match="Use either --out-frames or --duration-sec"):
+        replay.compute_output_frames(src_total_frames=849, fps=30, duration_sec=1.0, out_frames=10)
+
+
+def test_frame_to_source_indices_evenly_samples_source() -> None:
+    indices = replay.frame_to_source_indices(src_total_frames=9, out_frames=5)
+    assert indices.dtype == np.int32
+    assert indices.tolist() == [0, 2, 4, 6, 8]
+
+
+def test_scene_frame_bounds_split_video_evenly() -> None:
+    bounds = replay.scene_frame_bounds(out_frames=10, scene_count=3)
+    assert bounds == [(0, 3), (3, 6), (6, 10)]
+
+
+def test_scene_frame_bounds_rejects_more_scenes_than_frames() -> None:
+    with pytest.raises(ValueError, match="scene_count must not exceed out_frames"):
+        replay.scene_frame_bounds(out_frames=3, scene_count=4)
+
+
+def test_finger_joint_map_rewrites_legacy_hand_names() -> None:
+    mapping = replay.build_finger_joint_map()
+    assert mapping["left_hand_finger1_joint1"] == "left_finger1_joint1"
+    assert mapping["right_hand_finger5_joint4"] == "right_finger5_joint4"
+    assert len(mapping) == 40
+
+
+def test_patch_state_for_replay_rewrites_nested_robot_legacy_keys() -> None:
+    state = {
+        "robots": {
+            "openarm_wuji": {
+                "dof_pos": {"left_hand_finger1_joint1": 1.25},
+                "dof_vel": {"right_hand_finger5_joint4": -0.5},
+            }
+        }
+    }
+
+    patched = replay.patch_state_for_replay(state)
+
+    robot_state = patched["robots"]["openarm_wuji"]
+    assert robot_state["dof_pos"] == {"left_finger1_joint1": 1.25}
+    assert robot_state["dof_vel"] == {"right_finger5_joint4": -0.5}
+
+
+def test_patch_state_for_replay_does_not_mutate_input() -> None:
+    state = {"robots": {"openarm_wuji": {"dof_pos": {"left_hand_finger1_joint1": 1.25}}}}
+
+    replay.patch_state_for_replay(state)
+
+    assert state == {"robots": {"openarm_wuji": {"dof_pos": {"left_hand_finger1_joint1": 1.25}}}}
+
+
+def test_patch_state_for_replay_preserves_existing_canonical_value() -> None:
+    state = {
+        "robots": {
+            "openarm_wuji": {
+                "dof_pos": {
+                    "left_hand_finger1_joint1": "legacy",
+                    "left_finger1_joint1": "canonical",
+                }
+            }
+        }
+    }
+
+    patched = replay.patch_state_for_replay(state)
+
+    dof_pos = patched["robots"]["openarm_wuji"]["dof_pos"]
+    assert dof_pos == {"left_finger1_joint1": "canonical"}
+
+
+def test_patch_state_for_replay_ignores_non_dict_fields() -> None:
+    state = {"robots": {"openarm_wuji": {"dof_pos": ["left_hand_finger1_joint1"], "dof_vel": None}}}
+
+    assert replay.patch_state_for_replay(state) == state
+
+
+def test_bundle_paths_validate_required_files(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    (bundle / "assets" / "traj").mkdir(parents=True)
+    (bundle / "assets" / "local_pack_box" / "cardboard_box").mkdir(parents=True)
+    (bundle / "assets" / "local_pack_box" / "feast_soda_can").mkdir(parents=True)
+    (bundle / "assets" / "local_pack_box" / "feast_scented_candle").mkdir(parents=True)
+    (bundle / "assets" / "traj" / "task.pkl").write_bytes(b"pickle-bytes")
+    for rel in (
+        "assets/local_pack_box/cardboard_box/cardboard_box.usd",
+        "assets/local_pack_box/feast_soda_can/feast_soda_can.usd",
+        "assets/local_pack_box/feast_scented_candle/feast_scented_candle.usd",
+    ):
+        (bundle / rel).write_text("#usda\n", encoding="utf-8")
+
+    paths = replay.BoxTaskBundlePaths.from_root(bundle, traj_path=bundle / "assets/traj/task.pkl")
+
+    assert paths.bundle_root == bundle.resolve()
+    assert paths.traj_path.name == "task.pkl"
+    assert paths.cardboard_box_usd.name == "cardboard_box.usd"
+
+
+def test_bundle_paths_report_missing_traj_first(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError, match="task3_meshycup_openarm_wuji_20260513_232823_0_v2.pkl"):
+        replay.BoxTaskBundlePaths.from_root(tmp_path)
+
+
+def test_bundle_paths_report_missing_cardboard_after_traj(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    (bundle / "assets" / "traj").mkdir(parents=True)
+    (bundle / "assets" / "traj" / "task.pkl").write_bytes(b"pickle-bytes")
+
+    with pytest.raises(FileNotFoundError, match="cardboard_box.usd"):
+        replay.BoxTaskBundlePaths.from_root(bundle, traj_path=bundle / "assets/traj/task.pkl")
+
+
+def test_bundle_paths_reject_directory_where_file_required(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    (bundle / "assets" / "traj" / "task.pkl").mkdir(parents=True)
+
+    with pytest.raises(FileNotFoundError, match="task.pkl"):
+        replay.BoxTaskBundlePaths.from_root(bundle, traj_path=bundle / "assets/traj/task.pkl")

--- a/tests/test_box_task_replay.py
+++ b/tests/test_box_task_replay.py
@@ -76,6 +76,8 @@ def _install_fake_metasim_without_renderer_scene(monkeypatch: pytest.MonkeyPatch
     }
     modules["metasim.constants"].PhysicStateType = SimpleNamespace(RIGIDBODY="rigidbody")
     modules["metasim.scenario.cameras"].PinholeCameraCfg = SimpleCfg
+    modules["metasim.scenario.lights"].DistantLightCfg = SimpleCfg
+    modules["metasim.scenario.lights"].DomeLightCfg = SimpleCfg
     modules["metasim.scenario.lights"].SphereLightCfg = SimpleCfg
     modules["metasim.scenario.objects"].PrimitiveCubeCfg = SimpleCfg
     modules["metasim.scenario.objects"].RigidObjCfg = SimpleCfg
@@ -559,9 +561,15 @@ def test_build_box_task_scenario_uses_bundle_assets(tmp_path: Path) -> None:
     assert objects["cardboard_box"].usd_path == str(paths.cardboard_box_usd)
     assert objects["feast_soda_can"].usd_path == str(paths.soda_can_usd)
     assert objects["feast_scented_candle"].usd_path == str(paths.scented_candle_usd)
-    assert scenario.lights[0].name == "overhead_light"
-    assert "spherelight" in _cfg_class_name(scenario.lights[0])
-    assert scenario.lights[0].intensity == 1200.0
+    lights = {light.name: light for light in scenario.lights}
+    assert "domelight" in _cfg_class_name(lights["box_task_dome"])
+    assert lights["box_task_dome"].intensity == 400.0
+    assert "distantlight" in _cfg_class_name(lights["box_task_key"])
+    assert lights["box_task_key"].intensity == 2000.0
+    assert lights["box_task_key"].polar == 35.0
+    assert lights["box_task_key"].azimuth == -35.0
+    assert "spherelight" in _cfg_class_name(lights["overhead_light"])
+    assert lights["overhead_light"].intensity == 1200.0
     assert scenario.sim_params.dt == 0.005
     assert scenario.decimation == 4
     assert _render_mode(scenario.render) == "pathtracing"

--- a/tests/test_box_task_replay.py
+++ b/tests/test_box_task_replay.py
@@ -257,6 +257,53 @@ def test_disable_metasim_forced_exit_on_close_overrides_default(monkeypatch: pyt
     assert os.environ["METASIM_FORCE_EXIT_ON_CLOSE"] == "0"
 
 
+def test_local_bundle_decode_runtime_restores_process_wide_patches(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeSettings:
+        def __init__(self) -> None:
+            self.values: dict[str, str] = {}
+
+        def set_string(self, key: str, value: str) -> None:
+            self.values[key] = value
+
+    class FakeHandler:
+        def _load_render_settings(self) -> None:
+            raise ModuleNotFoundError("No module named 'omni.replicator'", name="omni.replicator")
+
+    fake_settings = FakeSettings()
+    fake_carb = ModuleType("carb")
+    fake_carb.settings = SimpleNamespace(get_settings=lambda: fake_settings)
+    fake_isaacsim = ModuleType("metasim.sim.isaacsim.isaacsim")
+    fake_isaacsim.IsaacsimHandler = FakeHandler
+    original_render_settings = FakeHandler._load_render_settings
+    original_download_check = object()
+    fake_hf_util = SimpleNamespace(check_and_download_recursive=original_download_check)
+    monkeypatch.setitem(sys.modules, "carb", fake_carb)
+    monkeypatch.setitem(sys.modules, "metasim.sim.isaacsim.isaacsim", fake_isaacsim)
+    monkeypatch.setenv("METASIM_FORCE_EXIT_ON_CLOSE", "1")
+
+    with replay.local_bundle_decode_runtime(fake_hf_util):
+        assert os.environ["METASIM_FORCE_EXIT_ON_CLOSE"] == "0"
+        assert fake_hf_util.check_and_download_recursive is not original_download_check
+        assert fake_hf_util.check_and_download_recursive(["local"], n_processes=1, optional=True) is None
+        handler = FakeHandler()
+        handler.scenario = SimpleNamespace(render=SimpleNamespace(mode="pathtracing"))
+        handler._load_render_settings()
+        assert fake_settings.values["/rtx/rendermode"] == "PathTracing"
+
+    assert os.environ["METASIM_FORCE_EXIT_ON_CLOSE"] == "1"
+    assert fake_hf_util.check_and_download_recursive is original_download_check
+    assert FakeHandler._load_render_settings is original_render_settings
+
+
+def test_resolve_decode_bundle_paths_prefers_validated_bundle_paths(tmp_path: Path) -> None:
+    paths = _make_bundle(tmp_path)
+    external_traj = tmp_path / "external" / "task.pkl"
+    external_traj.parent.mkdir()
+    external_traj.write_bytes(b"pickle-bytes")
+
+    assert replay.resolve_decode_bundle_paths(external_traj, paths) is paths
+
+
 def test_tensorize_replay_state_converts_pose_arrays_without_mutating_input() -> None:
     state = {
         "objects": {

--- a/tests/test_box_task_replay.py
+++ b/tests/test_box_task_replay.py
@@ -421,6 +421,35 @@ def test_load_raw_v2_pickle_removes_temporary_numpy_aliases(tmp_path: Path, monk
     assert alias_name not in sys.modules
 
 
+def test_decoded_tensor_state_helpers_use_torch_serialization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state_path = tmp_path / "nested" / "decoded.pt"
+    states = {5: "state-5"}
+    calls: dict[str, object] = {}
+    fake_torch = ModuleType("torch")
+
+    def fake_save(payload, path):
+        calls["save"] = (payload, Path(path))
+        Path(path).write_text("serialized", encoding="utf-8")
+
+    def fake_load(path, *, map_location=None, weights_only=None):
+        calls["load"] = (Path(path), map_location, weights_only)
+        return states
+
+    fake_torch.save = fake_save
+    fake_torch.load = fake_load
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    replay.save_decoded_tensor_states(states, state_path)
+    loaded = replay.load_decoded_tensor_states(state_path)
+
+    assert calls["save"] == (states, state_path)
+    assert calls["load"] == (state_path, "cpu", False)
+    assert loaded is states
+
+
 def test_patch_isaacsim_render_settings_falls_back_without_replicator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_box_task_replay.py
+++ b/tests/test_box_task_replay.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import pickle
 import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
@@ -210,6 +212,198 @@ def test_patch_state_for_replay_ignores_non_dict_fields() -> None:
     assert replay.patch_state_for_replay(state) == state
 
 
+def test_patch_openarm_wuji_robot_cfg_rewrites_legacy_joint_config() -> None:
+    legacy_actuator = object()
+    canonical_actuator = object()
+    robot_cfg = SimpleNamespace(
+        name="openarm_wuji",
+        joint_names=["openarm_left_joint1", "left_hand_finger1_joint1"],
+        left_hand_joint_names=["left_hand_finger1_joint1"],
+        right_hand_joint_names=["right_hand_finger5_joint4"],
+        ee_joint_names=["right_hand_finger5_joint4"],
+        joint_limits={
+            "left_hand_finger1_joint1": (-0.5, 1.6),
+            "right_hand_finger1_joint1": (0.058, 1.6),
+        },
+        default_joint_positions={"left_hand_finger1_joint1": 0.1, "right_hand_finger1_joint1": 0.0},
+        actuators={"left_hand_finger1_joint1": legacy_actuator, "left_finger1_joint1": canonical_actuator},
+        control_type={"right_hand_finger5_joint4": "position"},
+        left_ee_body_name="left_hand_palm_link",
+        right_ee_body_name="right_hand_palm_link",
+        ee_body_name="right_hand_palm_link",
+    )
+
+    patched = replay.patch_openarm_wuji_robot_cfg(robot_cfg)
+
+    assert patched is robot_cfg
+    assert robot_cfg.joint_names == ["openarm_left_joint1", "left_finger1_joint1"]
+    assert robot_cfg.left_hand_joint_names == ["left_finger1_joint1"]
+    assert robot_cfg.right_hand_joint_names == ["right_finger5_joint4"]
+    assert robot_cfg.ee_joint_names == ["right_finger5_joint4"]
+    assert robot_cfg.joint_limits == {"left_finger1_joint1": (-0.5, 1.6), "right_finger1_joint1": (0.058, 1.6)}
+    assert robot_cfg.default_joint_positions == {"left_finger1_joint1": 0.1, "right_finger1_joint1": 0.1}
+    assert robot_cfg.actuators == {"left_finger1_joint1": canonical_actuator}
+    assert robot_cfg.control_type == {"right_finger5_joint4": "position"}
+    assert robot_cfg.left_ee_body_name == "left_palm_link"
+    assert robot_cfg.right_ee_body_name == "right_palm_link"
+    assert robot_cfg.ee_body_name == "right_palm_link"
+
+
+def test_disable_metasim_forced_exit_on_close_overrides_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("METASIM_FORCE_EXIT_ON_CLOSE", "1")
+
+    replay.disable_metasim_forced_exit_on_close()
+
+    assert os.environ["METASIM_FORCE_EXIT_ON_CLOSE"] == "0"
+
+
+def test_tensorize_replay_state_converts_pose_arrays_without_mutating_input() -> None:
+    state = {
+        "objects": {
+            "cardboard_box": {
+                "pos": np.array([0.1, 0.2, 0.3]),
+                "rot": [1.0, 0.0, 0.0, 0.0],
+            }
+        },
+        "robots": {
+            "openarm_wuji": {
+                "pos": np.array([0.0, 0.0, 0.0]),
+                "rot": [1.0, 0.0, 0.0, 0.0],
+                "dof_pos": {"left_finger1_joint1": 0.5},
+            }
+        },
+    }
+
+    def fake_tensor(value):
+        if isinstance(value, np.ndarray):
+            return ("tensor", tuple(value.tolist()))
+        return ("tensor", tuple(value))
+
+    tensorized = replay.tensorize_replay_state(state, tensor_factory=fake_tensor)
+
+    assert tensorized["objects"]["cardboard_box"]["pos"] == ("tensor", (0.1, 0.2, 0.3))
+    assert tensorized["objects"]["cardboard_box"]["rot"] == ("tensor", (1.0, 0.0, 0.0, 0.0))
+    assert tensorized["robots"]["openarm_wuji"]["pos"] == ("tensor", (0.0, 0.0, 0.0))
+    assert tensorized["robots"]["openarm_wuji"]["rot"] == ("tensor", (1.0, 0.0, 0.0, 0.0))
+    assert tensorized["robots"]["openarm_wuji"]["dof_pos"] == {"left_finger1_joint1": 0.5}
+    assert isinstance(state["objects"]["cardboard_box"]["pos"], np.ndarray)
+
+
+def test_close_decode_env_without_closing_kit_marks_handler_as_shared() -> None:
+    class FakeHandler:
+        def __init__(self) -> None:
+            self._owns_simulation_app = True
+
+    class FakeEnv:
+        def __init__(self) -> None:
+            self.handler = FakeHandler()
+            self.closed = False
+
+        def close(self) -> None:
+            assert self.handler._owns_simulation_app is False
+            self.closed = True
+
+    env = FakeEnv()
+
+    replay.close_decode_env_without_closing_kit(env)
+
+    assert env.closed is True
+
+
+def test_load_v2_episode_states_converts_first_episode_to_v3_shape(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    flat_state = {
+        "openarm_wuji": {
+            "pos": [0.1, 0.2, 0.3],
+            "rot": [1.0, 0.0, 0.0, 0.0],
+            "dof_pos": {"left_hand_finger1_joint1": 0.4},
+        },
+        "cardboard_box": {"pos": [0.5, 0.0, 0.4], "rot": [1.0, 0.0, 0.0, 0.0]},
+        "feast_soda_can": {"pos": [0.6, 0.1, 0.4], "rot": [1.0, 0.0, 0.0, 0.0]},
+    }
+    flat_init = {
+        "openarm_wuji": {"pos": [0.0, 0.0, 0.0]},
+        "cardboard_box": {"pos": [0.4, 0.0, 0.4]},
+    }
+    payload = {"openarm_wuji": [{"states": [flat_state], "init_state": flat_init}]}
+    monkeypatch.setattr(replay, "load_raw_v2_pickle", lambda path: payload)
+
+    states = replay.load_v2_episode_states(tmp_path / "traj.pkl")
+
+    assert states == [
+        {
+            "robots": {"openarm_wuji": flat_state["openarm_wuji"]},
+            "objects": {
+                "cardboard_box": flat_state["cardboard_box"],
+                "feast_soda_can": flat_state["feast_soda_can"],
+            },
+        }
+    ]
+    assert states[0]["robots"]["openarm_wuji"]["dof_pos"]["left_hand_finger1_joint1"] == 0.4
+
+    init_state = replay.load_v2_init_state(tmp_path / "traj.pkl")
+    assert init_state == {
+        "robots": {"openarm_wuji": flat_init["openarm_wuji"]},
+        "objects": {"cardboard_box": flat_init["cardboard_box"]},
+    }
+
+
+def test_load_v2_episode_states_rejects_empty_states(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    payload = {"openarm_wuji": [{"states": []}]}
+    monkeypatch.setattr(replay, "load_raw_v2_pickle", lambda path: payload)
+
+    with pytest.raises(ValueError, match="states"):
+        replay.load_v2_episode_states(tmp_path / "traj.pkl")
+
+
+def test_load_raw_v2_pickle_removes_temporary_numpy_aliases(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    alias_name = "temporary.numpy.alias"
+    traj_path = tmp_path / "traj.pkl"
+    traj_path.write_bytes(pickle.dumps({"ok": True}))
+
+    def fake_install_aliases() -> list[str]:
+        sys.modules[alias_name] = ModuleType(alias_name)
+        return [alias_name]
+
+    monkeypatch.setattr(replay, "install_numpy_pickle_aliases", fake_install_aliases)
+
+    assert replay.load_raw_v2_pickle(traj_path) == {"ok": True}
+    assert alias_name not in sys.modules
+
+
+def test_patch_isaacsim_render_settings_falls_back_without_replicator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeSettings:
+        def __init__(self) -> None:
+            self.values: dict[str, str] = {}
+
+        def set_string(self, key: str, value: str) -> None:
+            self.values[key] = value
+
+    class FakeHandler:
+        def _load_render_settings(self) -> None:
+            raise ModuleNotFoundError("No module named 'omni.replicator'", name="omni.replicator")
+
+    fake_settings = FakeSettings()
+    fake_carb = ModuleType("carb")
+    fake_carb.settings = SimpleNamespace(get_settings=lambda: fake_settings)
+    fake_isaacsim = ModuleType("metasim.sim.isaacsim.isaacsim")
+    fake_isaacsim.IsaacsimHandler = FakeHandler
+    monkeypatch.setitem(sys.modules, "carb", fake_carb)
+    monkeypatch.setitem(sys.modules, "metasim.sim.isaacsim.isaacsim", fake_isaacsim)
+
+    replay._patch_isaacsim_render_settings_for_decode()
+
+    handler = FakeHandler()
+    handler.scenario = SimpleNamespace(render=SimpleNamespace(mode="pathtracing"))
+    handler._load_render_settings()
+    assert fake_settings.values["/rtx/rendermode"] == "PathTracing"
+
+
 def test_bundle_paths_validate_required_files(tmp_path: Path) -> None:
     bundle = tmp_path / "bundle"
     (bundle / "assets" / "traj").mkdir(parents=True)
@@ -313,6 +507,16 @@ def test_build_decode_scenario_uses_isaacsim() -> None:
         "feast_soda_can",
         "feast_scented_candle",
     }
+
+
+def test_build_decode_scenario_can_use_bundle_object_assets(tmp_path: Path) -> None:
+    paths = _make_bundle(tmp_path)
+    scenario = replay.build_decode_scenario(paths=paths)
+    objects = {obj.name: obj for obj in scenario.objects}
+
+    assert objects["cardboard_box"].usd_path == str(paths.cardboard_box_usd)
+    assert objects["feast_soda_can"].usd_path == str(paths.soda_can_usd)
+    assert objects["feast_scented_candle"].usd_path == str(paths.scented_candle_usd)
 
 
 def test_scenario_builders_set_renderer_and_scene_when_constructor_lacks_fields(

--- a/tests/test_box_task_replay.py
+++ b/tests/test_box_task_replay.py
@@ -1,11 +1,109 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 import numpy as np
 import pytest
 
 from scripts.benchmark.rendering import box_task_replay as replay
+
+
+def _make_bundle(tmp_path: Path) -> replay.BoxTaskBundlePaths:
+    bundle = tmp_path / "bundle"
+    for rel in (
+        "assets/traj",
+        "assets/local_pack_box/cardboard_box",
+        "assets/local_pack_box/feast_soda_can",
+        "assets/local_pack_box/feast_scented_candle",
+    ):
+        (bundle / rel).mkdir(parents=True)
+    (bundle / "assets/traj/task.pkl").write_bytes(b"pickle-bytes")
+    for rel in (
+        "assets/local_pack_box/cardboard_box/cardboard_box.usd",
+        "assets/local_pack_box/feast_soda_can/feast_soda_can.usd",
+        "assets/local_pack_box/feast_scented_candle/feast_scented_candle.usd",
+    ):
+        (bundle / rel).write_text("#usda\n", encoding="utf-8")
+    return replay.BoxTaskBundlePaths.from_root(bundle, traj_path=bundle / "assets/traj/task.pkl")
+
+
+def _install_fake_metasim_without_renderer_scene(monkeypatch: pytest.MonkeyPatch) -> None:
+    class SimpleCfg:
+        def __init__(self, **kwargs):
+            self.__dict__.update(kwargs)
+
+    class ScenarioCfg(SimpleCfg):
+        def __init__(
+            self,
+            *,
+            objects=None,
+            robots=None,
+            cameras=None,
+            lights=None,
+            sim_params=None,
+            decimation=None,
+            simulator=None,
+            headless=None,
+            num_envs=None,
+            render=None,
+        ):
+            super().__init__(
+                objects=objects,
+                robots=robots,
+                cameras=cameras,
+                lights=lights,
+                sim_params=sim_params,
+                decimation=decimation,
+                simulator=simulator,
+                headless=headless,
+                num_envs=num_envs,
+                render=render,
+            )
+
+    modules = {
+        "metasim": ModuleType("metasim"),
+        "metasim.constants": ModuleType("metasim.constants"),
+        "metasim.scenario": ModuleType("metasim.scenario"),
+        "metasim.scenario.cameras": ModuleType("metasim.scenario.cameras"),
+        "metasim.scenario.lights": ModuleType("metasim.scenario.lights"),
+        "metasim.scenario.objects": ModuleType("metasim.scenario.objects"),
+        "metasim.scenario.render": ModuleType("metasim.scenario.render"),
+        "metasim.scenario.scenario": ModuleType("metasim.scenario.scenario"),
+    }
+    modules["metasim.constants"].PhysicStateType = SimpleNamespace(RIGIDBODY="rigidbody")
+    modules["metasim.scenario.cameras"].PinholeCameraCfg = SimpleCfg
+    modules["metasim.scenario.lights"].SphereLightCfg = SimpleCfg
+    modules["metasim.scenario.objects"].PrimitiveCubeCfg = SimpleCfg
+    modules["metasim.scenario.objects"].RigidObjCfg = SimpleCfg
+    modules["metasim.scenario.render"].RenderCfg = SimpleCfg
+    modules["metasim.scenario.scenario"].ScenarioCfg = ScenarioCfg
+    modules["metasim.scenario.scenario"].SimParamCfg = SimpleCfg
+
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+def _cfg_names(items: list[object]) -> list[str]:
+    return [str(getattr(item, "name", item)) for item in items]
+
+
+def _cfg_class_name(item: object) -> str:
+    return type(item).__name__.lower()
+
+
+def _render_mode(render: object) -> str:
+    mode = getattr(render, "mode", render)
+    return str(mode).lower().replace("_", "").replace("-", "")
+
+
+def _assert_kujiale_scene_0021(scene: object) -> None:
+    scene_name = getattr(scene, "name", scene)
+    assert scene_name in ("kujiale_scene_0021", "kujiale_0021")
+    scene_usd_path = getattr(scene, "usd_path", None)
+    if scene_usd_path is not None:
+        assert "021.usda" in str(scene_usd_path)
 
 
 def test_normalize_scene_token_accepts_supported_forms() -> None:
@@ -153,3 +251,89 @@ def test_bundle_paths_reject_directory_where_file_required(tmp_path: Path) -> No
 
     with pytest.raises(FileNotFoundError, match="task.pkl"):
         replay.BoxTaskBundlePaths.from_root(bundle, traj_path=bundle / "assets/traj/task.pkl")
+
+
+def test_build_box_task_scenario_uses_bundle_assets(tmp_path: Path) -> None:
+    paths = _make_bundle(tmp_path)
+
+    scenario = replay.build_box_task_scenario(
+        paths=paths,
+        simulator="blender",
+        scene="kujiale_scene_0021",
+        width=640,
+        height=480,
+        camera_pos=(1.45, -1.0, 0.95),
+        camera_look_at=(0.55, 0.0, 0.38),
+        head_light_intensity=1200.0,
+    )
+
+    objects = {obj.name: obj for obj in scenario.objects}
+    assert scenario.simulator == "blender"
+    assert scenario.renderer == "blender"
+    assert _cfg_names(scenario.robots) == ["openarm_wuji"]
+    assert scenario.headless is True
+    assert scenario.num_envs == 1
+    assert scenario.requested_scene_name == "kujiale_scene_0021"
+    _assert_kujiale_scene_0021(scenario.scene)
+    camera = scenario.cameras[0]
+    assert camera.name == "camera0"
+    assert camera.data_types == ["rgb"]
+    assert camera.width == 640
+    assert camera.height == 480
+    assert tuple(camera.pos) == (1.45, -1.0, 0.95)
+    assert tuple(camera.look_at) == (0.55, 0.0, 0.38)
+    assert "primitivecube" in _cfg_class_name(objects["front_table"])
+    assert "rigidobj" in _cfg_class_name(objects["cardboard_box"])
+    assert "rigidobj" in _cfg_class_name(objects["feast_soda_can"])
+    assert "rigidobj" in _cfg_class_name(objects["feast_scented_candle"])
+    assert objects["cardboard_box"].usd_path == str(paths.cardboard_box_usd)
+    assert objects["feast_soda_can"].usd_path == str(paths.soda_can_usd)
+    assert objects["feast_scented_candle"].usd_path == str(paths.scented_candle_usd)
+    assert scenario.lights[0].name == "overhead_light"
+    assert "spherelight" in _cfg_class_name(scenario.lights[0])
+    assert scenario.lights[0].intensity == 1200.0
+    assert scenario.sim_params.dt == 0.005
+    assert scenario.decimation == 4
+    assert _render_mode(scenario.render) == "pathtracing"
+
+
+def test_build_decode_scenario_uses_isaacsim() -> None:
+    scenario = replay.build_decode_scenario()
+
+    assert scenario.simulator == "isaacsim"
+    assert scenario.renderer == "isaacsim"
+    assert _cfg_names(scenario.robots) == ["openarm_wuji"]
+    assert scenario.headless is True
+    assert scenario.num_envs == 1
+    assert scenario.sim_params.dt == 0.005
+    assert scenario.decimation == 4
+    assert set(_cfg_names(scenario.objects)) >= {
+        "front_table",
+        "cardboard_box",
+        "feast_soda_can",
+        "feast_scented_candle",
+    }
+
+
+def test_scenario_builders_set_renderer_and_scene_when_constructor_lacks_fields(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_fake_metasim_without_renderer_scene(monkeypatch)
+    paths = _make_bundle(tmp_path)
+
+    scenario = replay.build_box_task_scenario(
+        paths=paths,
+        simulator="blender",
+        scene="kujiale_scene_0021",
+        width=640,
+        height=480,
+        camera_pos=(1.45, -1.0, 0.95),
+        camera_look_at=(0.55, 0.0, 0.38),
+        head_light_intensity=1200.0,
+    )
+    decode_scenario = replay.build_decode_scenario()
+
+    assert scenario.renderer == "blender"
+    assert scenario.requested_scene_name == "kujiale_scene_0021"
+    assert scenario.scene == "kujiale_scene_0021"
+    assert decode_scenario.renderer == "isaacsim"

--- a/tests/test_generate_blender_material_overlay.py
+++ b/tests/test_generate_blender_material_overlay.py
@@ -280,7 +280,9 @@ def test_generate_overlay_authors_direct_diffuse_texture_chain_and_reports(tmp_p
     assert (cache / "conversion_report.json").exists()
     assert (cache / "conversion_report.md").exists()
     report = json.loads((cache / "conversion_report.json").read_text(encoding="utf-8"))
-    assert report["materials"]["/World/Looks/Textured"]["status"] == "converted"
+    textured = next(entry for entry in report["materials"] if entry["material_path"] == "/World/Looks/Textured")
+    assert textured["policy"] == "direct_graph"
+    assert textured["slots"]["base_color"]["status"] == "texture"
 
 
 def test_generate_overlay_can_rerun_over_existing_overlay(tmp_path):

--- a/tests/test_generate_blender_material_overlay.py
+++ b/tests/test_generate_blender_material_overlay.py
@@ -1,6 +1,8 @@
 import hashlib
 import json
 import os
+import shutil
+from pathlib import Path
 
 import pytest
 
@@ -12,9 +14,26 @@ from roboverse_pack.blender.usd.overlay import (
     verify_overlay_material_coverage,
 )
 
+FIXTURE_DIR = Path(__file__).parent / "fixtures" / "usd_materials"
+
 
 def _source_hash(path):
     return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _copy_fixture(tmp_path, fixture_name):
+    source = tmp_path / fixture_name
+    if not source.exists():
+        shutil.copyfile(FIXTURE_DIR / fixture_name, source)
+    return source
+
+
+def _generate_fixture_overlay(tmp_path, fixture_name):
+    source = _copy_fixture(tmp_path, fixture_name)
+    overlay = source.with_suffix(".blender_materials.usda")
+    root = source.with_suffix(".blender_root.usda")
+    report = generate_blender_overlay(source, overlay, root, tmp_path / "cache")
+    return overlay, root, report
 
 
 def _write_overlay_fixture(path):
@@ -49,6 +68,160 @@ def _preview_shader(stage, material_path):
     source_info = material.ComputeSurfaceSource()
     assert source_info
     return UsdShade.Shader(source_info[0])
+
+
+def _preview_input(stage, material_path, input_name):
+    return _preview_shader(stage, material_path).GetInput(input_name).Get()
+
+
+def test_root_sublayers_overlay_before_source(tmp_path):
+    overlay, root, _report = _generate_fixture_overlay(tmp_path, "omnipbr_basecolor_scalar.usda")
+    source = tmp_path / "omnipbr_basecolor_scalar.usda"
+
+    root_layer = Sdf.Layer.FindOrOpen(str(root))
+    assert root_layer.subLayerPaths[:2] == [str(overlay), str(source)]
+
+
+def test_generate_overlay_does_not_modify_source_usd(tmp_path):
+    source = _copy_fixture(tmp_path, "omnipbr_basecolor_scalar.usda")
+    before_hash = _source_hash(source)
+
+    _generate_fixture_overlay(tmp_path, "omnipbr_basecolor_scalar.usda")
+
+    assert _source_hash(source) == before_hash
+
+
+def test_direct_diffuse_texture_mapping_is_preserved(tmp_path):
+    overlay, _root, _report = _generate_fixture_overlay(tmp_path, "omnipbr_basecolor_texture.usda")
+
+    overlay_text = overlay.read_text(encoding="utf-8")
+    assert "UsdUVTexture" in overlay_text
+    assert "UsdPrimvarReader_float2" in overlay_text
+    assert "inputs:file" in overlay_text
+    assert "textures/wood.png" in overlay_text
+
+    stage = Usd.Stage.Open(str(overlay))
+    texture_shader = UsdShade.Shader.Get(stage, "/World/Looks/Wood/PreviewTexture")
+    reader_shader = UsdShade.Shader.Get(stage, "/World/Looks/Wood/PreviewSTReader")
+    preview_shader = UsdShade.Shader.Get(stage, "/World/Looks/Wood/PreviewSurface")
+
+    assert texture_shader.GetIdAttr().Get() == "UsdUVTexture"
+    assert texture_shader.GetInput("file").Get().path == "./textures/wood.png"
+    assert reader_shader.GetIdAttr().Get() == "UsdPrimvarReader_float2"
+    diffuse_connection = preview_shader.GetInput("diffuseColor").GetConnectedSource()
+    assert diffuse_connection[0].GetPath() == texture_shader.GetPath()
+    assert diffuse_connection[1] == "rgb"
+
+
+def test_scalar_roughness_metallic_opacity_emissive_are_preserved(tmp_path):
+    _overlay, root, _report = _generate_fixture_overlay(tmp_path, "omnipbr_basecolor_scalar.usda")
+
+    stage = Usd.Stage.Open(str(root))
+    shader = _preview_shader(stage, "/World/Looks/Paint")
+
+    assert shader.GetInput("roughness").Get() == pytest.approx(0.25)
+    assert shader.GetInput("metallic").Get() == pytest.approx(0.0)
+    assert shader.GetInput("opacity").Get() == pytest.approx(1.0)
+    assert shader.GetInput("emissiveColor").Get() == Gf.Vec3f(0.0, 0.0, 0.0)
+
+
+def test_glass_class_fallback_is_preserved(tmp_path):
+    _overlay, root, report = _generate_fixture_overlay(tmp_path, "omnipbr_glass_scalar.usda")
+
+    entry = report["materials"]["/World/Looks/GlassPane"]
+    assert entry["material_class"] == "glass"
+    assert entry["status"] == "converted"
+
+    stage = Usd.Stage.Open(str(root))
+    shader = _preview_shader(stage, "/World/Looks/GlassPane")
+    assert shader.GetInput("opacity").Get() == pytest.approx(0.35)
+    assert shader.GetInput("ior").Get() == pytest.approx(1.45)
+
+
+def test_report_includes_material_status_and_quality_warnings(tmp_path):
+    _overlay, _root, report = _generate_fixture_overlay(tmp_path, "omnipbr_basecolor_scalar.usda")
+
+    assert set(report["materials"]) == {"/World/Looks/Paint"}
+    material_path = "/World/Looks/Paint"
+    entry = report["materials"][material_path]
+    assert set(entry) == {"status", "warnings", "material_class"}
+    assert entry["status"] == "converted"
+    assert entry["warnings"] == []
+    assert entry["material_class"] is None
+
+
+def test_existing_preview_surface_values_are_preserved(tmp_path):
+    _overlay, root, report = _generate_fixture_overlay(tmp_path, "preview_surface_existing.usda")
+
+    entry = report["materials"]["/World/Looks/Previewed"]
+    assert entry["status"] == "converted"
+    assert entry["material_class"] is None
+    assert entry["warnings"] == []
+
+    stage = Usd.Stage.Open(str(root))
+    shader = _preview_shader(stage, "/World/Looks/Previewed")
+    assert shader.GetIdAttr().Get() == "UsdPreviewSurface"
+    assert shader.GetInput("diffuseColor").Get() == Gf.Vec3f(0.1, 0.2, 0.3)
+    assert shader.GetInput("roughness").Get() == pytest.approx(0.4)
+
+
+def test_alias_matrix_freezes_current_omnipbr_aliases(tmp_path):
+    overlay, root, report = _generate_fixture_overlay(tmp_path, "omnipbr_alias_matrix.usda")
+
+    overlay_text = overlay.read_text(encoding="utf-8")
+    for snippet in [
+        'def Material "BaseColorColor"',
+        'def Material "DiffuseColorConstant"',
+        'def Material "BaseColorTex"',
+        'def Material "DiffuseTexture"',
+        'def Shader "PreviewTexture"',
+        "@./textures/base.png@",
+        "@./textures/diffuse.png@",
+        "float inputs:roughness = 0.31",
+        "float inputs:roughness = 0.62",
+        "float inputs:metallic = 0.73",
+        "float inputs:metallic = 0.84",
+        "float inputs:opacity = 0.45",
+        "float inputs:opacity = 0.56",
+        "color3f inputs:emissiveColor = (0.1, 0.2, 0.3)",
+        "color3f inputs:emissiveColor = (0.3, 0.2, 0.1)",
+        'def Material "WallPanel"',
+        'def Material "FloorTile"',
+        'def Material "CabinetDoor"',
+        'def Material "GlassFallback"',
+    ]:
+        assert snippet in overlay_text
+
+    stage = Usd.Stage.Open(str(root))
+    assert _preview_input(stage, "/World/Looks/BaseColorColor", "diffuseColor") == Gf.Vec3f(0.2, 0.3, 0.4)
+    assert _preview_input(stage, "/World/Looks/DiffuseColorConstant", "diffuseColor") == Gf.Vec3f(0.4, 0.3, 0.2)
+
+    base_texture = _preview_shader(stage, "/World/Looks/BaseColorTex").GetInput("diffuseColor").GetConnectedSource()
+    diffuse_texture = _preview_shader(stage, "/World/Looks/DiffuseTexture").GetInput("diffuseColor").GetConnectedSource()
+    assert base_texture[0].GetPath() == Sdf.Path("/World/Looks/BaseColorTex/PreviewTexture")
+    assert diffuse_texture[0].GetPath() == Sdf.Path("/World/Looks/DiffuseTexture/PreviewTexture")
+
+    assert _preview_input(stage, "/World/Looks/ReflectionRoughness", "roughness") == pytest.approx(0.31)
+    assert _preview_input(stage, "/World/Looks/RoughnessAlias", "roughness") == pytest.approx(0.62)
+    assert _preview_input(stage, "/World/Looks/MetallicConstant", "metallic") == pytest.approx(0.73)
+    assert _preview_input(stage, "/World/Looks/MetallicAlias", "metallic") == pytest.approx(0.84)
+    assert _preview_input(stage, "/World/Looks/OpacityConstant", "opacity") == pytest.approx(0.45)
+    assert _preview_input(stage, "/World/Looks/OpacityAlias", "opacity") == pytest.approx(0.56)
+    assert _preview_input(stage, "/World/Looks/EmissiveColorOmni", "emissiveColor") == Gf.Vec3f(0.1, 0.2, 0.3)
+    assert _preview_input(stage, "/World/Looks/EmissiveColorAlias", "emissiveColor") == Gf.Vec3f(0.3, 0.2, 0.1)
+
+    assert _preview_input(stage, "/World/Looks/WallPanel", "diffuseColor") == Gf.Vec3f(0.72, 0.72, 0.68)
+    assert _preview_input(stage, "/World/Looks/FloorTile", "diffuseColor") == Gf.Vec3f(0.55, 0.50, 0.44)
+    assert _preview_input(stage, "/World/Looks/CabinetDoor", "diffuseColor") == Gf.Vec3f(0.60, 0.46, 0.32)
+    assert _preview_input(stage, "/World/Looks/GlassFallback", "diffuseColor") == Gf.Vec3f(0.78, 0.90, 0.96)
+    assert _preview_input(stage, "/World/Looks/GlassFallback", "opacity") == pytest.approx(0.35)
+    assert _preview_input(stage, "/World/Looks/GlassFallback", "ior") == pytest.approx(1.45)
+
+    assert report["materials"]["/World/Looks/ReflectionRoughness"]["warnings"] == [
+        "No diffuse color or texture alias found."
+    ]
+    for material_path in report["materials"]:
+        verify_overlay_material_coverage(root, [material_path])
 
 
 def test_generate_overlay_authors_root_sublayers_and_preview_values(tmp_path):

--- a/tests/test_generate_blender_material_overlay.py
+++ b/tests/test_generate_blender_material_overlay.py
@@ -154,9 +154,9 @@ def test_existing_preview_surface_values_are_preserved(tmp_path):
     _overlay, root, report = _generate_fixture_overlay(tmp_path, "preview_surface_existing.usda")
 
     entry = report["materials"]["/World/Looks/Previewed"]
-    assert entry["status"] == "converted"
+    assert entry["status"] == "skipped"
     assert entry["material_class"] is None
-    assert entry["warnings"] == []
+    assert entry["warnings"] == ["source UsdPreviewSurface graph preserved without overlay opinion"]
 
     stage = Usd.Stage.Open(str(root))
     shader = _preview_shader(stage, "/World/Looks/Previewed")

--- a/tests/test_generate_blender_material_overlay.py
+++ b/tests/test_generate_blender_material_overlay.py
@@ -101,8 +101,8 @@ def test_direct_diffuse_texture_mapping_is_preserved(tmp_path):
     assert "textures/wood.png" in overlay_text
 
     stage = Usd.Stage.Open(str(overlay))
-    texture_shader = UsdShade.Shader.Get(stage, "/World/Looks/Wood/PreviewTexture")
-    reader_shader = UsdShade.Shader.Get(stage, "/World/Looks/Wood/PreviewSTReader")
+    texture_shader = UsdShade.Shader.Get(stage, "/World/Looks/Wood/base_color_Texture")
+    reader_shader = UsdShade.Shader.Get(stage, "/World/Looks/Wood/base_color_Primvar")
     preview_shader = UsdShade.Shader.Get(stage, "/World/Looks/Wood/PreviewSurface")
 
     assert texture_shader.GetIdAttr().Get() == "UsdUVTexture"
@@ -174,7 +174,7 @@ def test_alias_matrix_freezes_current_omnipbr_aliases(tmp_path):
         'def Material "DiffuseColorConstant"',
         'def Material "BaseColorTex"',
         'def Material "DiffuseTexture"',
-        'def Shader "PreviewTexture"',
+        'def Shader "base_color_Texture"',
         "@./textures/base.png@",
         "@./textures/diffuse.png@",
         "float inputs:roughness = 0.31",
@@ -198,8 +198,8 @@ def test_alias_matrix_freezes_current_omnipbr_aliases(tmp_path):
 
     base_texture = _preview_shader(stage, "/World/Looks/BaseColorTex").GetInput("diffuseColor").GetConnectedSource()
     diffuse_texture = _preview_shader(stage, "/World/Looks/DiffuseTexture").GetInput("diffuseColor").GetConnectedSource()
-    assert base_texture[0].GetPath() == Sdf.Path("/World/Looks/BaseColorTex/PreviewTexture")
-    assert diffuse_texture[0].GetPath() == Sdf.Path("/World/Looks/DiffuseTexture/PreviewTexture")
+    assert base_texture[0].GetPath() == Sdf.Path("/World/Looks/BaseColorTex/base_color_Texture")
+    assert diffuse_texture[0].GetPath() == Sdf.Path("/World/Looks/DiffuseTexture/base_color_Texture")
 
     assert _preview_input(stage, "/World/Looks/ReflectionRoughness", "roughness") == pytest.approx(0.31)
     assert _preview_input(stage, "/World/Looks/RoughnessAlias", "roughness") == pytest.approx(0.62)
@@ -265,8 +265,8 @@ def test_generate_overlay_authors_direct_diffuse_texture_chain_and_reports(tmp_p
     generate_blender_overlay(source, overlay, root, cache)
 
     stage = Usd.Stage.Open(str(overlay))
-    texture_shader = UsdShade.Shader.Get(stage, "/World/Looks/Textured/PreviewTexture")
-    reader_shader = UsdShade.Shader.Get(stage, "/World/Looks/Textured/PreviewSTReader")
+    texture_shader = UsdShade.Shader.Get(stage, "/World/Looks/Textured/base_color_Texture")
+    reader_shader = UsdShade.Shader.Get(stage, "/World/Looks/Textured/base_color_Primvar")
     preview_shader = UsdShade.Shader.Get(stage, "/World/Looks/Textured/PreviewSurface")
 
     assert texture_shader.GetIdAttr().Get() == "UsdUVTexture"

--- a/tests/test_generate_blender_material_overlay.py
+++ b/tests/test_generate_blender_material_overlay.py
@@ -1,0 +1,140 @@
+import hashlib
+import json
+import os
+
+import pytest
+
+pxr = pytest.importorskip("pxr")
+from pxr import Gf, Sdf, Usd, UsdShade
+
+from roboverse_pack.blender.usd.overlay import (
+    generate_blender_overlay,
+    verify_overlay_material_coverage,
+)
+
+
+def _source_hash(path):
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_overlay_fixture(path):
+    stage = Usd.Stage.CreateNew(str(path))
+    stage.DefinePrim("/World", "Xform")
+
+    painted = UsdShade.Material.Define(stage, "/World/Looks/Painted")
+    painted_shader = UsdShade.Shader.Define(stage, "/World/Looks/Painted/Shader")
+    painted_shader.CreateIdAttr("OmniPBR")
+    painted_shader.CreateInput("BaseColor_Color", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(0.1, 0.2, 0.3))
+    painted_shader.CreateInput("reflection_roughness_constant", Sdf.ValueTypeNames.Float).Set(0.7)
+    painted_shader.CreateInput("metallic_constant", Sdf.ValueTypeNames.Float).Set(0.4)
+    painted.CreateSurfaceOutput().ConnectToSource(painted_shader.ConnectableAPI(), "surface")
+
+    textured = UsdShade.Material.Define(stage, "/World/Looks/Textured")
+    textured_shader = UsdShade.Shader.Define(stage, "/World/Looks/Textured/Shader")
+    textured_shader.CreateIdAttr("OmniPBR")
+    textured_shader.CreateInput("BaseColor_Tex", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath("albedo.png"))
+    textured.CreateSurfaceOutput().ConnectToSource(textured_shader.ConnectableAPI(), "surface")
+
+    glass = UsdShade.Material.Define(stage, "/World/Looks/GlassDoor")
+    glass_shader = UsdShade.Shader.Define(stage, "/World/Looks/GlassDoor/Shader")
+    glass_shader.CreateIdAttr("OmniGlass")
+    glass_shader.CreateInput("opacity_constant", Sdf.ValueTypeNames.Float).Set(0.25)
+    glass.CreateSurfaceOutput().ConnectToSource(glass_shader.ConnectableAPI(), "surface")
+
+    stage.GetRootLayer().Save()
+
+
+def _preview_shader(stage, material_path):
+    material = UsdShade.Material.Get(stage, material_path)
+    source_info = material.ComputeSurfaceSource()
+    assert source_info
+    return UsdShade.Shader(source_info[0])
+
+
+def test_generate_overlay_authors_root_sublayers_and_preview_values(tmp_path):
+    source = tmp_path / "scene.usda"
+    overlay = tmp_path / "scene.blender_materials.usda"
+    root = tmp_path / "scene.blender_root.usda"
+    cache = tmp_path / "cache"
+    _write_overlay_fixture(source)
+    before_hash = _source_hash(source)
+
+    report = generate_blender_overlay(source, overlay, root, cache, resolution=512, samples=2)
+
+    assert _source_hash(source) == before_hash
+    assert overlay.exists()
+    assert root.exists()
+    root_layer = Sdf.Layer.FindOrOpen(str(root))
+    assert root_layer.subLayerPaths[:2] == [str(overlay), str(source)]
+
+    stage = Usd.Stage.Open(str(root))
+    painted_shader = _preview_shader(stage, "/World/Looks/Painted")
+    assert painted_shader.GetIdAttr().Get() == "UsdPreviewSurface"
+    assert painted_shader.GetInput("diffuseColor").Get() == Gf.Vec3f(0.1, 0.2, 0.3)
+    assert painted_shader.GetInput("roughness").Get() == pytest.approx(0.7)
+    assert painted_shader.GetInput("metallic").Get() == pytest.approx(0.4)
+
+    glass_shader = _preview_shader(stage, "/World/Looks/GlassDoor")
+    assert glass_shader.GetInput("opacity").Get() == pytest.approx(0.25)
+    assert glass_shader.GetInput("ior").Get() == pytest.approx(1.45)
+    assert report["materials"]["/World/Looks/GlassDoor"]["material_class"] == "glass"
+
+    verify_overlay_material_coverage(root, ["/World/Looks/Painted", "/World/Looks/Textured", "/World/Looks/GlassDoor"])
+
+
+def test_generate_overlay_authors_direct_diffuse_texture_chain_and_reports(tmp_path):
+    source = tmp_path / "scene.usda"
+    overlay = tmp_path / "scene.blender_materials.usda"
+    root = tmp_path / "scene.blender_root.usda"
+    cache = tmp_path / "cache"
+    _write_overlay_fixture(source)
+
+    generate_blender_overlay(source, overlay, root, cache)
+
+    stage = Usd.Stage.Open(str(overlay))
+    texture_shader = UsdShade.Shader.Get(stage, "/World/Looks/Textured/PreviewTexture")
+    reader_shader = UsdShade.Shader.Get(stage, "/World/Looks/Textured/PreviewSTReader")
+    preview_shader = UsdShade.Shader.Get(stage, "/World/Looks/Textured/PreviewSurface")
+
+    assert texture_shader.GetIdAttr().Get() == "UsdUVTexture"
+    assert texture_shader.GetInput("file").Get().path == "albedo.png"
+    assert reader_shader.GetIdAttr().Get() == "UsdPrimvarReader_float2"
+    assert reader_shader.GetInput("varname").Get() == "st"
+    diffuse_connection = preview_shader.GetInput("diffuseColor").GetConnectedSource()
+    assert diffuse_connection[0].GetPath() == texture_shader.GetPath()
+    assert diffuse_connection[1] == "rgb"
+
+    assert (cache / "conversion_report.json").exists()
+    assert (cache / "conversion_report.md").exists()
+    report = json.loads((cache / "conversion_report.json").read_text(encoding="utf-8"))
+    assert report["materials"]["/World/Looks/Textured"]["status"] == "converted"
+
+
+def test_generate_overlay_can_rerun_over_existing_overlay(tmp_path):
+    source = tmp_path / "scene.usda"
+    overlay = tmp_path / "scene.blender_materials.usda"
+    root = tmp_path / "scene.blender_root.usda"
+    cache = tmp_path / "cache"
+    _write_overlay_fixture(source)
+
+    generate_blender_overlay(source, overlay, root, cache)
+    report = generate_blender_overlay(source, overlay, root, cache)
+
+    assert report["materials"]["/World/Looks/Painted"]["status"] == "converted"
+    verify_overlay_material_coverage(root, report["materials"].keys())
+
+
+def test_generate_overlay_authors_nested_relative_sublayers_from_root_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    source = "assets/scene.usda"
+    overlay = "assets/scene.blender_materials.usda"
+    root = "assets/scene.blender_root.usda"
+    cache = "cache"
+    os.makedirs("assets")
+    _write_overlay_fixture(source)
+
+    generate_blender_overlay(source, overlay, root, cache)
+
+    root_layer = Sdf.Layer.FindOrOpen(root)
+    assert root_layer.subLayerPaths[:2] == ["scene.blender_materials.usda", "scene.usda"]
+    verify_overlay_material_coverage(root, ["/World/Looks/Painted", "/World/Looks/Textured", "/World/Looks/GlassDoor"])

--- a/tests/test_manifest_v2.py
+++ b/tests/test_manifest_v2.py
@@ -1,0 +1,157 @@
+import json
+
+from roboverse_pack.blender.usd import compat
+
+
+def _write_outputs(tmp_path):
+    source = tmp_path / "scene.usda"
+    overlay = tmp_path / "scene.blender_materials.usda"
+    root = tmp_path / "scene.blender_root.usda"
+    manifest = tmp_path / "manifest.json"
+    source.write_text("#usda 1.0\n", encoding="utf-8")
+    overlay.write_text("overlay", encoding="utf-8")
+    root.write_text("root", encoding="utf-8")
+    return source, overlay, root, manifest
+
+
+def test_changing_referenced_texture_invalidates_overlay(tmp_path):
+    source, overlay, root, manifest = _write_outputs(tmp_path)
+    texture = tmp_path / "textures" / "wood.png"
+    texture.parent.mkdir()
+    texture.write_bytes(b"wood-one")
+
+    compat.write_manifest(
+        manifest,
+        source=source,
+        overlay=overlay,
+        root=root,
+        dependencies={"textures": [texture]},
+    )
+
+    assert compat.is_overlay_current(source, overlay, root, manifest)
+
+    texture.write_bytes(b"wood-two")
+
+    assert not compat.is_overlay_current(source, overlay, root, manifest)
+
+
+def test_subset_settings_match_is_accepted(tmp_path):
+    source, overlay, root, manifest = _write_outputs(tmp_path)
+    compat.write_manifest(
+        manifest,
+        source=source,
+        overlay=overlay,
+        root=root,
+        settings={"resolution": 1024, "samples": 4, "preserve_existing_preview": True},
+    )
+
+    assert compat.is_overlay_current(source, overlay, root, manifest, settings={"resolution": 1024})
+    assert compat.is_overlay_current(source, overlay, root, manifest, settings={})
+
+
+def test_schema_v1_manifest_is_rejected(tmp_path):
+    source, overlay, root, manifest = _write_outputs(tmp_path)
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "source": str(source),
+                "overlay": str(overlay),
+                "root": str(root),
+                "source_sha256": compat.file_sha256(source),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    assert not compat.is_overlay_current(source, overlay, root, manifest)
+
+
+def test_changing_requested_setting_invalidates_overlay(tmp_path):
+    source, overlay, root, manifest = _write_outputs(tmp_path)
+    compat.write_manifest(
+        manifest,
+        source=source,
+        overlay=overlay,
+        root=root,
+        settings={"resolution": 1024, "samples": 4},
+    )
+
+    assert not compat.is_overlay_current(source, overlay, root, manifest, settings={"resolution": 2048})
+
+
+def test_missing_dependency_invalidates_overlay(tmp_path):
+    source, overlay, root, manifest = _write_outputs(tmp_path)
+    texture = tmp_path / "textures" / "wood.png"
+    texture.parent.mkdir()
+    texture.write_bytes(b"wood")
+    compat.write_manifest(
+        manifest,
+        source=source,
+        overlay=overlay,
+        root=root,
+        dependencies={"textures": [texture]},
+    )
+
+    texture.unlink()
+
+    assert not compat.is_overlay_current(source, overlay, root, manifest)
+
+
+def test_missing_texture_reference_invalidates_when_file_appears(tmp_path):
+    source, overlay, root, manifest = _write_outputs(tmp_path)
+    compat.write_manifest(
+        manifest,
+        source=source,
+        overlay=overlay,
+        root=root,
+        dependencies={"missing_textures": ["textures/missing.png"]},
+    )
+
+    assert compat.is_overlay_current(source, overlay, root, manifest)
+
+    texture = tmp_path / "textures" / "missing.png"
+    texture.parent.mkdir()
+    texture.write_bytes(b"now-present")
+
+    assert not compat.is_overlay_current(source, overlay, root, manifest)
+
+
+def test_udim_texture_report_dependencies_track_tile_changes(tmp_path):
+    source, overlay, root, manifest = _write_outputs(tmp_path)
+    texture_dir = tmp_path / "textures"
+    texture_dir.mkdir()
+    tile_1001 = texture_dir / "wall.1001.png"
+    tile_1002 = texture_dir / "wall.1002.png"
+    tile_1001.write_bytes(b"tile-one")
+    tile_1002.write_bytes(b"tile-two")
+    report = {
+        "deep_report": {
+            "materials": [
+                {
+                    "slots": {
+                        "base_color": {
+                            "status": "texture",
+                            "file": "textures/wall.<UDIM>.png",
+                        }
+                    }
+                }
+            ]
+        }
+    }
+
+    dependencies = compat._texture_dependencies_from_report(report, source.parent)
+    assert dependencies["textures"] == [tile_1001, tile_1002]
+
+    compat.write_manifest(
+        manifest,
+        source=source,
+        overlay=overlay,
+        root=root,
+        dependencies=dependencies,
+    )
+    assert compat.is_overlay_current(source, overlay, root, manifest)
+
+    tile_1002.write_bytes(b"tile-two-changed")
+
+    assert not compat.is_overlay_current(source, overlay, root, manifest)

--- a/tests/test_material_graph_author_preview.py
+++ b/tests/test_material_graph_author_preview.py
@@ -39,6 +39,7 @@ def _spec(**overrides):
         material_class=overrides.pop("material_class", None),
         conversion_policy=overrides.pop("conversion_policy", "direct_graph"),
         quality_notes=overrides.pop("quality_notes", ()),
+        adapter_name=overrides.pop("adapter_name", None),
     )
 
 
@@ -80,6 +81,10 @@ def _stage_for(spec):
 
 def _preview(stage, material_path="/World/Looks/Mat"):
     return UsdShade.Shader.Get(stage, f"{material_path}/PreviewSurface")
+
+
+def _material(stage, material_path="/World/Looks/Mat"):
+    return UsdShade.Material.Get(stage, material_path)
 
 
 def _texture(stage, slot_name, material_path="/World/Looks/Mat"):
@@ -130,6 +135,24 @@ def test_resolved_texture_channel_for_a_or_r(source_input, expected):
     )
 
     assert _resolved_texture_channel(texture) == expected
+
+
+@pytest.mark.parametrize(
+    ("conversion_policy", "adapter_name"),
+    [
+        ("direct_graph", "omnipbr"),
+        ("scalar_fallback", "scalar_fallback"),
+        ("mdl_bake", "mdl_bake"),
+    ],
+)
+def test_authored_material_custom_data_tags_conversion_metadata(conversion_policy, adapter_name):
+    stage = _stage_for(_spec(conversion_policy=conversion_policy, adapter_name=adapter_name))
+
+    custom_data = _material(stage).GetPrim().GetCustomData()
+
+    assert custom_data["roboverse:material_conversion_policy"] == conversion_policy
+    assert custom_data["roboverse:material_adapter"] == adapter_name
+    assert custom_data["roboverse:material_graph_version"] == "v1"
 
 
 def test_base_color_texture_chain_connects_rgb_to_diffuse_color():

--- a/tests/test_material_graph_author_preview.py
+++ b/tests/test_material_graph_author_preview.py
@@ -1,0 +1,264 @@
+from pathlib import Path
+
+import pytest
+
+from roboverse_pack.blender.usd.material_graph.adapters.omnipbr import OmniPBRAdapter
+from roboverse_pack.blender.usd.material_graph.author_preview import _resolved_texture_channel, author_material
+from roboverse_pack.blender.usd.material_graph.context import MaterialContext
+from roboverse_pack.blender.usd.material_graph.schema import (
+    InputSpec,
+    PreviewMaterialSpec,
+    RawMaterialSpec,
+    TextureSpec,
+    freeze_values,
+)
+
+Gf = None
+Sdf = None
+Usd = None
+UsdShade = None
+
+
+def _spec(**overrides):
+    return PreviewMaterialSpec(
+        material_path=overrides.pop("material_path", "/World/Looks/Mat"),
+        material_name=overrides.pop("material_name", "Mat"),
+        source_shader_ids=overrides.pop("source_shader_ids", ("OmniPBR",)),
+        mdl_source_asset=overrides.pop("mdl_source_asset", None),
+        base_color=overrides.pop("base_color", InputSpec(value=(0.5, 0.5, 0.5))),
+        normal=overrides.pop("normal", None),
+        metallic=overrides.pop("metallic", None),
+        roughness=overrides.pop("roughness", None),
+        specular_color=overrides.pop("specular_color", None),
+        emissive_color=overrides.pop("emissive_color", None),
+        opacity=overrides.pop("opacity", None),
+        ior=overrides.pop("ior", None),
+        use_specular_workflow=overrides.pop("use_specular_workflow", False),
+        material_class=overrides.pop("material_class", None),
+        conversion_policy=overrides.pop("conversion_policy", "direct_graph"),
+        quality_notes=overrides.pop("quality_notes", ()),
+    )
+
+
+def _raw(values):
+    return RawMaterialSpec(
+        material_path="/World/Looks/Mat",
+        material_name="Mat",
+        shader_ids=("OmniPBR",),
+        connected_surface_shader_id="OmniPBR",
+        mdl_source_asset=None,
+        values=freeze_values(values),
+    )
+
+
+def _context():
+    return MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=Path("."),
+        material_path="/World/Looks/Mat",
+    )
+
+
+def _stage_for(spec):
+    global Gf, Sdf, Usd, UsdShade
+    pxr = pytest.importorskip("pxr")
+    from pxr import Gf as _Gf
+    from pxr import Sdf as _Sdf
+    from pxr import Usd as _Usd
+    from pxr import UsdShade as _UsdShade
+
+    Gf = _Gf
+    Sdf = _Sdf
+    Usd = _Usd
+    UsdShade = _UsdShade
+    stage = Usd.Stage.CreateInMemory()
+    author_material(stage, spec, Gf, Sdf, UsdShade)
+    return stage
+
+
+def _preview(stage, material_path="/World/Looks/Mat"):
+    return UsdShade.Shader.Get(stage, f"{material_path}/PreviewSurface")
+
+
+def _texture(stage, slot_name, material_path="/World/Looks/Mat"):
+    return UsdShade.Shader.Get(stage, f"{material_path}/{slot_name}_Texture")
+
+
+def _reader(stage, slot_name, material_path="/World/Looks/Mat"):
+    return UsdShade.Shader.Get(stage, f"{material_path}/{slot_name}_Primvar")
+
+
+def _connected_source(stage, input_name, material_path="/World/Looks/Mat"):
+    return _preview(stage, material_path).GetInput(input_name).GetConnectedSource()
+
+
+def _texture_input(file, channel="rgb", source_color_space="sRGB", **overrides):
+    return InputSpec(
+        texture=TextureSpec(
+            file=file,
+            source_color_space=source_color_space,
+            channel=channel,
+            **overrides,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    ("source_input", "expected"),
+    [
+        ("Opacity_Tex", "a"),
+        ("Opacity_Texture", "a"),
+        ("Alpha_Tex", "a"),
+        ("Alpha_Texture", "a"),
+        ("alpha_texture", "a"),
+        ("opacity_texture", "r"),
+        (None, "r"),
+    ],
+)
+def test_resolved_texture_channel_for_a_or_r(source_input, expected):
+    texture = TextureSpec(
+        file="textures/opacity.png",
+        source_color_space="raw",
+        channel="a_or_r",
+        source_input=source_input,
+    )
+
+    assert _resolved_texture_channel(texture) == expected
+
+
+def test_base_color_texture_chain_connects_rgb_to_diffuse_color():
+    stage = _stage_for(
+        _spec(base_color=_texture_input("textures/albedo.png", source_color_space="sRGB"))
+    )
+
+    texture = _texture(stage, "base_color")
+    reader = _reader(stage, "base_color")
+    connection = _connected_source(stage, "diffuseColor")
+
+    assert texture.GetIdAttr().Get() == "UsdUVTexture"
+    assert texture.GetInput("file").Get().path == "textures/albedo.png"
+    assert texture.GetInput("sourceColorSpace").Get() == "sRGB"
+    assert texture.GetInput("wrapS").Get() == "repeat"
+    assert texture.GetInput("wrapT").Get() == "repeat"
+    assert reader.GetIdAttr().Get() == "UsdPrimvarReader_float2"
+    assert reader.GetInput("varname").Get() == "st"
+    assert connection[0].GetPath() == texture.GetPath()
+    assert connection[1] == "rgb"
+
+
+def test_primvar_reader_varname_is_authored_as_string_not_token():
+    stage = _stage_for(
+        _spec(base_color=_texture_input("textures/albedo.png", source_color_space="sRGB"))
+    )
+
+    assert 'string inputs:varname = "st"' in stage.GetRootLayer().ExportToString()
+
+
+def test_normal_texture_authors_raw_source_color_space_and_scale_bias():
+    stage = _stage_for(
+        _spec(
+            normal=_texture_input(
+                "textures/normal.png",
+                source_color_space="raw",
+                scale=(2.0, 2.0, 2.0, 1.0),
+                bias=(-1.0, -1.0, -1.0, 0.0),
+            )
+        )
+    )
+
+    texture = _texture(stage, "normal")
+    connection = _connected_source(stage, "normal")
+
+    assert texture.GetInput("sourceColorSpace").Get() == "raw"
+    assert texture.GetInput("scale").Get() == Gf.Vec4f(2.0, 2.0, 2.0, 1.0)
+    assert texture.GetInput("bias").Get() == Gf.Vec4f(-1.0, -1.0, -1.0, 0.0)
+    assert connection[0].GetPath() == texture.GetPath()
+    assert connection[1] == "rgb"
+
+
+def test_normal_scalar_value_is_not_authored():
+    stage = _stage_for(_spec(normal=InputSpec(value=(0.0, 0.0, 1.0))))
+
+    assert not _preview(stage).GetInput("normal")
+
+
+def test_metallic_texture_connects_r_channel():
+    stage = _stage_for(_spec(metallic=_texture_input("textures/metal.png", channel="r", source_color_space="raw")))
+
+    connection = _connected_source(stage, "metallic")
+
+    assert connection[0].GetPath() == _texture(stage, "metallic").GetPath()
+    assert connection[1] == "r"
+
+
+def test_roughness_texture_connects_r_channel():
+    stage = _stage_for(_spec(roughness=_texture_input("textures/rough.png", channel="r", source_color_space="raw")))
+
+    connection = _connected_source(stage, "roughness")
+
+    assert connection[0].GetPath() == _texture(stage, "roughness").GetPath()
+    assert connection[1] == "r"
+
+
+def test_glossiness_texture_inversion_scale_and_bias_are_authored():
+    converted = OmniPBRAdapter().convert(_raw({"Glossiness_Tex": "textures/gloss.png"}), _context())
+    stage = _stage_for(converted)
+
+    texture = _texture(stage, "roughness")
+
+    assert texture.GetInput("scale").Get() == Gf.Vec4f(-1.0, -1.0, -1.0, -1.0)
+    assert texture.GetInput("bias").Get() == Gf.Vec4f(1.0, 1.0, 1.0, 1.0)
+    assert _connected_source(stage, "roughness")[1] == "r"
+
+
+def test_specular_texture_sets_specular_workflow_flag():
+    stage = _stage_for(
+        _spec(
+            specular_color=_texture_input("textures/specular.png", source_color_space="sRGB"),
+            use_specular_workflow=True,
+        )
+    )
+
+    connection = _connected_source(stage, "specularColor")
+
+    assert connection[0].GetPath() == _texture(stage, "specular").GetPath()
+    assert connection[1] == "rgb"
+    assert _preview(stage).GetInput("useSpecularWorkflow").Get() == 1
+
+
+def test_emissive_texture_connects_rgb_to_emissive_color():
+    stage = _stage_for(_spec(emissive_color=_texture_input("textures/emissive.png", source_color_space="sRGB")))
+
+    connection = _connected_source(stage, "emissiveColor")
+
+    assert connection[0].GetPath() == _texture(stage, "emissive").GetPath()
+    assert connection[1] == "rgb"
+
+
+@pytest.mark.parametrize("source_input", ["Opacity_Tex", "Alpha_Tex"])
+def test_opacity_adapter_a_or_r_sources_connect_alpha_channel(source_input):
+    converted = OmniPBRAdapter().convert(_raw({source_input: "textures/opacity.png"}), _context())
+    stage = _stage_for(converted)
+
+    connection = _connected_source(stage, "opacity")
+
+    assert converted.opacity.texture.source_input == source_input
+    assert connection[0].GetPath() == _texture(stage, "opacity").GetPath()
+    assert connection[1] == "a"
+
+
+def test_opacity_a_or_r_non_alpha_source_connects_r_channel():
+    stage = _stage_for(
+        _spec(
+            opacity=InputSpec(
+                texture=TextureSpec(
+                    file="textures/opacity.png",
+                    source_color_space="raw",
+                    channel="a_or_r",
+                    source_input="opacity_texture",
+                )
+            )
+        )
+    )
+
+    assert _connected_source(stage, "opacity")[1] == "r"

--- a/tests/test_material_graph_author_preview.py
+++ b/tests/test_material_graph_author_preview.py
@@ -10,6 +10,8 @@ from roboverse_pack.blender.usd.material_graph.schema import (
     PreviewMaterialSpec,
     RawMaterialSpec,
     TextureSpec,
+    UVSetSpec,
+    UVTransformSpec,
     freeze_values,
 )
 
@@ -88,6 +90,10 @@ def _reader(stage, slot_name, material_path="/World/Looks/Mat"):
     return UsdShade.Shader.Get(stage, f"{material_path}/{slot_name}_Primvar")
 
 
+def _transform(stage, slot_name, material_path="/World/Looks/Mat"):
+    return UsdShade.Shader.Get(stage, f"{material_path}/{slot_name}_Transform2d")
+
+
 def _connected_source(stage, input_name, material_path="/World/Looks/Mat"):
     return _preview(stage, material_path).GetInput(input_name).GetConnectedSource()
 
@@ -152,6 +158,35 @@ def test_primvar_reader_varname_is_authored_as_string_not_token():
     )
 
     assert 'string inputs:varname = "st"' in stage.GetRootLayer().ExportToString()
+
+
+def test_texture_chain_authors_transform2d_and_custom_uv_varname():
+    stage = _stage_for(
+        _spec(
+            base_color=_texture_input(
+                "textures/albedo.png",
+                source_color_space="sRGB",
+                uv_set=UVSetSpec("st1", 1, "matched"),
+                uv_transform=UVTransformSpec(
+                    scale=(2.0, 3.0),
+                    rotation_degrees=45.0,
+                    translation=(0.25, 0.5),
+                ),
+            )
+        )
+    )
+
+    reader = _reader(stage, "base_color")
+    transform = _transform(stage, "base_color")
+    texture = _texture(stage, "base_color")
+
+    assert reader.GetInput("varname").Get() == "st1"
+    assert transform.GetIdAttr().Get() == "UsdTransform2d"
+    assert transform.GetInput("scale").Get() == Gf.Vec2f(2.0, 3.0)
+    assert transform.GetInput("rotation").Get() == pytest.approx(45.0)
+    assert transform.GetInput("translation").Get() == Gf.Vec2f(0.25, 0.5)
+    assert transform.GetInput("in").GetConnectedSource()[0].GetPath() == reader.GetPath()
+    assert texture.GetInput("st").GetConnectedSource()[0].GetPath() == transform.GetPath()
 
 
 def test_normal_texture_authors_raw_source_color_space_and_scale_bias():

--- a/tests/test_material_graph_bindings.py
+++ b/tests/test_material_graph_bindings.py
@@ -1,0 +1,179 @@
+from pathlib import Path
+
+import pytest
+
+from roboverse_pack.blender.usd.material_graph.adapters.omnipbr import _common_uv_primvars
+from roboverse_pack.blender.usd.material_graph.bindings import (
+    _uv_primvars,
+    collect_material_binding_contexts,
+    resolve_uv_set,
+)
+from roboverse_pack.blender.usd.material_graph.context import MaterialContext
+
+
+class _Attr:
+    def __init__(self, name):
+        self._name = name
+
+    def GetName(self):
+        return self._name
+
+
+class _Prim:
+    def __init__(self, attr_names, path="/World/Prim", is_gprim=True):
+        self._attr_names = attr_names
+        self._path = path
+        self._is_gprim = is_gprim
+
+    def GetAttributes(self):
+        return [_Attr(name) for name in self._attr_names]
+
+    def GetPath(self):
+        return self._path
+
+    def IsA(self, schema):
+        return schema is _UsdGeom.Gprim and self._is_gprim
+
+
+class _Material:
+    def GetPath(self):
+        return "/World/Looks/Mat"
+
+
+class _Binding:
+    def __init__(self, prim):
+        self._prim = prim
+
+    def ComputeBoundMaterial(self):
+        return (_Material(), None)
+
+
+class _UsdShade:
+    @staticmethod
+    def MaterialBindingAPI(prim):
+        return _Binding(prim)
+
+
+class _UsdGeom:
+    class Gprim:
+        pass
+
+    class Mesh:
+        pass
+
+
+class _Stage:
+    def __init__(self, prims):
+        self._prims = prims
+
+    def Traverse(self):
+        return tuple(self._prims)
+
+
+def _context(uv_primvars_by_prim=None):
+    return MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=Path("."),
+        material_path="/World/Looks/Mat",
+        bound_prim_paths=tuple(uv_primvars_by_prim or ()),
+        uv_primvars_by_prim=uv_primvars_by_prim,
+    )
+
+
+@pytest.mark.parametrize(
+    ("requested", "available", "expected_name", "expected_status"),
+    [
+        (None, ("uv", "st"), "st", "matched"),
+        (0, ("uv0", "map1"), "uv0", "matched"),
+        (1, ("map2", "uv2", "st1"), "st1", "matched"),
+        (2, ("uv3", "map3"), "uv3", "matched"),
+        (3, ("st", "uv"), "st", "guessed_or_missing"),
+    ],
+)
+def test_resolve_uv_set_preference_order(requested, available, expected_name, expected_status):
+    spec = resolve_uv_set(requested, available)
+
+    assert spec.primvar_name == expected_name
+    assert spec.requested_index == requested
+    assert spec.resolution_status == expected_status
+
+
+def test_uv_primvars_extracts_valid_primvar_names_from_fake_prim():
+    prim = _Prim(
+        [
+            "primvars:st",
+            "primvars:st1",
+            "primvars:uv",
+            "primvars:uv2",
+            "primvars:map1",
+            "primvars:displayColor",
+            "points",
+        ]
+    )
+
+    assert _uv_primvars(prim, UsdGeom=None) == ("map1", "st", "st1", "uv", "uv2")
+
+
+def test_common_uv_primvars_returns_sorted_intersection_for_shared_sets():
+    context = _context(
+        {
+            "/World/MeshA": ("st", "st1", "uv"),
+            "/World/MeshB": ("st1", "st", "map1"),
+        }
+    )
+
+    assert _common_uv_primvars(context) == ("st", "st1")
+
+
+def test_common_uv_primvars_defaults_to_st_for_disjoint_sets():
+    context = _context(
+        {
+            "/World/MeshA": ("st1",),
+            "/World/MeshB": ("uv",),
+        }
+    )
+
+    assert _common_uv_primvars(context) == ("st",)
+
+
+def test_common_uv_primvars_defaults_to_st_without_bindings():
+    assert _common_uv_primvars(_context()) == ("st",)
+
+
+def test_collect_material_binding_contexts_skips_bound_container_prims_without_uvs():
+    container = _Prim([], path="/World/Container", is_gprim=False)
+    mesh = _Prim(["primvars:st1"], path="/World/Container/Mesh", is_gprim=True)
+
+    contexts = collect_material_binding_contexts(_Stage([container, mesh]), _UsdShade, _UsdGeom)
+
+    context = contexts["/World/Looks/Mat"]
+    assert context.bound_prim_paths == ("/World/Container/Mesh",)
+    assert context.uv_primvars_by_prim == {"/World/Container/Mesh": ("st1",)}
+    assert _common_uv_primvars(
+        MaterialContext(
+            source_path=Path("scene.usda"),
+            texture_base_dir=Path("."),
+            material_path="/World/Looks/Mat",
+            bound_prim_paths=context.bound_prim_paths,
+            uv_primvars_by_prim=context.uv_primvars_by_prim,
+        )
+    ) == ("st1",)
+
+
+def test_collect_material_binding_contexts_with_pxr_stage():
+    pytest.importorskip("pxr")
+    from pxr import Sdf, Usd, UsdGeom, UsdShade
+
+    from roboverse_pack.blender.usd.material_graph.bindings import collect_material_binding_contexts
+
+    stage = Usd.Stage.CreateInMemory()
+    mesh = UsdGeom.Mesh.Define(stage, "/World/Mesh")
+    material = UsdShade.Material.Define(stage, "/World/Looks/Mat")
+    mesh.GetPrim().CreateAttribute("primvars:st1", Sdf.ValueTypeNames.TexCoord2fArray)
+    UsdShade.MaterialBindingAPI(mesh).Bind(material)
+
+    contexts = collect_material_binding_contexts(stage, UsdShade, UsdGeom)
+
+    assert contexts["/World/Looks/Mat"].material_path == "/World/Looks/Mat"
+    assert contexts["/World/Looks/Mat"].bound_prim_paths == ("/World/Mesh",)
+    assert contexts["/World/Looks/Mat"].uv_primvars_by_prim == {"/World/Mesh": ("st1",)}

--- a/tests/test_material_graph_existing_preview_adapter.py
+++ b/tests/test_material_graph_existing_preview_adapter.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from roboverse_pack.blender.usd.material_graph.adapters.existing_preview import ExistingPreviewSurfaceAdapter
+from roboverse_pack.blender.usd.material_graph.context import MaterialContext
+from roboverse_pack.blender.usd.material_graph.schema import RawMaterialSpec, freeze_values
+
+
+def test_existing_preview_policy_preserves_existing_graph():
+    raw = RawMaterialSpec(
+        material_path="/World/Looks/Previewed",
+        material_name="Previewed",
+        shader_ids=("UsdPreviewSurface",),
+        connected_surface_shader_id="UsdPreviewSurface",
+        mdl_source_asset=None,
+        values=freeze_values({"diffuseColor": (0.1, 0.2, 0.3), "roughness": 0.4}),
+    )
+    context = MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=Path("."),
+        material_path=raw.material_path,
+    )
+
+    adapter = ExistingPreviewSurfaceAdapter()
+    spec = adapter.convert(raw, context)
+
+    assert adapter.score(raw) == 100
+    assert spec.conversion_policy == "preserve_existing_preview"
+    assert spec.base_color.value == (0.1, 0.2, 0.3)
+    assert spec.roughness is not None
+    assert spec.roughness.value == 0.4
+    assert spec.quality_notes == ("source UsdPreviewSurface graph preserved without overlay opinion",)

--- a/tests/test_material_graph_extract.py
+++ b/tests/test_material_graph_extract.py
@@ -1,0 +1,77 @@
+from roboverse_pack.blender.usd.material_graph.extract import source_asset_from_shader
+
+
+class _Value:
+    def __init__(self, value):
+        self._value = value
+
+    def Get(self):
+        return self._value
+
+
+class _Asset:
+    def __init__(self, path):
+        self.path = path
+
+
+class _Prim:
+    def __init__(self, value=None):
+        self._value = value
+
+    def GetAttribute(self, name):
+        if name == "info:mdl:sourceAsset" and self._value is not None:
+            return _Value(self._value)
+        return None
+
+
+class _Shader:
+    def __init__(self, source_asset=None, info_asset=None, input_asset=None):
+        self._source_asset = source_asset
+        self._prim = _Prim(info_asset)
+        self._input_asset = input_asset
+
+    def GetSourceAsset(self, source_type):
+        assert source_type == "mdl"
+        return self._source_asset
+
+    def GetPrim(self):
+        return self._prim
+
+    def GetInput(self, name):
+        if name == "mdl:sourceAsset" and self._input_asset is not None:
+            return _Value(self._input_asset)
+        return None
+
+
+def test_source_asset_from_shader_prefers_get_source_asset():
+    shader = _Shader(
+        source_asset=_Asset("from_source_asset.mdl"),
+        info_asset=_Asset("from_info_attr.mdl"),
+        input_asset=_Asset("from_input.mdl"),
+    )
+
+    assert source_asset_from_shader(shader) == "from_source_asset.mdl"
+
+
+def test_source_asset_from_shader_reads_info_attribute_before_legacy_input():
+    shader = _Shader(info_asset=_Asset("from_info_attr.mdl"), input_asset=_Asset("from_input.mdl"))
+
+    assert source_asset_from_shader(shader) == "from_info_attr.mdl"
+
+
+def test_source_asset_from_shader_falls_back_to_legacy_input():
+    shader = _Shader(input_asset=_Asset("from_input.mdl"))
+
+    assert source_asset_from_shader(shader) == "from_input.mdl"
+
+
+def test_source_asset_from_shader_ignores_empty_get_source_asset():
+    shader = _Shader(source_asset=_Asset(""), info_asset=_Asset("from_info_attr.mdl"))
+
+    assert source_asset_from_shader(shader) == "from_info_attr.mdl"
+
+
+def test_source_asset_from_shader_ignores_blank_info_attribute():
+    shader = _Shader(info_asset=_Asset("  "), input_asset=_Asset("from_input.mdl"))
+
+    assert source_asset_from_shader(shader) == "from_input.mdl"

--- a/tests/test_material_graph_generic_adapter.py
+++ b/tests/test_material_graph_generic_adapter.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+from roboverse_pack.blender.usd.material_graph.adapters import convert_material, select_adapter
+from roboverse_pack.blender.usd.material_graph.adapters.fallback import SemanticClassFallbackAdapter
+from roboverse_pack.blender.usd.material_graph.adapters.generic import GenericTextureGraphAdapter
+from roboverse_pack.blender.usd.material_graph.context import MaterialContext
+from roboverse_pack.blender.usd.material_graph.schema import RawMaterialSpec, freeze_values
+
+
+def _context(material_path="/World/Looks/Mat"):
+    return MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=Path("."),
+        material_path=material_path,
+    )
+
+
+def _raw(values=None, material_path="/World/Looks/Mat"):
+    return RawMaterialSpec(
+        material_path=material_path,
+        material_name=material_path.rsplit("/", 1)[-1],
+        shader_ids=("UnknownShader",),
+        connected_surface_shader_id="UnknownShader",
+        mdl_source_asset=None,
+        values=freeze_values(values or {}),
+    )
+
+
+def test_generic_adapter_converts_unknown_diffuse_texture_to_direct_graph():
+    raw = _raw({"diffuse_texture": "textures/diffuse.png"})
+    adapter = GenericTextureGraphAdapter()
+
+    assert adapter.score(raw) == 40
+    spec = adapter.convert(raw, _context())
+
+    assert spec.conversion_policy == "direct_graph"
+    assert spec.base_color.texture is not None
+    assert spec.base_color.texture.file == "textures/diffuse.png"
+
+
+def test_unknown_material_with_no_values_selects_class_fallback():
+    raw = _raw(material_path="/World/Looks/GlassPane")
+    adapter = select_adapter(raw)
+    spec = convert_material(raw, _context(raw.material_path))
+
+    assert isinstance(adapter, SemanticClassFallbackAdapter)
+    assert spec.conversion_policy == "class_fallback"
+    assert spec.material_class == "glass"
+    assert spec.quality_notes == ("semantic class fallback used",)

--- a/tests/test_material_graph_mdl_bake_policy.py
+++ b/tests/test_material_graph_mdl_bake_policy.py
@@ -1,0 +1,140 @@
+from pathlib import Path
+
+from roboverse_pack.blender.usd.material_graph.adapters import convert_material, select_adapter_by_policy
+from roboverse_pack.blender.usd.material_graph.adapters.mdl_bake import choose_conversion_policy
+from roboverse_pack.blender.usd.material_graph.context import MaterialContext
+from roboverse_pack.blender.usd.material_graph.kit_bake import kit_bake_command
+from roboverse_pack.blender.usd.material_graph.schema import RawMaterialSpec, freeze_values
+
+
+def _raw(**overrides):
+    values = overrides.pop("values", {})
+    material_path = overrides.pop("material_path", "/World/Looks/Mat")
+    return RawMaterialSpec(
+        material_path=material_path,
+        material_name=overrides.pop("material_name", material_path.rsplit("/", 1)[-1]),
+        shader_ids=overrides.pop("shader_ids", ("OmniPBR",)),
+        connected_surface_shader_id=overrides.pop("connected_surface_shader_id", "OmniPBR"),
+        mdl_source_asset=overrides.pop("mdl_source_asset", None),
+        values=freeze_values(values),
+    )
+
+
+def _context(raw: RawMaterialSpec, *, enable_mdl_bake: bool = False) -> MaterialContext:
+    return MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=Path("."),
+        material_path=raw.material_path,
+        enable_mdl_bake=enable_mdl_bake,
+    )
+
+
+def _complex_mdl_raw() -> RawMaterialSpec:
+    return _raw(
+        shader_ids=("OmniPBR", "ProceduralNoise"),
+        connected_surface_shader_id="OmniPBR",
+        mdl_source_asset="ComplexLayeredMaterial.mdl",
+        values={"noise_scale": 12.0, "BaseColor_Tex": "textures/base.png"},
+    )
+
+
+def test_existing_preview_surface_policy_preserves_source_graph():
+    raw = _raw(
+        shader_ids=("UsdPreviewSurface",),
+        connected_surface_shader_id="UsdPreviewSurface",
+    )
+
+    assert choose_conversion_policy(raw) == "preserve_existing_preview"
+
+
+def test_complex_procedural_mdl_policy_uses_mdl_bake():
+    assert choose_conversion_policy(_complex_mdl_raw()) == "mdl_bake"
+
+
+def test_complex_mdl_with_known_texture_slots_still_uses_mdl_bake():
+    raw = _raw(
+        shader_ids=("OmniPBR", "ProceduralNoise"),
+        connected_surface_shader_id="OmniPBR",
+        mdl_source_asset="OmniPBR.mdl",
+        values={"BaseColor_Tex": "textures/base.png"},
+    )
+
+    assert choose_conversion_policy(raw) == "mdl_bake"
+
+
+def test_simple_omnipbr_file_texture_policy_uses_direct_graph():
+    raw = _raw(values={"BaseColor_Tex": "textures/wood.png"})
+
+    assert choose_conversion_policy(raw) == "direct_graph"
+
+
+def test_unconnected_omnipbr_helper_scalar_stays_scalar_fallback():
+    raw = _raw(
+        shader_ids=("OmniPBR",),
+        connected_surface_shader_id="DifferentShader",
+        mdl_source_asset="OmniPBR.mdl",
+        values={"roughness": 0.5},
+    )
+
+    assert choose_conversion_policy(raw) == "scalar_fallback"
+
+    spec = convert_material(raw, _context(raw))
+
+    assert spec.adapter_name == "scalar_fallback"
+    assert spec.conversion_policy == "scalar_fallback"
+
+
+def test_generic_file_texture_policy_still_uses_direct_graph():
+    raw = _raw(
+        shader_ids=("UnknownShader",),
+        connected_surface_shader_id="UnknownShader",
+        values={"diffuse_texture": "textures/diffuse.png"},
+    )
+
+    assert choose_conversion_policy(raw) == "direct_graph"
+
+    spec = convert_material(raw, _context(raw))
+
+    assert spec.adapter_name == "generic_texture_graph"
+    assert spec.conversion_policy == "direct_graph"
+
+
+def test_disabled_mdl_bake_policy_selects_fallback_adapter():
+    adapter = select_adapter_by_policy(_complex_mdl_raw(), enable_mdl_bake=False)
+
+    assert adapter.name in {"scalar_fallback", "semantic_class_fallback"}
+
+
+def test_convert_material_notes_when_mdl_bake_policy_is_unavailable():
+    raw = _complex_mdl_raw()
+
+    spec = convert_material(raw, _context(raw, enable_mdl_bake=False))
+
+    assert spec.adapter_name in {"scalar_fallback", "semantic_class_fallback"}
+    assert spec.conversion_policy in {"scalar_fallback", "class_fallback"}
+    assert "mdl_bake_unavailable" in spec.quality_notes
+
+
+def test_kit_bake_command_shape_stringifies_paths():
+    command = kit_bake_command(
+        Path("/opt/isaacsim/isaac-sim.sh"),
+        Path("/tmp/bake_mdl.py"),
+        Path("/tmp/source.usda"),
+        "/World/Looks/Mat",
+        Path("/tmp/cache"),
+    )
+
+    assert command == [
+        "/opt/isaacsim/isaac-sim.sh",
+        "--no-window",
+        "--/app/window/enabled=false",
+        "--exec",
+        "/tmp/bake_mdl.py",
+        "--",
+        "--source",
+        "/tmp/source.usda",
+        "--material",
+        "/World/Looks/Mat",
+        "--cache-dir",
+        "/tmp/cache",
+    ]

--- a/tests/test_material_graph_omnipbr_adapter.py
+++ b/tests/test_material_graph_omnipbr_adapter.py
@@ -1,0 +1,156 @@
+from pathlib import Path
+
+import pytest
+
+from roboverse_pack.blender.usd.material_graph.adapters import select_adapter
+from roboverse_pack.blender.usd.material_graph.adapters.omnipbr import OmniPBRAdapter
+from roboverse_pack.blender.usd.material_graph.context import MaterialContext
+from roboverse_pack.blender.usd.material_graph.schema import RawMaterialSpec, freeze_values
+from roboverse_pack.blender.usd.material_graph.slots import SLOT_REGISTRY
+
+
+def _raw(**overrides):
+    values = overrides.pop("values", {})
+    return RawMaterialSpec(
+        material_path=overrides.pop("material_path", "/World/Looks/Mat"),
+        material_name=overrides.pop("material_name", "Mat"),
+        shader_ids=overrides.pop("shader_ids", ("OmniPBR",)),
+        connected_surface_shader_id=overrides.pop("connected_surface_shader_id", "OmniPBR"),
+        mdl_source_asset=overrides.pop("mdl_source_asset", None),
+        values=freeze_values(values),
+    )
+
+
+def _context():
+    return MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=Path("."),
+        material_path="/World/Looks/Mat",
+    )
+
+
+def test_omnipbr_adapter_scores_omnipbr_shader():
+    assert OmniPBRAdapter().score(_raw()) == 80
+
+
+def test_omnipbr_adapter_does_not_score_unconnected_omnipbr_helper():
+    raw = _raw(
+        shader_ids=("SomeShader", "OmniPBR"),
+        connected_surface_shader_id="SomeShader",
+        mdl_source_asset="OmniPBR.mdl",
+    )
+
+    assert OmniPBRAdapter().score(raw) == 0
+
+
+def test_omnipbr_adapter_maps_base_color_texture():
+    spec = OmniPBRAdapter().convert(_raw(values={"BaseColor_Tex": "textures/wood.png"}), _context())
+
+    assert spec.base_color.texture is not None
+    assert spec.base_color.texture.file == "textures/wood.png"
+    assert spec.base_color.texture.source_color_space == "sRGB"
+    assert spec.base_color.texture.channel == "rgb"
+    assert spec.base_color.texture.source_input == "BaseColor_Tex"
+    assert spec.conversion_policy == "direct_graph"
+
+
+def test_omnipbr_adapter_inverts_glossiness_scalar_to_roughness():
+    spec = OmniPBRAdapter().convert(_raw(values={"glossiness": 0.25}), _context())
+
+    assert spec.roughness is not None
+    assert spec.roughness.value == pytest.approx(0.75)
+    assert spec.roughness.source_inputs == ("glossiness",)
+
+
+def test_omnipbr_adapter_sets_specular_workflow_for_specular_slot():
+    spec = OmniPBRAdapter().convert(_raw(values={"specular": (0.2, 0.3, 0.4)}), _context())
+
+    assert spec.specular_color is not None
+    assert spec.specular_color.value == (0.2, 0.3, 0.4)
+    assert spec.use_specular_workflow is True
+
+
+def test_omnipbr_adapter_inverts_gloss_color_scalar_to_roughness():
+    spec = OmniPBRAdapter().convert(_raw(values={"Gloss_Color": 0.2}), _context())
+
+    assert spec.roughness is not None
+    assert spec.roughness.value == pytest.approx(0.8)
+    assert spec.roughness.source_inputs == ("Gloss_Color",)
+
+
+def test_omnipbr_adapter_inverts_gloss_color_tuple_to_roughness():
+    spec = OmniPBRAdapter().convert(_raw(values={"Gloss_Color": (0.2, 0.2, 0.2)}), _context())
+
+    assert spec.roughness is not None
+    assert spec.roughness.value == pytest.approx(0.8)
+    assert spec.roughness.source_inputs == ("Gloss_Color",)
+
+
+def test_omnipbr_adapter_maps_metallic_color_alias():
+    spec = OmniPBRAdapter().convert(_raw(values={"Metallic_Color": 0.65}), _context())
+
+    assert spec.metallic is not None
+    assert spec.metallic.value == pytest.approx(0.65)
+    assert spec.metallic.source_inputs == ("Metallic_Color",)
+
+
+def test_omnipbr_adapter_maps_metallic_color_tuple_alias_to_scalar():
+    spec = OmniPBRAdapter().convert(_raw(values={"Metallic_Color": (0.65, 0.65, 0.65)}), _context())
+
+    assert spec.metallic is not None
+    assert spec.metallic.value == pytest.approx(0.65)
+    assert spec.metallic.source_inputs == ("Metallic_Color",)
+
+
+def test_omnipbr_adapter_maps_roughness_alias():
+    spec = OmniPBRAdapter().convert(_raw(values={"Roughness": 0.35}), _context())
+
+    assert spec.roughness is not None
+    assert spec.roughness.value == pytest.approx(0.35)
+    assert spec.roughness.source_inputs == ("Roughness",)
+
+
+def test_omnipbr_adapter_maps_alpha_texture_to_opacity_channel():
+    spec = OmniPBRAdapter().convert(_raw(values={"Alpha_Tex": "textures/alpha.png"}), _context())
+
+    assert spec.opacity is not None
+    assert spec.opacity.texture is not None
+    assert spec.opacity.texture.file == "textures/alpha.png"
+    assert spec.opacity.texture.channel == "a_or_r"
+    assert spec.opacity.texture.source_input == "Alpha_Tex"
+
+
+def test_omnipbr_adapter_uses_shared_and_planned_ior_aliases():
+    glass_ior_spec = OmniPBRAdapter().convert(_raw(values={"glass_ior": 1.52}), _context())
+    fresnel_spec = OmniPBRAdapter().convert(_raw(values={"FresnelB": 1.33}), _context())
+
+    assert glass_ior_spec.ior == pytest.approx(1.52)
+    assert fresnel_spec.ior == pytest.approx(1.33)
+
+
+def test_slot_registry_includes_planned_uva_aliases():
+    assert {"BaseColor_UVA", "Diffuse_UVA"}.issubset(SLOT_REGISTRY["base_color"].uva_aliases)
+    assert "Normal_UVA" in SLOT_REGISTRY["normal"].uva_aliases
+    assert "Metallic_UVA" in SLOT_REGISTRY["metallic"].uva_aliases
+    assert "Roughness_UVA" in SLOT_REGISTRY["roughness"].uva_aliases
+    assert "Gloss_UVA" in SLOT_REGISTRY["glossiness"].uva_aliases
+    assert "Specular_UVA" in SLOT_REGISTRY["specular"].uva_aliases
+    assert {"Emissive_UVA", "Emission_UVA"}.issubset(SLOT_REGISTRY["emissive"].uva_aliases)
+    assert {"Opacity_UVA", "Alpha_UVA"}.issubset(SLOT_REGISTRY["opacity"].uva_aliases)
+
+
+def test_select_adapter_tie_breaks_by_registration_order():
+    class FakeAdapter:
+        def __init__(self, name):
+            self.name = name
+
+        def score(self, raw):
+            return 5
+
+        def convert(self, raw, context):
+            raise AssertionError("not used")
+
+    earlier = FakeAdapter("earlier")
+    later = FakeAdapter("later")
+
+    assert select_adapter(_raw(), adapters=(earlier, later)) is earlier

--- a/tests/test_material_graph_omnipbr_adapter.py
+++ b/tests/test_material_graph_omnipbr_adapter.py
@@ -54,6 +54,85 @@ def test_omnipbr_adapter_maps_base_color_texture():
     assert spec.conversion_policy == "direct_graph"
 
 
+def test_omnipbr_adapter_sets_texture_uv_set_and_transform_from_bindings():
+    context = MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=Path("."),
+        material_path="/World/Looks/Mat",
+        bound_prim_paths=("/World/Mesh",),
+        uv_primvars_by_prim={"/World/Mesh": ("st", "st1")},
+    )
+
+    spec = OmniPBRAdapter().convert(
+        _raw(
+            values={
+                "BaseColor_Tex": "textures/wood.png",
+                "MaxTexCoordIndex": 1,
+                "BaseColor_UVA": (2.0, 3.0, 0.25, 0.5),
+            }
+        ),
+        context,
+    )
+
+    assert spec.base_color.texture is not None
+    assert spec.base_color.texture.uv_set.primvar_name == "st1"
+    assert spec.base_color.texture.uv_set.requested_index == 1
+    assert spec.base_color.texture.uv_set.resolution_status == "matched"
+    assert spec.base_color.texture.uv_transform is not None
+    assert spec.base_color.texture.uv_transform.scale == (2.0, 3.0)
+    assert spec.base_color.texture.uv_transform.translation == (0.25, 0.5)
+    assert spec.base_color.texture.uv_transform.source_input == "BaseColor_UVA"
+
+
+def test_omnipbr_adapter_prefers_slot_uv_index_over_global_index():
+    context = MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=Path("."),
+        material_path="/World/Looks/Mat",
+        bound_prim_paths=("/World/Mesh",),
+        uv_primvars_by_prim={"/World/Mesh": ("st", "st1")},
+    )
+
+    spec = OmniPBRAdapter().convert(
+        _raw(
+            values={
+                "BaseColor_Tex": "textures/wood.png",
+                "MaxTexCoordIndex": 0,
+                "BaseColor_MaxTexCoordIndex": 1,
+            }
+        ),
+        context,
+    )
+
+    assert spec.base_color.texture is not None
+    assert spec.base_color.texture.uv_set.primvar_name == "st1"
+    assert spec.base_color.texture.uv_set.requested_index == 1
+    assert spec.base_color.texture.uv_set.resolution_status == "matched"
+
+
+def test_omnipbr_adapter_does_not_false_match_disjoint_bound_uv_sets():
+    context = MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=Path("."),
+        material_path="/World/Looks/Mat",
+        bound_prim_paths=("/World/MeshA", "/World/MeshB"),
+        uv_primvars_by_prim={
+            "/World/MeshA": ("st1",),
+            "/World/MeshB": ("uv",),
+        },
+    )
+
+    spec = OmniPBRAdapter().convert(
+        _raw(values={"BaseColor_Tex": "textures/wood.png", "BaseColor_MaxTexCoordIndex": 1}),
+        context,
+    )
+
+    assert spec.base_color.texture is not None
+    assert spec.base_color.texture.uv_set.primvar_name == "st"
+    assert spec.base_color.texture.uv_set.requested_index == 1
+    assert spec.base_color.texture.uv_set.resolution_status == "guessed_or_missing"
+
+
 def test_omnipbr_adapter_inverts_glossiness_scalar_to_roughness():
     spec = OmniPBRAdapter().convert(_raw(values={"glossiness": 0.25}), _context())
 

--- a/tests/test_material_graph_report.py
+++ b/tests/test_material_graph_report.py
@@ -1,0 +1,144 @@
+from roboverse_pack.blender.usd.material_graph.report import ConversionReport, adapter_from_policy
+from roboverse_pack.blender.usd.material_graph.schema import (
+    InputSpec,
+    PreviewMaterialSpec,
+    TextureSpec,
+    UVSetSpec,
+    UVTransformSpec,
+)
+
+
+def _spec(**overrides):
+    data = {
+        "material_path": "/World/Looks/Paint",
+        "material_name": "Paint",
+        "source_shader_ids": ("OmniPBR",),
+        "mdl_source_asset": None,
+        "base_color": InputSpec(value=(0.2, 0.3, 0.4), source_inputs=("BaseColor_Color",)),
+        "normal": None,
+        "metallic": None,
+        "roughness": None,
+        "specular_color": None,
+        "emissive_color": None,
+        "opacity": None,
+        "conversion_policy": "direct_graph",
+        "quality_notes": (),
+    }
+    data.update(overrides)
+    return PreviewMaterialSpec(**data)
+
+
+def test_counts_texture_base_color_and_scalar_roughness():
+    report = ConversionReport()
+    report.add_material(
+        _spec(
+            base_color=InputSpec(
+                texture=TextureSpec(
+                    file="textures/albedo.png",
+                    source_color_space="sRGB",
+                    source_input="BaseColor_Tex",
+                ),
+                source_inputs=("BaseColor_Tex",),
+            ),
+            roughness=InputSpec(value=0.42, source_inputs=("Reflection_Roughness",)),
+        )
+    )
+
+    data = report.to_dict()
+
+    assert data["summary"]["materials_total"] == 1
+    assert data["summary"]["converted_by_direct_graph"] == 1
+    assert data["texture_slots"]["base_color"]["texture"] == 1
+    assert data["texture_slots"]["roughness"]["scalar"] == 1
+
+
+def test_material_slot_entry_includes_source_texture_and_uv_details():
+    report = ConversionReport()
+    report.add_material(
+        _spec(
+            base_color=InputSpec(
+                texture=TextureSpec(
+                    file="textures/albedo.png",
+                    source_color_space="sRGB",
+                    uv_set=UVSetSpec(primvar_name="uv2", requested_index=1, resolution_status="matched"),
+                    uv_transform=UVTransformSpec(
+                        scale=(2.0, 3.0),
+                        rotation_degrees=15.0,
+                        translation=(0.25, 0.5),
+                        source_input="BaseColor_UVA",
+                    ),
+                    source_input="BaseColor_Tex",
+                ),
+                source_inputs=("BaseColor_Tex",),
+            )
+        )
+    )
+
+    material = report.to_dict()["materials"][0]
+    slot = material["slots"]["base_color"]
+
+    assert slot["status"] == "texture"
+    assert slot["source_input"] == "BaseColor_Tex"
+    assert slot["source_inputs"] == ["BaseColor_Tex"]
+    assert slot["file"] == "textures/albedo.png"
+    assert slot["source_color_space"] == "sRGB"
+    assert slot["uv_set"] == {"primvar_name": "uv2", "requested_index": 1, "resolution_status": "matched"}
+    assert slot["uv_transform"]["source_input"] == "BaseColor_UVA"
+
+
+def test_failed_material_increments_failed_count_and_warning():
+    report = ConversionReport()
+    report.add_failed_material("/World/Looks/Broken", "conversion failed: boom")
+
+    data = report.to_dict()
+
+    assert data["summary"]["materials_total"] == 1
+    assert data["summary"]["failed"] == 1
+    assert data["materials"][0]["adapter"] == "failed"
+    assert data["materials"][0]["warnings"] == ["conversion failed: boom"]
+
+
+def test_udim_and_uv_summaries_are_recorded():
+    report = ConversionReport()
+    report.add_material(
+        _spec(
+            base_color=InputSpec(
+                texture=TextureSpec(
+                    file="textures/tile_<UDIM>.png",
+                    source_color_space="sRGB",
+                    uv_set=UVSetSpec(primvar_name="uv1", requested_index=0, resolution_status="matched"),
+                    uv_transform=UVTransformSpec(scale=(2.0, 2.0), source_input="BaseColor_UVA"),
+                    source_input="BaseColor_Tex",
+                ),
+                source_inputs=("BaseColor_Tex",),
+            )
+        )
+    )
+
+    data = report.to_dict()
+
+    assert data["uv"]["uv_transforms_found"] == 1
+    assert data["uv"]["uv_transforms_converted"] == 1
+    assert data["uv"]["multi_uv_requested"] == 1
+    assert data["uv"]["multi_uv_resolved"] == 1
+    assert data["udim"]["materials_with_udim"] == 1
+    assert data["udim"]["normalized"] == 1
+
+
+def test_adapter_from_policy_mapping():
+    assert adapter_from_policy("preserve_existing_preview") == "existing_preview"
+    assert adapter_from_policy("direct_graph") == "omnipbr"
+    assert adapter_from_policy("mdl_bake") == "mdl_bake"
+    assert adapter_from_policy("scalar_fallback") == "scalar_fallback"
+    assert adapter_from_policy("class_fallback") == "semantic_class_fallback"
+    assert adapter_from_policy("failed") == "failed"
+
+
+def test_report_uses_actual_adapter_name_when_present():
+    report = ConversionReport()
+    report.add_material(_spec(adapter_name="generic_texture_graph"))
+
+    data = report.to_dict()
+
+    assert data["materials"][0]["adapter"] == "generic_texture_graph"
+    assert data["materials"][0]["policy"] == "direct_graph"

--- a/tests/test_material_graph_schema.py
+++ b/tests/test_material_graph_schema.py
@@ -1,0 +1,66 @@
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from roboverse_pack.blender.usd.material_graph.schema import (
+    InputSpec,
+    PreviewMaterialSpec,
+    RawMaterialSpec,
+    TextureSpec,
+    freeze_values,
+)
+
+
+def test_texture_spec_defaults_to_rgb_and_default_uv_set():
+    texture = TextureSpec(file="textures/wood.png", source_color_space="sRGB")
+
+    assert texture.channel == "rgb"
+    assert texture.uv_set.primvar_name == "st"
+    assert texture.scale is None
+    assert texture.bias is None
+
+
+def test_preview_material_spec_is_frozen():
+    spec = PreviewMaterialSpec(
+        material_path="/World/Looks/Paint",
+        material_name="Paint",
+        source_shader_ids=("OmniPBR",),
+        mdl_source_asset=None,
+        base_color=InputSpec(value=(0.1, 0.2, 0.3)),
+        normal=None,
+        metallic=InputSpec(value=0.0),
+        roughness=InputSpec(value=0.5),
+        specular_color=None,
+        emissive_color=None,
+        opacity=InputSpec(value=1.0),
+        ior=1.45,
+    )
+
+    assert spec.emissive_color is None
+    assert spec.ior == 1.45
+    with pytest.raises(FrozenInstanceError):
+        spec.material_name = "Primer"
+
+
+def test_raw_material_spec_carries_uninterpreted_values():
+    token = object()
+    raw = RawMaterialSpec(
+        material_path="/World/Looks/Raw",
+        material_name="Raw",
+        shader_ids=("OmniPBR",),
+        connected_surface_shader_id="OmniPBR",
+        mdl_source_asset=None,
+        values=freeze_values({"BaseColor_Color": token}),
+    )
+
+    assert raw.values["BaseColor_Color"] is token
+
+
+def test_freeze_values_returns_immutable_copy():
+    values = {"roughness": 0.4}
+    frozen = freeze_values(values)
+    values["roughness"] = 0.9
+
+    assert frozen["roughness"] == 0.4
+    with pytest.raises(TypeError):
+        frozen["roughness"] = 0.1

--- a/tests/test_material_graph_udim.py
+++ b/tests/test_material_graph_udim.py
@@ -1,0 +1,126 @@
+from pathlib import Path
+
+from roboverse_pack.blender.usd.material_graph.adapters.generic import GenericTextureGraphAdapter
+from roboverse_pack.blender.usd.material_graph.adapters.omnipbr import OmniPBRAdapter
+from roboverse_pack.blender.usd.material_graph.context import MaterialContext
+from roboverse_pack.blender.usd.material_graph.schema import RawMaterialSpec, freeze_values
+from roboverse_pack.blender.usd.material_graph.texture_paths import (
+    detect_udim_pattern,
+    find_texture_file_candidates,
+    normalize_texture_asset_path,
+)
+
+
+def _context(base_dir: Path) -> MaterialContext:
+    return MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=base_dir,
+        material_path="/World/Looks/Mat",
+    )
+
+
+def _raw(values: dict[str, object], shader_id: str = "OmniPBR") -> RawMaterialSpec:
+    return RawMaterialSpec(
+        material_path="/World/Looks/Mat",
+        material_name="Mat",
+        shader_ids=(shader_id,),
+        connected_surface_shader_id=shader_id,
+        mdl_source_asset=None,
+        values=freeze_values(values),
+    )
+
+
+def test_dot_number_udim_pattern_normalizes_to_token():
+    info = detect_udim_pattern("textures/wall.1001.png")
+
+    assert info is not None
+    assert info.normalized_path == "textures/wall.<UDIM>.png"
+    assert info.first_tile == 1001
+
+
+def test_existing_udim_token_is_kept():
+    info = detect_udim_pattern("textures/wall.<UDIM>.png")
+
+    assert info is not None
+    assert info.normalized_path == "textures/wall.<UDIM>.png"
+    assert info.first_tile is None
+
+
+def test_printf_udim_token_is_normalized():
+    info = detect_udim_pattern("textures/wall.%(UDIM)d.png")
+
+    assert info is not None
+    assert info.normalized_path == "textures/wall.<UDIM>.png"
+    assert info.first_tile is None
+
+
+def test_arbitrary_four_digit_version_is_not_udim():
+    assert detect_udim_pattern("textures/version_1042.png") is None
+
+
+def test_existing_relative_texture_candidate_found(tmp_path):
+    texture = tmp_path / "textures" / "diffuse.png"
+    texture.parent.mkdir()
+    texture.write_text("fake image")
+
+    candidates = find_texture_file_candidates(" @textures/diffuse.png@ ", tmp_path)
+    result = normalize_texture_asset_path(" @textures/diffuse.png@ ", tmp_path)
+
+    assert candidates == [texture]
+    assert result.raw == "textures/diffuse.png"
+    assert result.normalized == "textures/diffuse.png"
+    assert result.exists is True
+    assert result.warnings == ()
+
+
+def test_udim_candidate_matching_scans_existing_tiles(tmp_path):
+    texture = tmp_path / "textures" / "wall.1002.png"
+    texture.parent.mkdir()
+    texture.write_text("fake image")
+
+    result = normalize_texture_asset_path("textures/wall.1001.png", tmp_path)
+
+    assert result.normalized == "textures/wall.<UDIM>.png"
+    assert result.is_udim is True
+    assert result.candidates == (texture,)
+    assert result.exists is True
+    assert result.warnings == ()
+
+
+def test_missing_texture_warning_mentions_path(tmp_path):
+    result = normalize_texture_asset_path("textures/missing.png", tmp_path)
+
+    assert result.exists is False
+    assert result.warnings == ("Texture file not found: textures/missing.png",)
+
+
+def test_missing_udim_warning_mentions_tile(tmp_path):
+    result = normalize_texture_asset_path("textures/wall.<UDIM>.png", tmp_path)
+
+    assert result.exists is False
+    assert result.warnings == ("UDIM texture tile/file not found: textures/wall.<UDIM>.png",)
+
+
+def test_omnipbr_adapter_normalizes_udim_path_and_reports_missing(tmp_path):
+    spec = OmniPBRAdapter().convert(
+        _raw({"BaseColor_Tex": "textures/wall.1001.png"}),
+        _context(tmp_path),
+    )
+
+    assert spec.base_color.texture is not None
+    assert spec.base_color.texture.file == "textures/wall.<UDIM>.png"
+    assert spec.base_color.texture.role == "base_color"
+    assert spec.quality_notes == ("UDIM texture tile/file not found: textures/wall.<UDIM>.png",)
+
+
+def test_generic_adapter_keeps_direct_graph_and_reports_missing(tmp_path):
+    spec = GenericTextureGraphAdapter().convert(
+        _raw({"diffuse_texture": "textures/missing.png"}, shader_id="UnknownShader"),
+        _context(tmp_path),
+    )
+
+    assert spec.conversion_policy == "direct_graph"
+    assert spec.base_color.texture is not None
+    assert spec.base_color.texture.file == "textures/missing.png"
+    assert spec.base_color.texture.role == "base_color"
+    assert spec.quality_notes == ("Texture file not found: textures/missing.png",)

--- a/tests/test_material_graph_uv_transform.py
+++ b/tests/test_material_graph_uv_transform.py
@@ -1,0 +1,88 @@
+from roboverse_pack.blender.usd.material_graph.schema import UVTransformSpec
+from roboverse_pack.blender.usd.material_graph.uv import parse_uva, resolve_slot_uv_transform
+
+
+def test_parse_uva_float4_uses_scale_and_translation_pairs():
+    assert parse_uva((2.0, 3.0, 0.25, 0.5)) == UVTransformSpec(
+        scale=(2.0, 3.0),
+        translation=(0.25, 0.5),
+    )
+
+
+def test_parse_uva_float3_uses_uniform_scale_and_translation_pair():
+    assert parse_uva((2.0, 0.25, 0.5)) == UVTransformSpec(
+        scale=(2.0, 2.0),
+        translation=(0.25, 0.5),
+    )
+
+
+def test_parse_uva_mapping_accepts_aliases_for_translation_and_rotation():
+    assert parse_uva(
+        {
+            "scale": (2.0, 3.0),
+            "offset": (0.25, 0.5),
+            "rotation": 45.0,
+        }
+    ) == UVTransformSpec(
+        scale=(2.0, 3.0),
+        rotation_degrees=45.0,
+        translation=(0.25, 0.5),
+    )
+
+
+def test_parse_uva_mapping_accepts_scalar_scale_translation_and_rotation_degrees():
+    assert parse_uva(
+        {
+            "scale": 2.0,
+            "translation": 0.25,
+            "rotation_degrees": 90.0,
+        }
+    ) == UVTransformSpec(
+        scale=(2.0, 2.0),
+        rotation_degrees=90.0,
+        translation=(0.25, 0.25),
+    )
+
+
+def test_parse_uva_returns_none_for_unparseable_values():
+    assert parse_uva("not-a-uva") is None
+    assert parse_uva((1.0, 2.0)) is None
+
+
+def test_resolve_slot_uv_transform_prefers_alias_and_records_source_input():
+    spec = resolve_slot_uv_transform(
+        {"BaseColor_UVA": (2.0, 3.0, 0.25, 0.5), "BaseColor_UScale": 8.0},
+        "BaseColor",
+        ("BaseColor_UVA",),
+    )
+
+    assert spec == UVTransformSpec(
+        scale=(2.0, 3.0),
+        translation=(0.25, 0.5),
+        source_input="BaseColor_UVA",
+    )
+
+
+def test_resolve_slot_uv_transform_falls_back_to_separate_fields():
+    spec = resolve_slot_uv_transform(
+        {
+            "BaseColor_UScale": 2.0,
+            "BaseColor_VScale": 3.0,
+            "BaseColor_Rotation": 45.0,
+            "BaseColor_UOffset": 0.25,
+            "BaseColor_VOffset": 0.5,
+        },
+        "BaseColor",
+        ("BaseColor_UVA",),
+    )
+
+    assert spec == UVTransformSpec(
+        scale=(2.0, 3.0),
+        rotation_degrees=45.0,
+        translation=(0.25, 0.5),
+        source_input="BaseColor_*",
+    )
+
+
+def test_resolve_slot_uv_transform_ignores_empty_separate_defaults():
+    assert resolve_slot_uv_transform({}, "BaseColor", ("BaseColor_UVA",)) is None

--- a/tests/test_material_overlay_error_handling.py
+++ b/tests/test_material_overlay_error_handling.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+
+from roboverse_pack.blender.usd import overlay
+from roboverse_pack.blender.usd.material_graph.context import MaterialContext
+from roboverse_pack.blender.usd.material_graph.schema import InputSpec, PreviewMaterialSpec, RawMaterialSpec, freeze_values
+
+
+def test_material_authoring_failure_records_failed_entry_and_continues(monkeypatch):
+    raw = RawMaterialSpec(
+        material_path="/World/Looks/Broken",
+        material_name="Broken",
+        shader_ids=("OmniPBR",),
+        connected_surface_shader_id="OmniPBR",
+        mdl_source_asset=None,
+        values=freeze_values({"BaseColor_Color": (0.1, 0.2, 0.3)}),
+    )
+    spec = PreviewMaterialSpec(
+        material_path=raw.material_path,
+        material_name=raw.material_name,
+        source_shader_ids=raw.shader_ids,
+        mdl_source_asset=None,
+        base_color=InputSpec(value=(0.1, 0.2, 0.3)),
+        normal=None,
+        metallic=None,
+        roughness=None,
+        specular_color=None,
+        emissive_color=None,
+        opacity=None,
+    )
+    context = MaterialContext(
+        source_path=Path("scene.usda"),
+        texture_base_dir=Path("."),
+        material_path=raw.material_path,
+    )
+    report = {"materials": {}}
+
+    monkeypatch.setattr(overlay, "convert_material", lambda raw_arg, context_arg: spec)
+
+    def fail_authoring(*_args):
+        raise RuntimeError("author failed")
+
+    monkeypatch.setattr(overlay, "author_preview_material", fail_authoring)
+
+    overlay._convert_and_author_material(raw, context, report, object(), object(), object(), object())
+
+    assert report["materials"][raw.material_path] == {
+        "status": "failed",
+        "warnings": ["conversion failed: author failed"],
+        "material_class": None,
+    }
+
+
+def test_material_extraction_failure_records_failed_entry(monkeypatch):
+    class _Prim:
+        def GetPath(self):
+            return "/World/Looks/BrokenExtract"
+
+    report = {"materials": {}}
+
+    def fail_extract(*_args):
+        raise RuntimeError("extract failed")
+
+    monkeypatch.setattr(overlay, "extract_material", fail_extract)
+
+    overlay._extract_convert_and_author_material(
+        _Prim(),
+        object(),
+        Path("scene.usda"),
+        report,
+        object(),
+        object(),
+        object(),
+        object(),
+    )
+
+    assert report["materials"]["/World/Looks/BrokenExtract"] == {
+        "status": "failed",
+        "warnings": ["conversion failed: extract failed"],
+        "material_class": None,
+    }

--- a/tests/test_render_box_task_blender_video.py
+++ b/tests/test_render_box_task_blender_video.py
@@ -62,6 +62,13 @@ def test_parse_args_accepts_target_video_options(tmp_path: Path) -> None:
     assert args.duration_sec == 1.5
     assert args.fps == 30
     assert args.dry_run is True
+    assert args.scene_task_offset == "none"
+    assert args.scene_import_offset == "auto"
+    assert args.clear_task_volume is True
+    assert args.camera_pos == (1.45, -1.0, 0.95)
+    assert args.camera_look_at == (0.55, 0.0, 0.38)
+    assert args.head_light_intensity == 400.0
+    assert args.exposure == -2.0
 
 
 @pytest.mark.parametrize("option", ["--fps", "--width", "--height", "--samples", "--out-frames"])
@@ -368,6 +375,113 @@ def test_camera_object_lookup_prefers_public_then_private_mapping() -> None:
         cli.camera_object_for(private_only, "missing")
 
 
+def test_scene_task_offset_auto_uses_negative_scene_default_position() -> None:
+    scenario = SimpleNamespace(scene=SimpleNamespace(default_position=(-5.8, 1.8, 0.0)))
+
+    assert cli.resolve_scene_task_offset("auto", scenario) == (5.8, -1.8, -0.0)
+    assert cli.resolve_scene_task_offset("none", scenario) == (0.0, 0.0, 0.0)
+    assert cli.resolve_scene_task_offset("1.0,2.0,3.0", scenario) == (1.0, 2.0, 3.0)
+
+
+def test_scene_import_offset_auto_uses_scene_default_position() -> None:
+    scenario = SimpleNamespace(scene=SimpleNamespace(default_position=(-5.8, 1.8, 0.0)))
+
+    assert cli.resolve_scene_import_offset("auto", scenario) == (-5.8, 1.8, 0.0)
+    assert cli.resolve_scene_import_offset("none", scenario) == (0.0, 0.0, 0.0)
+    assert cli.resolve_scene_import_offset("1.0,2.0,3.0", scenario) == (1.0, 2.0, 3.0)
+
+
+def test_apply_scene_task_offset_moves_cameras_and_lights() -> None:
+    camera = SimpleNamespace(pos=(1.45, -1.0, 0.95), look_at=(0.55, 0.0, 0.38))
+    light = SimpleNamespace(pos=(0.55, 0.0, 1.45))
+    scenario = SimpleNamespace(cameras=[camera], lights=[light])
+
+    cli.apply_scene_task_offset_to_scenario(scenario, (5.8, -1.8, 0.0))
+
+    assert camera.pos == (7.25, -2.8, 0.95)
+    assert camera.look_at == (6.35, -1.8, 0.38)
+    assert light.pos == (6.35, -1.8, 1.45)
+
+
+def test_apply_scene_import_offset_moves_blender_scene_roots(monkeypatch: pytest.MonkeyPatch) -> None:
+    update_calls: list[str] = []
+    bpy = ModuleType("bpy")
+    bpy.context = SimpleNamespace(view_layer=SimpleNamespace(update=lambda: update_calls.append("update")))
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+
+    root = SimpleNamespace(location=[10.0, -2.0, 0.0])
+    handler = SimpleNamespace(_scene_objs=[root])
+
+    cli.apply_scene_import_offset_to_handler(handler, (-5.8, 1.8, 0.0))
+
+    assert root.location == pytest.approx([4.2, -0.2, 0.0])
+    assert update_calls == ["update"]
+
+
+def test_clear_task_volume_hides_intersecting_scene_meshes_but_keeps_floor() -> None:
+    class IdentityMatrix:
+        def __matmul__(self, point):
+            return point
+
+    def obj(name: str, bounds, obj_type: str = "MESH"):
+        return SimpleNamespace(
+            name=name,
+            type=obj_type,
+            bound_box=[
+                (bounds[0][0], bounds[0][1], bounds[0][2]),
+                (bounds[0][0], bounds[0][1], bounds[1][2]),
+                (bounds[0][0], bounds[1][1], bounds[0][2]),
+                (bounds[0][0], bounds[1][1], bounds[1][2]),
+                (bounds[1][0], bounds[0][1], bounds[0][2]),
+                (bounds[1][0], bounds[0][1], bounds[1][2]),
+                (bounds[1][0], bounds[1][1], bounds[0][2]),
+                (bounds[1][0], bounds[1][1], bounds[1][2]),
+            ],
+            matrix_world=IdentityMatrix(),
+            children=[],
+            hide_render=False,
+            hide_viewport=False,
+        )
+
+    wall = obj("wall", ((-0.1, -1.0, 0.0), (0.1, 1.0, 2.0)))
+    floor = obj("floor", ((-2.0, -2.0, -0.02), (2.0, 2.0, 0.02)))
+    far_cabinet = obj("cabinet", ((5.0, 5.0, 0.0), (6.0, 6.0, 1.0)))
+    handler = SimpleNamespace(_scene_objs=[SimpleNamespace(children=[wall, floor, far_cabinet])])
+
+    status = cli.clear_task_volume_for_replay(handler, center=(0.0, 0.0, 0.0), half_extents=(1.0, 1.0, 2.0))
+
+    assert status == {"status": "applied", "hidden_count": 1}
+    assert wall.hide_render is True
+    assert wall.hide_viewport is True
+    assert floor.hide_render is False
+    assert far_cabinet.hide_render is False
+
+
+def test_translate_tensor_state_offsets_root_and_body_positions_without_mutating_source() -> None:
+    state = SimpleNamespace(
+        objects={
+            "box": SimpleNamespace(
+                root_state=np.array([[0.55, 0.0, 0.42, 1.0, 0.0, 0.0, 0.0]], dtype=np.float32),
+                body_state=None,
+            )
+        },
+        robots={
+            "robot": SimpleNamespace(
+                root_state=np.array([[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0]], dtype=np.float32),
+                body_state=np.array([[[0.1, 0.2, 0.3, 1.0, 0.0, 0.0, 0.0]]], dtype=np.float32),
+            )
+        },
+        cameras={},
+    )
+
+    shifted = cli.translate_tensor_state(state, (5.8, -1.8, 0.0))
+
+    np.testing.assert_allclose(shifted.objects["box"].root_state[0, :3], [6.35, -1.8, 0.42])
+    np.testing.assert_allclose(shifted.robots["robot"].root_state[0, :3], [5.8, -1.8, 0.0])
+    np.testing.assert_allclose(shifted.robots["robot"].body_state[0, 0, :3], [5.9, -1.6, 0.3])
+    np.testing.assert_allclose(state.objects["box"].root_state[0, :3], [0.55, 0.0, 0.42])
+
+
 def test_configure_blender_for_video_sets_cpu_and_gpu_devices(monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeDevice:
         def __init__(self, device_type: str):
@@ -401,16 +515,82 @@ def test_configure_blender_for_video_sets_cpu_and_gpu_devices(monkeypatch: pytes
     assert scene.cycles.device == "CPU"
     assert scene.render.image_settings.file_format == "PNG"
     assert scene.render.image_settings.color_mode == "RGB"
+    assert scene.render.use_compositing is False
+    assert scene.render.use_sequencer is False
     assert scene.view_settings.view_transform == "Standard"
-    assert scene.view_settings.exposure == 0.0
+    assert scene.view_settings.exposure == -2.0
     assert scene.view_settings.gamma == 1.0
+    assert scene.cycles.use_denoising is True
+    assert scene.cycles.denoiser == "OPTIX"
+    assert scene.cycles.denoising_input_passes == "RGB_ALBEDO_NORMAL"
+    assert scene.cycles.denoising_prefilter == "ACCURATE"
+    assert scene.cycles.denoising_quality == "HIGH"
+    assert scene.cycles.use_adaptive_sampling is False
+    assert scene.cycles.max_bounces == 10
+    assert scene.cycles.diffuse_bounces == 4
+    assert scene.cycles.glossy_bounces == 4
+    assert scene.cycles.transmission_bounces == 10
+    assert scene.cycles.transparent_max_bounces == 10
+    assert scene.cycles.caustics_reflective is True
+    assert scene.cycles.caustics_refractive is True
+    assert scene.cycles.sample_clamp_indirect == 10.0
+    assert scene.cycles.blur_glossy == 1.0
 
-    cli.configure_blender_for_video(samples=8, device="AUTO")
+    cli.configure_blender_for_video(samples=8, device="AUTO", exposure=-1.25)
     assert scene.cycles.device == "GPU"
     assert scene.cycles.samples == 8
+    assert scene.view_settings.exposure == -1.25
     assert cycles_prefs.compute_device_type == "OPTIX"
     assert cycles_prefs.get_devices_calls == 1
     assert all(device.use for device in cycles_prefs.devices)
+
+
+def test_repair_imported_scene_materials_uses_metasim_helper(monkeypatch: pytest.MonkeyPatch) -> None:
+    scene_objects = [object(), object()]
+    update_calls: list[str] = []
+    bpy = ModuleType("bpy")
+    bpy.context = SimpleNamespace(
+        scene=SimpleNamespace(objects=scene_objects),
+        view_layer=SimpleNamespace(update=lambda: update_calls.append("update")),
+    )
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+
+    repair_calls: list[tuple[list[object], dict[str, tuple[float, float, float, float]]]] = []
+    blender_module = ModuleType("metasim.sim.blender.blender")
+    blender_module._repair_imported_materials = lambda objects, overrides: repair_calls.append((objects, overrides))
+    monkeypatch.setitem(sys.modules, "metasim", ModuleType("metasim"))
+    monkeypatch.setitem(sys.modules, "metasim.sim", ModuleType("metasim.sim"))
+    monkeypatch.setitem(sys.modules, "metasim.sim.blender", ModuleType("metasim.sim.blender"))
+    monkeypatch.setitem(sys.modules, "metasim.sim.blender.blender", blender_module)
+
+    status = cli.repair_imported_scene_materials()
+
+    assert status["status"] == "applied"
+    assert status["object_count"] == 2
+    assert status["override_count"] > 0
+    assert repair_calls == [(scene_objects, cli.KUJIALE_MATERIAL_OVERRIDES)]
+    assert "Wall" in repair_calls[0][1]
+    assert update_calls == ["update"]
+
+
+def test_local_bundle_render_runtime_disables_hf_download_checks(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+    hf_util = ModuleType("metasim.utils.hf_util")
+    hf_util.check_and_download_single = lambda filepath: calls.append(f"single:{filepath}")
+    hf_util.check_and_download_recursive = lambda filepaths, n_processes=16: calls.append("recursive")
+    monkeypatch.setitem(sys.modules, "metasim", ModuleType("metasim"))
+    monkeypatch.setitem(sys.modules, "metasim.utils", ModuleType("metasim.utils"))
+    monkeypatch.setitem(sys.modules, "metasim.utils.hf_util", hf_util)
+
+    original_single = hf_util.check_and_download_single
+    original_recursive = hf_util.check_and_download_recursive
+    with cli.local_bundle_render_runtime():
+        hf_util.check_and_download_single("missing.png")
+        hf_util.check_and_download_recursive(["missing.png"])
+
+    assert calls == []
+    assert hf_util.check_and_download_single is original_single
+    assert hf_util.check_and_download_recursive is original_recursive
 
 
 def test_render_scene_segment_launches_handler_before_rendering(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -434,7 +614,22 @@ def test_render_scene_segment_launches_handler_before_rendering(monkeypatch: pyt
     monkeypatch.setitem(sys.modules, "metasim.sim", ModuleType("metasim.sim"))
     monkeypatch.setitem(sys.modules, "metasim.sim.blender", ModuleType("metasim.sim.blender"))
     monkeypatch.setitem(sys.modules, "metasim.sim.blender.blender", blender_module)
-    monkeypatch.setattr(cli, "configure_blender_for_video", lambda *, samples, device: events.append("configure"))
+    monkeypatch.setattr(
+        cli,
+        "apply_scene_import_offset_to_handler",
+        lambda handler, offset: events.append(f"scene_offset:{offset}"),
+    )
+    monkeypatch.setattr(cli, "configure_blender_for_video", lambda *, samples, device, exposure=-2.0: events.append("configure"))
+    monkeypatch.setattr(
+        cli,
+        "repair_imported_scene_materials",
+        lambda: events.append("repair") or {"status": "applied"},
+    )
+    monkeypatch.setattr(
+        cli,
+        "clear_task_volume_for_replay",
+        lambda handler, center: events.append(f"clear:{center}") or {"status": "applied", "hidden_count": 2},
+    )
     monkeypatch.setattr(cli, "apply_state_to_handler", lambda handler, state: events.append(f"state:{state}"))
     monkeypatch.setattr(
         cli,
@@ -453,10 +648,22 @@ def test_render_scene_segment_launches_handler_before_rendering(monkeypatch: pyt
         frame_dir=tmp_path,
         samples=8,
         device="CPU",
+        scene_import_offset=(1.0, 2.0, 3.0),
     )
 
     assert created_handlers[0].scenario is scenario
-    assert events == ["launch", "configure", "state:state-7", "render:camera0:frame_000000.png", "close"]
+    assert scenario._box_task_room_material_repair == {"status": "applied"}
+    assert scenario._box_task_volume_clearance == {"status": "applied", "hidden_count": 2}
+    assert events == [
+        "launch",
+        "scene_offset:(1.0, 2.0, 3.0)",
+        "clear:(0.0, 0.0, 0.0)",
+        "repair",
+        "configure",
+        "state:state-7",
+        "render:camera0:frame_000000.png",
+        "close",
+    ]
 
 
 def test_render_png_frame_sets_camera_resolution_and_filepath(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -491,6 +698,45 @@ def test_render_png_frame_sets_camera_resolution_and_filepath(monkeypatch: pytes
     assert scene.render.image_settings.file_format == "PNG"
     assert scene.render.image_settings.color_mode == "RGB"
     assert render_calls == [{"write_still": True}]
+
+
+def test_apply_state_to_handler_uses_private_tensor_path_without_readback_render(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    update_calls: list[str] = []
+    bpy = ModuleType("bpy")
+    bpy.context = SimpleNamespace(view_layer=SimpleNamespace(update=lambda: update_calls.append("update")))
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+
+    class FastTensorHandler:
+        def __init__(self):
+            self.applied = []
+            self.invalidated = 0
+            self._last_tensor_state = None
+            self._render_dirty = False
+
+        def _invalidate_state_caches(self):
+            self.invalidated += 1
+
+        def _apply_tensor_state(self, state):
+            self.applied.append(state)
+
+        def set_states(self, state):
+            raise AssertionError("fast TensorState path must not call set_states")
+
+        def refresh_render(self):
+            raise AssertionError("fast TensorState path must not render readback")
+
+    state = SimpleNamespace(objects={}, robots={}, cameras={})
+    handler = FastTensorHandler()
+
+    cli.apply_state_to_handler(handler, state)
+
+    assert handler.applied == [state]
+    assert handler.invalidated == 1
+    assert handler._last_tensor_state is state
+    assert handler._render_dirty is True
+    assert update_calls == ["update"]
 
 
 def test_apply_state_to_handler_uses_blender_readback_format_for_handler_refresh(

--- a/tests/test_render_box_task_blender_video.py
+++ b/tests/test_render_box_task_blender_video.py
@@ -206,8 +206,8 @@ def test_render_frames_materializes_unique_source_frames_before_scene_render(
     tensor_states = {2: "state-2", 5: "state-5", 9: "state-9"}
     calls: dict[str, object] = {"segments": []}
 
-    def fake_decode(traj_path, requested_indices):
-        calls["decode"] = (traj_path, list(requested_indices))
+    def fake_decode(traj_path, requested_indices, bundle_paths=None):
+        calls["decode"] = (traj_path, list(requested_indices), bundle_paths)
         return tensor_states
 
     def fake_build_scenario(**kwargs):
@@ -236,7 +236,7 @@ def test_render_frames_materializes_unique_source_frames_before_scene_render(
         frame_dir=tmp_path / "frames",
     )
 
-    assert calls["decode"] == (paths.traj_path, [2, 5, 9])
+    assert calls["decode"] == (paths.traj_path, [2, 5, 9], paths)
     assert len(calls["segments"]) == 2
     assert calls["segments"][0]["scenario"] == {"scene": "scene-a", "width": 320, "height": 240}
     assert calls["segments"][0]["out_start"] == 0

--- a/tests/test_render_box_task_blender_video.py
+++ b/tests/test_render_box_task_blender_video.py
@@ -116,3 +116,36 @@ def test_dry_run_prints_render_plan(tmp_path: Path, capsys) -> None:
     assert payload["out_frames"] == 6
     assert payload["scene_frame_bounds"] == [[0, 3], [3, 6]]
     assert payload["out_video"].endswith("out.mp4")
+
+
+def test_frame_pattern_uses_zero_padded_pngs(tmp_path: Path) -> None:
+    assert cli.frame_path(tmp_path, 12).name == "frame_000012.png"
+
+
+def test_ffmpeg_command_uses_yuv420p_for_compatibility(tmp_path: Path) -> None:
+    command = cli.ffmpeg_command(
+        ffmpeg_bin="/usr/bin/ffmpeg",
+        frame_dir=tmp_path / "frames",
+        fps=30,
+        out_video=tmp_path / "video.mp4",
+    )
+
+    assert command == [
+        "/usr/bin/ffmpeg",
+        "-y",
+        "-framerate",
+        "30",
+        "-i",
+        str(tmp_path / "frames" / "frame_%06d.png"),
+        "-pix_fmt",
+        "yuv420p",
+        "-vcodec",
+        "libx264",
+        str(tmp_path / "video.mp4"),
+    ]
+
+
+def test_work_dir_defaults_under_bundle_root(tmp_path: Path) -> None:
+    bundle = _make_bundle(tmp_path)
+    work_dir = cli.select_work_dir(bundle_root=bundle, tmp_dir=None, pid=123)
+    assert work_dir == bundle / ".tmp_box_task_blender" / "render_work_123"

--- a/tests/test_render_box_task_blender_video.py
+++ b/tests/test_render_box_task_blender_video.py
@@ -4,7 +4,9 @@ import json
 import subprocess
 import sys
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
+import numpy as np
 import pytest
 
 from scripts.benchmark.rendering import render_box_task_blender_video as cli
@@ -149,3 +151,263 @@ def test_work_dir_defaults_under_bundle_root(tmp_path: Path) -> None:
     bundle = _make_bundle(tmp_path)
     work_dir = cli.select_work_dir(bundle_root=bundle, tmp_dir=None, pid=123)
     assert work_dir == bundle / ".tmp_box_task_blender" / "render_work_123"
+
+
+def test_render_plan_calls_frame_renderer_once_per_output_frame(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    bundle = _make_bundle(tmp_path)
+    calls: dict[str, object] = {}
+
+    def fake_render_frames(**kwargs):
+        calls["render_frames"] = kwargs
+        kwargs["frame_dir"].mkdir(parents=True, exist_ok=True)
+
+    def fake_assemble_video(**kwargs):
+        calls["assemble_video"] = kwargs
+        kwargs["out_video"].write_bytes(b"fake mp4")
+
+    monkeypatch.setattr(cli, "render_frames", fake_render_frames)
+    monkeypatch.setattr(cli, "assemble_video", fake_assemble_video)
+
+    exit_code = cli.main(
+        [
+            "--bundle-root",
+            str(bundle),
+            "--scenes",
+            "0021,0022",
+            "--out-frames",
+            "4",
+            "--fps",
+            "24",
+            "--out-video",
+            str(tmp_path / "out.mp4"),
+        ]
+    )
+
+    assert exit_code == 0
+    render_kwargs = calls["render_frames"]
+    assert render_kwargs["scenes"] == ["kujiale_scene_0021", "kujiale_scene_0022"]
+    assert render_kwargs["frame_to_src"].tolist() == [0, 283, 565, 848]
+    assert len(render_kwargs["frame_to_src"]) == 4
+    assert calls["assemble_video"]["frame_dir"] == render_kwargs["frame_dir"]
+    assert calls["assemble_video"]["fps"] == 24
+    assert calls["assemble_video"]["out_video"] == (tmp_path / "out.mp4").resolve()
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"status": "ok", "out_video": str((tmp_path / "out.mp4").resolve()), "frames": 4}
+    assert (tmp_path / "out.mp4").read_bytes() == b"fake mp4"
+
+
+def test_render_frames_materializes_unique_source_frames_before_scene_render(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = cli.BoxTaskBundlePaths.from_root(_make_bundle(tmp_path))
+    source_indices = np.array([5, 2, 5, 9, 2, 9], dtype=np.int32)
+    tensor_states = {2: "state-2", 5: "state-5", 9: "state-9"}
+    calls: dict[str, object] = {"segments": []}
+
+    def fake_decode(traj_path, requested_indices):
+        calls["decode"] = (traj_path, list(requested_indices))
+        return tensor_states
+
+    def fake_build_scenario(**kwargs):
+        return {"scene": kwargs["scene"], "width": kwargs["width"], "height": kwargs["height"]}
+
+    def fake_render_scene_segment(**kwargs):
+        calls["segments"].append(kwargs)
+
+    monkeypatch.setattr(cli, "decode_trajectory_tensor_states", fake_decode)
+    monkeypatch.setattr(cli, "build_box_task_scenario", fake_build_scenario)
+    monkeypatch.setattr(cli, "render_scene_segment", fake_render_scene_segment)
+
+    cli.render_frames(
+        args=SimpleNamespace(
+            width=320,
+            height=240,
+            samples=8,
+            device="CPU",
+            camera_pos=(1.0, 2.0, 3.0),
+            camera_look_at=(0.0, 0.0, 0.0),
+            head_light_intensity=100.0,
+        ),
+        paths=paths,
+        scenes=["scene-a", "scene-b"],
+        frame_to_src=source_indices,
+        frame_dir=tmp_path / "frames",
+    )
+
+    assert calls["decode"] == (paths.traj_path, [2, 5, 9])
+    assert len(calls["segments"]) == 2
+    assert calls["segments"][0]["scenario"] == {"scene": "scene-a", "width": 320, "height": 240}
+    assert calls["segments"][0]["out_start"] == 0
+    assert calls["segments"][0]["out_end"] == 3
+    assert calls["segments"][0]["frame_to_src"].tolist() == [5, 2, 5, 9, 2, 9]
+    assert calls["segments"][0]["tensor_states_by_src"] is tensor_states
+    assert calls["segments"][1]["scenario"]["scene"] == "scene-b"
+    assert calls["segments"][1]["out_start"] == 3
+    assert calls["segments"][1]["out_end"] == 6
+
+
+def test_camera_object_lookup_prefers_public_then_private_mapping() -> None:
+    handler = SimpleNamespace(camera_objs={"camera0": "public-camera"}, _camera_objs={"camera0": "private-camera"})
+    assert cli.camera_object_for(handler, "camera0") == "public-camera"
+
+    private_only = SimpleNamespace(_camera_objs={"camera0": "private-camera"})
+    assert cli.camera_object_for(private_only, "camera0") == "private-camera"
+
+    with pytest.raises(KeyError, match="missing"):
+        cli.camera_object_for(private_only, "missing")
+
+
+def test_configure_blender_for_video_sets_cpu_and_gpu_devices(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeDevice:
+        def __init__(self, device_type: str):
+            self.type = device_type
+            self.use = False
+
+    class FakePreferences:
+        def __init__(self):
+            self.compute_device_type = None
+            self.devices = [FakeDevice("CPU"), FakeDevice("OPTIX")]
+            self.get_devices_calls = 0
+
+        def get_devices(self):
+            self.get_devices_calls += 1
+            return self.devices
+
+    cycles_prefs = FakePreferences()
+    scene = SimpleNamespace(
+        render=SimpleNamespace(engine=None, image_settings=SimpleNamespace(file_format=None, color_mode=None)),
+        cycles=SimpleNamespace(samples=None, device=None),
+        view_settings=SimpleNamespace(view_transform=None, exposure=None, gamma=None),
+    )
+    bpy = ModuleType("bpy")
+    bpy.context = SimpleNamespace(scene=scene, preferences=SimpleNamespace(addons={"cycles": SimpleNamespace(preferences=cycles_prefs)}))
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+
+    cli.configure_blender_for_video(samples=4, device="CPU")
+    assert scene.render.engine == "CYCLES"
+    assert scene.cycles.samples == 4
+    assert scene.cycles.device == "CPU"
+    assert scene.render.image_settings.file_format == "PNG"
+    assert scene.render.image_settings.color_mode == "RGB"
+    assert scene.view_settings.view_transform == "Standard"
+    assert scene.view_settings.exposure == 0.0
+    assert scene.view_settings.gamma == 1.0
+
+    cli.configure_blender_for_video(samples=8, device="AUTO")
+    assert scene.cycles.device == "GPU"
+    assert scene.cycles.samples == 8
+    assert cycles_prefs.compute_device_type == "OPTIX"
+    assert cycles_prefs.get_devices_calls == 1
+    assert all(device.use for device in cycles_prefs.devices)
+
+
+def test_render_scene_segment_launches_handler_before_rendering(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    events: list[str] = []
+    created_handlers: list[object] = []
+
+    class FakeHandler:
+        def __init__(self, scenario):
+            self.scenario = scenario
+            created_handlers.append(self)
+
+        def launch(self):
+            events.append("launch")
+
+        def close(self):
+            events.append("close")
+
+    blender_module = ModuleType("metasim.sim.blender.blender")
+    blender_module.BlenderHandler = FakeHandler
+    monkeypatch.setitem(sys.modules, "metasim", ModuleType("metasim"))
+    monkeypatch.setitem(sys.modules, "metasim.sim", ModuleType("metasim.sim"))
+    monkeypatch.setitem(sys.modules, "metasim.sim.blender", ModuleType("metasim.sim.blender"))
+    monkeypatch.setitem(sys.modules, "metasim.sim.blender.blender", blender_module)
+    monkeypatch.setattr(cli, "configure_blender_for_video", lambda *, samples, device: events.append("configure"))
+    monkeypatch.setattr(cli, "apply_state_to_handler", lambda handler, state: events.append(f"state:{state}"))
+    monkeypatch.setattr(
+        cli,
+        "render_png_frame",
+        lambda *, handler, camera, path: events.append(f"render:{camera.name}:{path.name}"),
+    )
+
+    camera = SimpleNamespace(name="camera0", width=320, height=240)
+    scenario = SimpleNamespace(cameras=[camera])
+    cli.render_scene_segment(
+        scenario=scenario,
+        tensor_states_by_src={7: "state-7"},
+        frame_to_src=[7],
+        out_start=0,
+        out_end=1,
+        frame_dir=tmp_path,
+        samples=8,
+        device="CPU",
+    )
+
+    assert created_handlers[0].scenario is scenario
+    assert events == ["launch", "configure", "state:state-7", "render:camera0:frame_000000.png", "close"]
+
+
+def test_render_png_frame_sets_camera_resolution_and_filepath(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    render_calls: list[dict[str, object]] = []
+    scene = SimpleNamespace(
+        camera=None,
+        render=SimpleNamespace(resolution_x=None, resolution_y=None, resolution_percentage=None, filepath=None),
+    )
+    bpy = ModuleType("bpy")
+    bpy.context = SimpleNamespace(scene=scene)
+    bpy.ops = SimpleNamespace(render=SimpleNamespace(render=lambda **kwargs: render_calls.append(kwargs)))
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+
+    camera_obj = object()
+    handler = SimpleNamespace(camera_objs={"camera0": camera_obj})
+    camera = SimpleNamespace(name="camera0", width=320, height=240)
+    out_path = tmp_path / "frame.png"
+
+    cli.render_png_frame(handler=handler, camera=camera, path=out_path)
+
+    assert scene.camera is camera_obj
+    assert scene.render.resolution_x == 320
+    assert scene.render.resolution_y == 240
+    assert scene.render.resolution_percentage == 100
+    assert scene.render.filepath == str(out_path)
+    assert render_calls == [{"write_still": True}]
+
+
+def test_apply_state_to_handler_passes_tensor_state_directly_falls_back_to_list_and_refreshes() -> None:
+    class FakeHandler:
+        def __init__(self):
+            self.calls = []
+            self.refresh_calls = 0
+
+        def set_states(self, state):
+            if isinstance(state, list):
+                raise AssertionError("TensorState must not be wrapped in a list")
+            self.calls.append(state)
+
+        def refresh_render(self):
+            self.refresh_calls += 1
+
+    handler = FakeHandler()
+    cli.apply_state_to_handler(handler, "tensor-state")
+    assert handler.calls == ["tensor-state"]
+    assert handler.refresh_calls == 1
+
+    class FallbackHandler:
+        def __init__(self):
+            self.calls = []
+            self.refresh_calls = 0
+
+        def set_states(self, state):
+            self.calls.append(state)
+            if state == "tensor-state":
+                raise TypeError("cannot apply tensor")
+
+        def refresh_render(self):
+            self.refresh_calls += 1
+
+    fallback_handler = FallbackHandler()
+    cli.apply_state_to_handler(fallback_handler, "tensor-state")
+    assert fallback_handler.calls == ["tensor-state", ["tensor-state"]]
+    assert fallback_handler.refresh_calls == 1

--- a/tests/test_render_box_task_blender_video.py
+++ b/tests/test_render_box_task_blender_video.py
@@ -198,7 +198,7 @@ def test_render_plan_calls_frame_renderer_once_per_output_frame(
     assert (tmp_path / "out.mp4").read_bytes() == b"fake mp4"
 
 
-def test_render_frames_materializes_unique_source_frames_before_scene_render(
+def test_render_frames_decodes_unique_source_frames_in_subprocess_before_scene_render(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     paths = cli.BoxTaskBundlePaths.from_root(_make_bundle(tmp_path))
@@ -206,8 +206,11 @@ def test_render_frames_materializes_unique_source_frames_before_scene_render(
     tensor_states = {2: "state-2", 5: "state-5", 9: "state-9"}
     calls: dict[str, object] = {"segments": []}
 
-    def fake_decode(traj_path, requested_indices, bundle_paths=None):
-        calls["decode"] = (traj_path, list(requested_indices), bundle_paths)
+    def fake_decode_subprocess(**kwargs):
+        calls["decode_subprocess"] = kwargs
+
+    def fake_load_decoded(path):
+        calls["load_decoded"] = path
         return tensor_states
 
     def fake_build_scenario(**kwargs):
@@ -216,10 +219,12 @@ def test_render_frames_materializes_unique_source_frames_before_scene_render(
     def fake_render_scene_segment(**kwargs):
         calls["segments"].append(kwargs)
 
-    monkeypatch.setattr(cli, "decode_trajectory_tensor_states", fake_decode)
+    monkeypatch.setattr(cli, "decode_trajectory_tensor_states_subprocess", fake_decode_subprocess)
+    monkeypatch.setattr(cli, "load_decoded_tensor_states", fake_load_decoded)
     monkeypatch.setattr(cli, "build_box_task_scenario", fake_build_scenario)
     monkeypatch.setattr(cli, "render_scene_segment", fake_render_scene_segment)
 
+    frame_dir = tmp_path / "work" / "frames"
     cli.render_frames(
         args=SimpleNamespace(
             width=320,
@@ -233,10 +238,13 @@ def test_render_frames_materializes_unique_source_frames_before_scene_render(
         paths=paths,
         scenes=["scene-a", "scene-b"],
         frame_to_src=source_indices,
-        frame_dir=tmp_path / "frames",
+        frame_dir=frame_dir,
     )
 
-    assert calls["decode"] == (paths.traj_path, [2, 5, 9], paths)
+    assert calls["decode_subprocess"]["paths"] is paths
+    assert calls["decode_subprocess"]["source_indices"] == [2, 5, 9]
+    assert calls["decode_subprocess"]["state_path"] == frame_dir.parent / "decoded_tensor_states.pt"
+    assert calls["load_decoded"] == frame_dir.parent / "decoded_tensor_states.pt"
     assert len(calls["segments"]) == 2
     assert calls["segments"][0]["scenario"] == {"scene": "scene-a", "width": 320, "height": 240}
     assert calls["segments"][0]["out_start"] == 0
@@ -246,6 +254,107 @@ def test_render_frames_materializes_unique_source_frames_before_scene_render(
     assert calls["segments"][1]["scenario"]["scene"] == "scene-b"
     assert calls["segments"][1]["out_start"] == 3
     assert calls["segments"][1]["out_end"] == 6
+
+
+def test_decode_subprocess_command_passes_bundle_traj_indices_and_output(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = cli.BoxTaskBundlePaths.from_root(_make_bundle(tmp_path))
+    state_path = tmp_path / "states.pt"
+    calls: dict[str, object] = {}
+
+    def fake_run(command, *, text, capture_output, check):
+        calls["command"] = command
+        calls["run_kwargs"] = {"text": text, "capture_output": capture_output, "check": check}
+        return SimpleNamespace(returncode=0, stdout="decoded", stderr="")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    cli.decode_trajectory_tensor_states_subprocess(
+        paths=paths,
+        source_indices=[5, 2, 5],
+        state_path=state_path,
+        python_bin="/python",
+        script_path=Path("/repo/render.py"),
+    )
+
+    assert calls["command"] == [
+        "/python",
+        "/repo/render.py",
+        "--bundle-root",
+        str(paths.bundle_root),
+        "--traj-path",
+        str(paths.traj_path),
+        "--decode-source-indices-json",
+        "[5, 2, 5]",
+        "--decode-states-out",
+        str(state_path),
+    ]
+    assert calls["run_kwargs"] == {"text": True, "capture_output": True, "check": False}
+
+
+def test_decode_subprocess_reports_worker_output_tail_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    paths = cli.BoxTaskBundlePaths.from_root(_make_bundle(tmp_path))
+
+    def fake_run(command, *, text, capture_output, check):
+        return SimpleNamespace(returncode=7, stdout="stdout detail", stderr="stderr detail")
+
+    monkeypatch.setattr(cli.subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="decode worker failed with exit code 7"):
+        cli.decode_trajectory_tensor_states_subprocess(
+            paths=paths,
+            source_indices=[1],
+            state_path=tmp_path / "states.pt",
+            python_bin="/python",
+            script_path=Path("/repo/render.py"),
+        )
+
+
+def test_decode_worker_mode_writes_decoded_states_without_rendering(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    bundle = _make_bundle(tmp_path)
+    calls: dict[str, object] = {}
+
+    def fake_decode(traj_path, source_indices, bundle_paths=None):
+        calls["decode"] = (traj_path, list(source_indices), bundle_paths)
+        return {2: "state-2", 5: "state-5"}
+
+    def fake_save(states, path):
+        calls["save"] = (states, path)
+
+    def fail_render_video(args):
+        raise AssertionError("decode worker mode must not render")
+
+    monkeypatch.setattr(cli, "decode_trajectory_tensor_states", fake_decode)
+    monkeypatch.setattr(cli, "save_decoded_tensor_states", fake_save)
+    monkeypatch.setattr(cli, "render_video", fail_render_video)
+
+    state_path = tmp_path / "decoded.pt"
+    exit_code = cli.main(
+        [
+            "--bundle-root",
+            str(bundle),
+            "--decode-source-indices-json",
+            "[5, 2, 5]",
+            "--decode-states-out",
+            str(state_path),
+        ]
+    )
+
+    assert exit_code == 0
+    decoded_paths = calls["decode"][2]
+    assert calls["decode"] == (decoded_paths.traj_path, [5, 2, 5], decoded_paths)
+    assert calls["save"] == ({2: "state-2", 5: "state-5"}, state_path)
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {"status": "decoded", "states": str(state_path), "source_frames": 3}
 
 
 def test_camera_object_lookup_prefers_public_then_private_mapping() -> None:
@@ -276,8 +385,9 @@ def test_configure_blender_for_video_sets_cpu_and_gpu_devices(monkeypatch: pytes
             return self.devices
 
     cycles_prefs = FakePreferences()
+    image_settings = SimpleNamespace(file_format=None, color_mode=None)
     scene = SimpleNamespace(
-        render=SimpleNamespace(engine=None, image_settings=SimpleNamespace(file_format=None, color_mode=None)),
+        render=SimpleNamespace(engine=None, image_settings=image_settings),
         cycles=SimpleNamespace(samples=None, device=None),
         view_settings=SimpleNamespace(view_transform=None, exposure=None, gamma=None),
     )
@@ -353,7 +463,13 @@ def test_render_png_frame_sets_camera_resolution_and_filepath(monkeypatch: pytes
     render_calls: list[dict[str, object]] = []
     scene = SimpleNamespace(
         camera=None,
-        render=SimpleNamespace(resolution_x=None, resolution_y=None, resolution_percentage=None, filepath=None),
+        render=SimpleNamespace(
+            resolution_x=None,
+            resolution_y=None,
+            resolution_percentage=None,
+            filepath=None,
+            image_settings=SimpleNamespace(file_format="BMP", color_mode="RGB"),
+        ),
     )
     bpy = ModuleType("bpy")
     bpy.context = SimpleNamespace(scene=scene)
@@ -372,7 +488,38 @@ def test_render_png_frame_sets_camera_resolution_and_filepath(monkeypatch: pytes
     assert scene.render.resolution_y == 240
     assert scene.render.resolution_percentage == 100
     assert scene.render.filepath == str(out_path)
+    assert scene.render.image_settings.file_format == "PNG"
+    assert scene.render.image_settings.color_mode == "RGB"
     assert render_calls == [{"write_still": True}]
+
+
+def test_apply_state_to_handler_uses_blender_readback_format_for_handler_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scene = SimpleNamespace(render=SimpleNamespace(image_settings=SimpleNamespace(file_format="PNG", color_mode="RGBA")))
+    bpy = ModuleType("bpy")
+    bpy.context = SimpleNamespace(scene=scene)
+    monkeypatch.setitem(sys.modules, "bpy", bpy)
+    calls: list[tuple[object, str, str]] = []
+
+    class FakeRefreshingHandler:
+        set_states_refreshes = True
+
+        def set_states(self, state):
+            calls.append(
+                (
+                    state,
+                    scene.render.image_settings.file_format,
+                    scene.render.image_settings.color_mode,
+                )
+            )
+
+        def refresh_render(self):
+            raise AssertionError("set_states already refreshes")
+
+    cli.apply_state_to_handler(FakeRefreshingHandler(), "tensor-state")
+
+    assert calls == [("tensor-state", "BMP", "RGB")]
 
 
 def test_apply_state_to_handler_passes_tensor_state_directly_falls_back_to_list_and_refreshes() -> None:

--- a/tests/test_render_box_task_blender_video.py
+++ b/tests/test_render_box_task_blender_video.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.benchmark.rendering import render_box_task_blender_video as cli
+
+
+def _make_bundle(tmp_path: Path) -> Path:
+    bundle = tmp_path / "bundle"
+    for rel in (
+        "assets/traj",
+        "assets/local_pack_box/cardboard_box",
+        "assets/local_pack_box/feast_soda_can",
+        "assets/local_pack_box/feast_scented_candle",
+    ):
+        (bundle / rel).mkdir(parents=True)
+    (bundle / "assets/traj/task3_meshycup_openarm_wuji_20260513_232823_0_v2.pkl").write_bytes(b"pickle-bytes")
+    for rel in (
+        "assets/local_pack_box/cardboard_box/cardboard_box.usd",
+        "assets/local_pack_box/feast_soda_can/feast_soda_can.usd",
+        "assets/local_pack_box/feast_scented_candle/feast_scented_candle.usd",
+    ):
+        (bundle / rel).write_text("#usda\n", encoding="utf-8")
+    return bundle
+
+
+def test_parse_args_accepts_target_video_options(tmp_path: Path) -> None:
+    bundle = _make_bundle(tmp_path)
+    args = cli.parse_args(
+        [
+            "--bundle-root",
+            str(bundle),
+            "--scenes",
+            "0021,0022",
+            "--duration-sec",
+            "1.5",
+            "--fps",
+            "30",
+            "--width",
+            "320",
+            "--height",
+            "240",
+            "--samples",
+            "8",
+            "--device",
+            "CPU",
+            "--out-video",
+            str(tmp_path / "out.mp4"),
+            "--dry-run",
+        ]
+    )
+
+    assert args.bundle_root == bundle
+    assert args.scenes == "0021,0022"
+    assert args.duration_sec == 1.5
+    assert args.fps == 30
+    assert args.dry_run is True
+
+
+@pytest.mark.parametrize("option", ["--fps", "--width", "--height", "--samples", "--out-frames"])
+def test_parse_args_rejects_non_positive_integer_options(tmp_path: Path, option: str) -> None:
+    with pytest.raises(SystemExit):
+        cli.parse_args(
+            [
+                "--out-video",
+                str(tmp_path / "out.mp4"),
+                option,
+                "0",
+            ]
+        )
+
+
+def test_script_help_runs_when_executed_directly() -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    script = repo_root / "scripts/benchmark/rendering/render_box_task_blender_video.py"
+
+    result = subprocess.run(
+        [sys.executable, str(script), "--help"],
+        cwd=repo_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Render box-task replay video in Blender." in result.stdout
+
+
+def test_dry_run_prints_render_plan(tmp_path: Path, capsys) -> None:
+    bundle = _make_bundle(tmp_path)
+    exit_code = cli.main(
+        [
+            "--bundle-root",
+            str(bundle),
+            "--scenes",
+            "0021,0022",
+            "--out-frames",
+            "6",
+            "--fps",
+            "30",
+            "--out-video",
+            str(tmp_path / "out.mp4"),
+            "--dry-run",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "dry_run"
+    assert payload["scenes"] == ["kujiale_scene_0021", "kujiale_scene_0022"]
+    assert payload["out_frames"] == 6
+    assert payload["scene_frame_bounds"] == [[0, 3], [3, 6]]
+    assert payload["out_video"].endswith("out.mp4")

--- a/tests/test_usd_material_audit.py
+++ b/tests/test_usd_material_audit.py
@@ -1,0 +1,44 @@
+import json
+
+import pytest
+
+pxr = pytest.importorskip("pxr")
+from pxr import Sdf, Usd, UsdShade
+
+from roboverse_pack.blender.usd.audit import audit_usd_materials, main
+
+
+def _write_audit_fixture(path):
+    stage = Usd.Stage.CreateNew(str(path))
+    material = UsdShade.Material.Define(stage, "/World/Looks/Wood")
+    shader = UsdShade.Shader.Define(stage, "/World/Looks/Wood/Shader")
+    shader.CreateIdAttr("OmniPBR")
+    shader.CreateInput("diffuseColor", Sdf.ValueTypeNames.Color3f).Set((0.2, 0.3, 0.4))
+    shader.CreateInput("mdl:sourceAsset", Sdf.ValueTypeNames.Asset).Set(Sdf.AssetPath("OmniPBR.mdl"))
+    material.CreateSurfaceOutput().ConnectToSource(shader.ConnectableAPI(), "surface")
+    stage.GetRootLayer().Save()
+
+
+def test_audit_usd_materials_reports_shader_ids_and_mdl_assets(tmp_path):
+    usd_path = tmp_path / "material.usda"
+    _write_audit_fixture(usd_path)
+
+    report = audit_usd_materials(usd_path)
+
+    assert report["input_path"] == str(usd_path)
+    assert report["materials_total"] == 1
+    assert report["materials"][0]["material_path"] == "/World/Looks/Wood"
+    assert report["materials"][0]["shader_ids"] == ["OmniPBR"]
+    assert report["materials"][0]["mdl_source_asset"] == "OmniPBR.mdl"
+
+
+def test_audit_cli_writes_json(tmp_path):
+    usd_path = tmp_path / "material.usda"
+    output_path = tmp_path / "audit.json"
+    _write_audit_fixture(usd_path)
+
+    assert main(["--input", str(usd_path), "--output", str(output_path)]) == 0
+
+    report = json.loads(output_path.read_text(encoding="utf-8"))
+    assert report["materials_total"] == 1
+


### PR DESCRIPTION
## Summary

Adds the RoboVerse Blender USD material overlay stack and benchmark tooling on the `blender-bench` branch.

Highlights:
- adds `roboverse_pack.blender.usd` compatibility helpers for generating Blender-friendly USD material overlays;
- adds the `material_graph` conversion package, adapters, reports, texture path handling, and audit/Kit overlay entry points;
- adds Blender benchmark/replay scripts for box-task rendering and seed-stability analysis;
- adds USD material fixtures and focused tests for overlay generation, material graph conversion, reports, UV/UDIM handling, and benchmark helpers.

## Notes

This PR is opened as a draft because the branch currently diverges from `main` and is 30 commits ahead / 42 commits behind. It may need a rebase or merge from current `main` before review.

## Validation

- `python -m compileall -q roboverse_pack/blender/usd` in the local `blender-bench` worktree.
- Compared `blender-bench` against `main` with the GitHub compare API before opening this PR.