### PR TITLE
fix(rl): gate TD3/SAC delayed updates on a per-iteration counter

### DIFF
--- a/roboverse_learn/rl/clean_rl/sac.py
+++ b/roboverse_learn/rl/clean_rl/sac.py
@@ -191,6 +191,19 @@ if __name__ == "__main__":
     obs, _ = envs.reset(seed=args.seed)
     obs = obs.to(device)
     global_step = 0
+    # Counts gradient-update iterations. The delayed actor update and the target
+    # update must be gated on this, NOT on global_step: global_step advances by
+    # num_envs each loop, so `global_step % policy_frequency` is constant and the
+    # gate is always open — and because the actor block then runs its inner
+    # `for _ in range(policy_frequency)` loop every iteration, the actor was
+    # over-trained by a factor of policy_frequency relative to the critic.
+    update_count = 0
+    # actor_loss / alpha_loss are only assigned when the (now correctly delayed)
+    # policy gate fires; the %100 logging runs on a different cadence, so seed
+    # them to None and guard the logs to avoid an UnboundLocalError before the
+    # first actor update (e.g. when num_envs is a multiple of 100).
+    actor_loss = None
+    alpha_loss = None
 
     # Initialize episode tracker
     episode_tracker = EpisodeTracker(args.num_envs, device)
@@ -221,6 +234,7 @@ if __name__ == "__main__":
 
         # ALGO LOGIC: training.
         if global_step > args.learning_starts:
+            update_count += 1
             data = rb.sample(args.batch_size)
             with torch.no_grad():
                 next_state_actions, next_state_log_pi, _ = actor.get_action(data.next_observations)
@@ -240,7 +254,7 @@ if __name__ == "__main__":
             qf_loss.backward()
             q_optimizer.step()
 
-            if global_step % args.policy_frequency == 0:  # TD 3 Delayed update support
+            if update_count % args.policy_frequency == 0:  # TD 3 Delayed update support
                 for _ in range(
                     args.policy_frequency
                 ):  # compensate for the delay by doing 'actor_update_interval' instead of 1
@@ -265,7 +279,7 @@ if __name__ == "__main__":
                         alpha = log_alpha.exp().item()
 
             # update the target networks
-            if global_step % args.target_network_frequency == 0:
+            if update_count % args.target_network_frequency == 0:
                 for param, target_param in zip(qf1.parameters(), qf1_target.parameters()):
                     target_param.data.copy_(args.tau * param.data + (1 - args.tau) * target_param.data)
                 for param, target_param in zip(qf2.parameters(), qf2_target.parameters()):
@@ -277,7 +291,8 @@ if __name__ == "__main__":
                 writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
                 writer.add_scalar("losses/qf2_loss", qf2_loss.item(), global_step)
                 writer.add_scalar("losses/qf_loss", qf_loss.item() / 2.0, global_step)
-                writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
+                if actor_loss is not None:
+                    writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
                 writer.add_scalar("losses/alpha", alpha, global_step)
 
                 # Log episode statistics
@@ -293,7 +308,7 @@ if __name__ == "__main__":
                     int(global_step / (time.time() - start_time)),
                     global_step,
                 )
-                if args.autotune:
+                if args.autotune and alpha_loss is not None:
                     writer.add_scalar("losses/alpha_loss", alpha_loss.item(), global_step)
 
     envs.close()

--- a/roboverse_learn/rl/clean_rl/td3.py
+++ b/roboverse_learn/rl/clean_rl/td3.py
@@ -159,6 +159,17 @@ if __name__ == "__main__":
     obs, _ = envs.reset(seed=args.seed)
     obs = obs.to(device)
     global_step = 0
+    # Counts gradient-update iterations (one per training step past learning_starts).
+    # The delayed policy/target update must be gated on this, NOT on global_step:
+    # global_step advances by num_envs each loop, so `global_step % policy_frequency`
+    # is constant (always 0 when policy_frequency divides num_envs) and the TD3
+    # delayed-update mechanism never actually delays.
+    update_count = 0
+    # actor_loss is only assigned when the (now correctly delayed) policy gate
+    # fires; the %100 logging below runs on a different cadence, so seed it to
+    # None and guard the log to avoid an UnboundLocalError before the first
+    # actor update (e.g. when num_envs is a multiple of 100).
+    actor_loss = None
 
     # Initialize episode tracker
     episode_tracker = EpisodeTracker(args.num_envs, device)
@@ -189,6 +200,7 @@ if __name__ == "__main__":
 
         # ALGO LOGIC: training.
         if global_step > args.learning_starts:
+            update_count += 1
             data = rb.sample(args.batch_size)
             with torch.no_grad():
                 clipped_noise = (torch.randn_like(data.actions, device=device) * args.policy_noise).clamp(
@@ -214,7 +226,7 @@ if __name__ == "__main__":
             qf_loss.backward()
             q_optimizer.step()
 
-            if global_step % args.policy_frequency == 0:
+            if update_count % args.policy_frequency == 0:
                 actor_loss = -qf1(data.observations, actor(data.observations)).mean()
                 actor_optimizer.zero_grad()
                 actor_loss.backward()
@@ -234,7 +246,8 @@ if __name__ == "__main__":
                 writer.add_scalar("losses/qf1_loss", qf1_loss.item(), global_step)
                 writer.add_scalar("losses/qf2_loss", qf2_loss.item(), global_step)
                 writer.add_scalar("losses/qf_loss", qf_loss.item() / 2.0, global_step)
-                writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
+                if actor_loss is not None:
+                    writer.add_scalar("losses/actor_loss", actor_loss.item(), global_step)
 
                 # Log episode statistics
                 avg_return, avg_length = episode_tracker.get_stats()

--- a/tests/test_clean_rl_delayed_update_gate.py
+++ b/tests/test_clean_rl_delayed_update_gate.py
@@ -1,0 +1,87 @@
+"""Regression: TD3/SAC delayed policy update must be gated on a per-iteration counter.
+
+``global_step`` advances by ``num_envs`` every loop, so ``global_step % policy_frequency``
+is constant (always 0 whenever ``policy_frequency`` divides ``num_envs`` — true for the
+defaults num_envs=128, policy_frequency=2). The "delayed" TD3/SAC update therefore ran
+*every* iteration, defeating the mechanism; in SAC it compounded with the inner
+``for _ in range(policy_frequency)`` loop, over-training the actor by ``policy_frequency``x.
+
+The fix gates the actor/target updates on ``update_count`` (incremented once per gradient
+step) instead of ``global_step``. These tests pin that source contract (the training
+scripts run only under ``__main__`` and need the full RL stack, so they aren't importable
+here) and document the intended cadence arithmetic.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+_RL = pathlib.Path(__file__).resolve().parents[1] / "roboverse_learn" / "rl" / "clean_rl"
+
+
+def _src(name: str) -> str:
+    return (_RL / name).read_text()
+
+
+@pytest.mark.general
+@pytest.mark.parametrize("fname", ["td3.py", "sac.py"])
+def test_delayed_update_gate_uses_update_count_not_global_step(fname):
+    src = _src(fname)
+    # The buggy gate must be gone, and the counter-based gate present.
+    assert "global_step % args.policy_frequency" not in src, (
+        f"{fname}: delayed policy update is gated on global_step (advances by num_envs) — "
+        f"it never delays. Gate on update_count instead."
+    )
+    assert "update_count % args.policy_frequency" in src, f"{fname}: policy update must gate on update_count"
+    # The counter must be initialised and incremented once per gradient step.
+    assert "update_count = 0" in src, f"{fname}: update_count is not initialised"
+    assert "update_count += 1" in src, f"{fname}: update_count is never incremented"
+    # The per-100 logging cadence intentionally stays on global_step (env-step semantics).
+    assert "global_step % 100 == 0" in src
+    # Because the actor update is now genuinely delayed (decoupled from the %100
+    # logging), actor_loss can be unset on a logging iteration — it must be seeded
+    # to None and the log guarded, or training crashes (UnboundLocalError) for
+    # num_envs that are multiples of 100.
+    assert "actor_loss = None" in src, f"{fname}: actor_loss must be seeded before the loop"
+    assert "if actor_loss is not None:" in src, f"{fname}: the actor_loss log must be guarded"
+
+
+@pytest.mark.general
+def test_sac_target_update_also_uses_update_count():
+    """SAC's target-network update shares the same fragility and must use the counter."""
+    src = _src("sac.py")
+    assert "global_step % args.target_network_frequency" not in src
+    assert "update_count % args.target_network_frequency" in src
+
+
+def _fired_iterations(num_envs, policy_frequency, n_iters, learning_starts=10, use_counter=True):
+    """Iterations on which the delayed update fires, for the buggy vs fixed gate."""
+    global_step = 0
+    update_count = 0
+    fired = []
+    for it in range(n_iters):
+        global_step += num_envs
+        if global_step > learning_starts:
+            update_count += 1
+            gate = update_count if use_counter else global_step
+            if gate % policy_frequency == 0:
+                fired.append(it)
+    return fired
+
+
+@pytest.mark.general
+def test_cadence_arithmetic_buggy_vs_fixed():
+    """Document the behaviour: buggy gate fires every iteration; fixed fires every Nth."""
+    # Buggy: global_step (multiple of 128) % 2 == 0 always -> fires every post-warmup iter.
+    buggy = _fired_iterations(num_envs=128, policy_frequency=2, n_iters=20, use_counter=False)
+    assert len(buggy) == 20
+    # Fixed: fires exactly every policy_frequency-th gradient step.
+    fixed = _fired_iterations(num_envs=128, policy_frequency=2, n_iters=20, use_counter=True)
+    assert fixed == [1, 3, 5, 7, 9, 11, 13, 15, 17, 19]
+    # Fixed cadence is independent of num_envs once past warmup (learning_starts=0
+    # so update_count increments from iter 0 in both): every policy_frequency-th step.
+    a = _fired_iterations(1, 3, 30, learning_starts=0, use_counter=True)
+    b = _fired_iterations(997, 3, 30, learning_starts=0, use_counter=True)
+    assert a == b == [2, 5, 8, 11, 14, 17, 20, 23, 26, 29]


### PR DESCRIPTION
global_step advances by num_envs each loop, so the delayed-update gate
`global_step % policy_frequency == 0` was constant-true (128 % 2 == 0), and the
TD3/SAC "delayed" actor/target update ran every iteration. In SAC it compounded
with the inner `for _ in range(policy_frequency)` loop, over-training the actor
by policy_frequency x.

Introduce update_count (incremented once per gradient step) and gate the actor
update (td3+sac) and the SAC target-network update on it, restoring the intended
cadence independent of num_envs. The %100 logging stays on global_step (env-step
cadence).

Because the actor update is now genuinely decoupled from the %100 logging,
actor_loss (td3+sac) and alpha_loss (sac autotune) could be read before the
first actor update fires (e.g. num_envs a multiple of 100) -> UnboundLocalError.
Seed them to None before the loop and guard the log lines.

Adds a general regression test: source guards that the gates use update_count
(not global_step) and that the loss logs are seeded/guarded, plus an arithmetic
cadence spec. Red on pre-fix. (Training scripts run only under __main__ and need
the full RL stack, so the gate logic isn't importable for a runtime test here.)

**Backward compatibility:** API-compatible; training dynamics change (the delayed actor/target update now fires on the intended cadence, independent of `num_envs`).
