### PR TITLE
fix(robots): chain G1TrackingCfg.__post_init__ to super so mjx_mjcf_path resolves

### DIFF
--- a/roboverse_pack/robots/g1_tracking.py
+++ b/roboverse_pack/robots/g1_tracking.py
@@ -265,3 +265,8 @@ class G1TrackingCfg(RobotCfg):
         self.actuators = {k: v for k, v in zip(name_list, value_list)}
         _, name_list, value_list = resolve_matching_names_values(action_scale, joint_names)
         self.action_scale = {k: v for k, v in zip(name_list, value_list)}
+
+        # Chain to the base __post_init__ so mjx_mjcf_path defaults to mjcf_path
+        # (and scale/fix_base_link are normalised). Without this the MJX backend
+        # gets mjx_mjcf_path=None for this robot. Mirrors g1_cfg.py.
+        return super().__post_init__()

--- a/tests/test_roboverse_robot_cfg_validation.py
+++ b/tests/test_roboverse_robot_cfg_validation.py
@@ -208,6 +208,24 @@ def test_known_gap_dicts_match_actual_failures():
 
 
 @pytest.mark.general
+def test_g1_tracking_resolves_mjx_mjcf_path():
+    """Regression: G1TrackingCfg.__post_init__ must chain to super().
+
+    The base ArticulationObjCfg.__post_init__ defaults ``mjx_mjcf_path`` to
+    ``mjcf_path`` when None. G1TrackingCfg computed its actuators but never called
+    super(), so ``mjx_mjcf_path`` stayed None and the MJX backend got no path.
+    """
+    from roboverse_pack.robots.g1_tracking import G1TrackingCfg
+
+    cfg = G1TrackingCfg()
+    assert cfg.mjcf_path is not None
+    assert cfg.mjx_mjcf_path == cfg.mjcf_path, "mjx_mjcf_path should default to mjcf_path via super().__post_init__()"
+    # The actuator/action_scale computation must be preserved (not clobbered by super).
+    assert len(cfg.actuators) > 0
+    assert len(cfg.action_scale) == len(cfg.actuators)
+
+
+@pytest.mark.general
 def test_anymal_default_orientation_is_wxyz_identity():
     """Regression: ANYmal's default_orientation must be wxyz identity [1,0,0,0].
 


### PR DESCRIPTION
G1TrackingCfg.__post_init__ computed its actuators/action_scale but never
called super().__post_init__(), so the base ArticulationObjCfg default that sets
mjx_mjcf_path = mjcf_path when None never ran — the MJX backend got
mjx_mjcf_path=None for this robot. Add `return super().__post_init__()` at the
end (after the subclass fields are computed; the base only fills the still-None
mjx_mjcf_path and does not clobber actuators). Mirrors g1_cfg.py.

A scan confirmed g1_tracking was the only robot cfg missing the super call.
Adds a general regression test (mjx_mjcf_path == mjcf_path, actuators preserved).

**Backward compatibility:** Fully compatible; pure fix — the previously-broken MJX backend now resolves `mjx_mjcf_path`; happy path unchanged.

> **Note:** Touches `tests/test_roboverse_robot_cfg_validation.py`, also appended to by the sibling `anymal-default-orientation` PR — expect a trivial test-only rebase if merged after it.
