### PR TITLE
fix(humanoid): apply standing-env zeroing in resample_commands

### DIFF
--- a/roboverse_pack/callback_funcs/humanoid/step_funcs.py
+++ b/roboverse_pack/callback_funcs/humanoid/step_funcs.py
@@ -47,7 +47,10 @@ def resample_commands(env: EnvTypes, env_states: TensorState = None):
     # low_cmd_mask = torch.norm(cfg.value[env_ids, :2], dim=1) < 0.1
     random_mask = sample_uniform(0, 1, (len(env_ids),), device=env.device) <= cfg.rel_standing_envs
     final_env_ids = random_mask.nonzero(as_tuple=False).flatten()
-    cfg.value[env_ids][final_env_ids, :] = 0.0
+    # final_env_ids index INTO env_ids; cfg.value[env_ids] is advanced indexing
+    # (a copy), so the chained write was a silent no-op — the standing-command
+    # envs never had their velocity command zeroed. Index by absolute env id.
+    cfg.value[env_ids[final_env_ids], :] = 0.0
 
     if cfg.heading_command:
         env_states = env.get_states(mode="tensor") if env_states is None else env_states

--- a/tests/test_resample_commands_standing.py
+++ b/tests/test_resample_commands_standing.py
@@ -1,0 +1,56 @@
+"""Regression: resample_commands actually zeroes the standing-env velocity commands.
+
+``resample_commands`` picks a ``rel_standing_envs`` fraction of the just-resampled
+envs and zeroes their velocity command so the robot learns to stand still. The
+zeroing was written as ``cfg.value[env_ids][final_env_ids, :] = 0.0`` — but
+``cfg.value[env_ids]`` is advanced indexing (a copy), so the write was discarded
+and the standing command was never applied. With ``rel_standing_envs = 1.0`` every
+resampled env must end up with a zero command; this is backend-free (a stub env +
+commands cfg, no simulator).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+
+@pytest.mark.general
+def test_standing_envs_command_is_zeroed():
+    import roboverse_pack.callback_funcs.humanoid.step_funcs as sf
+
+    # Velocity ranges kept away from 0 so the pre-fix (un-zeroed) command is
+    # detectably non-zero.
+    ranges = SimpleNamespace(
+        lin_vel_x=(0.5, 1.0),
+        lin_vel_y=(0.5, 1.0),
+        ang_vel_yaw=(0.5, 1.0),
+        heading=(0.5, 1.0),
+    )
+    cfg = SimpleNamespace(
+        value=None,
+        num_commands=3,
+        ranges=ranges,
+        heading_command=False,
+        rel_standing_envs=1.0,  # every resampled env becomes a standing env
+        resampling_time=0.02,
+    )
+    env = SimpleNamespace(
+        commands_manager=cfg,
+        num_envs=8,
+        device="cpu",
+        step_dt=0.02,  # resampling_time / step_dt == 1 -> all envs resampled this step
+        _episode_steps=torch.zeros(8, dtype=torch.long),
+    )
+
+    sf.resample_commands(env)
+
+    # All 8 envs were resampled and are standing -> every command must be zero.
+    assert cfg.value is not None
+    assert cfg.value.shape == (8, 3)
+    assert torch.count_nonzero(cfg.value) == 0, (
+        "standing-env velocity commands were not zeroed — the advanced-index write "
+        "is a no-op; index by absolute env id instead."
+    )


### PR DESCRIPTION
The standing-command zeroing wrote `cfg.value[env_ids][final_env_ids, :] = 0.0`,
but `cfg.value[env_ids]` is advanced indexing (a copy), so the write was
discarded — the rel_standing_envs fraction never had its velocity command
zeroed. Three locomotion configs set rel_standing_envs=0.02, so they were
silently not getting standing envs (the default 0 masked it).

Index by absolute env id: `cfg.value[env_ids[final_env_ids], :] = 0.0`. This
matches the known-good mjlab reference (tasks/mjlab/mdp/commands.py:104-112,
`stand_ids = env_ids[standing_mask]; self._command[stand_ids] = 0.0`).

Adds a backend-free regression test driving the real resample_commands with
rel_standing_envs=1.0 (all resampled envs must end zero). Red on pre-fix.

**Backward compatibility:** API-compatible; training behavior changes (the `rel_standing_envs` fraction now actually has its velocity command zeroed).
