### PR TITLE
fix(robots): correct ANYmal default_orientation to wxyz identity

### DIFF
--- a/roboverse_pack/robots/anymal_cfg.py
+++ b/roboverse_pack/robots/anymal_cfg.py
@@ -79,7 +79,7 @@ class AnymalCfg(RobotCfg):
 
     # Default base position
     default_position: list[float] = [0.0, 0.0, 0.62]
-    default_orientation: list[float] = [0.0, 0.0, 0.0, 1.0]  # quaternion
+    default_orientation: list[float] = [1.0, 0.0, 0.0, 0.0]  # quaternion (wxyz); identity
 
     # Observation configuration
     observe_base_position: bool = True

--- a/tests/test_roboverse_robot_cfg_validation.py
+++ b/tests/test_roboverse_robot_cfg_validation.py
@@ -205,3 +205,20 @@ def test_known_gap_dicts_match_actual_failures():
             f"_KNOWN_DEFAULT_POS_OUT_OF_RANGE_GAPS[{name!r}] lists this as a gap ({reason!r}) but "
             f"all defaults are now inside limits — remove the entry."
         )
+
+
+@pytest.mark.general
+def test_anymal_default_orientation_is_wxyz_identity():
+    """Regression: ANYmal's default_orientation must be wxyz identity [1,0,0,0].
+
+    Handlers consume default_orientation as wxyz (mujoco.py reads qw,qx,qy,qz;
+    isaacgym reorders wxyz->xyzw). The value was [0,0,0,1] (the xyzw identity),
+    which under wxyz is a 180 degree yaw — ANYmal would spawn facing backwards.
+    """
+    from roboverse_pack.robots.anymal_cfg import AnymalCfg
+
+    cfg = AnymalCfg()
+    assert cfg.default_orientation == [1.0, 0.0, 0.0, 0.0], (
+        f"expected wxyz identity [1,0,0,0], got {cfg.default_orientation} "
+        f"(w must be the largest component for an identity quaternion)"
+    )


### PR DESCRIPTION
default_orientation is consumed as wxyz by every backend (mujoco reads
qw,qx,qy,qz; isaacgym/newton reorder wxyz->xyzw; isaacsim rot is wxyz). The
value [0,0,0,1] is the xyzw identity pasted into a wxyz field — under wxyz it is
a 180-degree yaw, so ANYmal spawned facing backwards. Use [1,0,0,0]. No task or
policy references anymal, so nothing depended on the old spawn.

Adds a general regression test asserting the wxyz identity.

**Backward compatibility:** Fully compatible; no task or policy references ANYmal, so nothing depended on the old (180°-yaw) spawn.

> **Note:** Touches `tests/test_roboverse_robot_cfg_validation.py`, also appended to by the sibling `g1-tracking-post-init-super` PR — expect a trivial test-only rebase if merged after it.
