### PR TITLE
fix(tasks): track_knife tracks the knife asset, not the teapot

### DIFF
--- a/roboverse_pack/tasks/pick_place/track_knife.py
+++ b/roboverse_pack/tasks/pick_place/track_knife.py
@@ -172,9 +172,9 @@ class PickPlaceTrackKnife(PickPlaceBase):
                 scale=(1, 1, 1),
                 enabled_gravity=False,
                 physics=PhysicStateType.RIGIDBODY,
-                usd_path="roboverse_data/EmbodiedGenData/all_asset/ceramic_teapot/usd/ceramic_teapot.usd",
-                urdf_path="roboverse_data/EmbodiedGenData/all_asset/ceramic_teapot/ceramic_teapot.urdf",
-                mjcf_path="roboverse_data/EmbodiedGenData/all_asset/ceramic_teapot/mjcf/ceramic_teapot.xml",
+                usd_path="roboverse_data/EmbodiedGenData/all_asset/knife/usd/knife.usd",
+                urdf_path="roboverse_data/EmbodiedGenData/all_asset/knife/knife.urdf",
+                mjcf_path="roboverse_data/EmbodiedGenData/all_asset/knife/knife.xml",
             ),
             RigidObjCfg(
                 name="plate",

--- a/tests/test_track_knife_asset.py
+++ b/tests/test_track_knife_asset.py
@@ -1,0 +1,30 @@
+"""Regression: the track_knife task must load the knife asset, not the teapot.
+
+``PickPlaceTrackKnife``'s tracked ``"object"`` had its usd/urdf/mjcf paths copied
+from ``track_ceramic_teapot`` (all_asset/ceramic_teapot/...), while the rest of
+the task is knife-specific (knife grasp-state pkl, knife centre offset). So the
+simulated object (a teapot) mismatched the grasp poses the reward assumes. This
+pins the corrected knife asset. Backend-free: the task class is importable and
+its ScenarioCfg is inspectable without a simulator.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.general
+def test_track_knife_object_uses_knife_asset():
+    from roboverse_pack.tasks.pick_place.track_knife import PickPlaceTrackKnife
+
+    obj = next(o for o in PickPlaceTrackKnife.scenario.objects if o.name == "object")
+
+    for path in (obj.usd_path, obj.urdf_path, obj.mjcf_path):
+        assert "ceramic_teapot" not in path, f"track_knife still references the teapot asset: {path}"
+        assert "knife" in path, f"track_knife object path is not the knife asset: {path}"
+
+    # Match the sibling approach_grasp_knife.py layout exactly (mjcf lives directly
+    # under knife/, not knife/mjcf/).
+    assert obj.usd_path == "roboverse_data/EmbodiedGenData/all_asset/knife/usd/knife.usd"
+    assert obj.urdf_path == "roboverse_data/EmbodiedGenData/all_asset/knife/knife.urdf"
+    assert obj.mjcf_path == "roboverse_data/EmbodiedGenData/all_asset/knife/knife.xml"


### PR DESCRIPTION
The tracked "object" RigidObjCfg in track_knife.py had usd/urdf/mjcf paths
copied from track_ceramic_teapot (all_asset/ceramic_teapot/...), while the task
loads the knife grasp-state pkl and uses the knife centre offset — so the
simulated manipuland (a teapot) mismatched the grasp poses the reward assumes.
Point the three asset paths at the knife asset, matching approach_grasp_knife.py
(mjcf is knife/knife.xml, directly under the asset dir).

A full sweep of all track_*/approach_grasp_* tasks confirmed this was the only
mismatched manipuland asset. Adds a backend-free regression test inspecting the
ScenarioCfg object paths. Red on pre-fix.

**Backward compatibility:** Fully compatible; pure correction (loads the knife asset the reward/grasp-poses assume instead of a teapot).
