### PR TITLE
fix(rl): freeze FastTD3 obs-normalizer stats on replay batches

### DIFF
--- a/roboverse_learn/rl/fast_td3/train.py
+++ b/roboverse_learn/rl/fast_td3/train.py
@@ -500,6 +500,11 @@ def main() -> None:
 
         batch_size = cfg("batch_size") // cfg("num_envs")
         if global_step > cfg("learning_starts"):
+            # Freeze the running obs statistics while normalising *replayed* batches:
+            # forward() updates the stats when training, so normalising resampled
+            # (and next-) observations here would double-count them on top of the
+            # per-rollout update at line ~473 and fold next_obs into the input stats.
+            obs_normalizer.eval()
             for i in range(cfg("num_updates")):
                 data = rb.sample(batch_size)
                 data["observations"] = normalize_obs(data["observations"])
@@ -514,6 +519,8 @@ def main() -> None:
 
                 for param, target_param in zip(qnet.parameters(), qnet_target.parameters()):
                     target_param.data.copy_(cfg("tau") * param.data + (1 - cfg("tau")) * target_param.data)
+            # Restore training mode so the next rollout's normalize_obs updates stats.
+            obs_normalizer.train()
 
             if torch.cuda.is_available():
                 torch.cuda.synchronize(device)

--- a/tests/test_fast_td3_obs_norm.py
+++ b/tests/test_fast_td3_obs_norm.py
@@ -1,0 +1,66 @@
+"""Regression: FastTD3 must not update obs-normalization stats on replay batches.
+
+``EmpiricalNormalization.forward`` folds the input into its running mean/var when
+in training mode. FastTD3 already updates the stats once per rollout step (fresh
+obs). The per-gradient-step normalisation of the *sampled replay batch* (and of
+``next_observations``) was also running in training mode, double-counting stale
+resampled obs and corrupting the input statistics with next-obs.
+
+The fix brackets the replay normalisation with ``obs_normalizer.eval()`` /
+``.train()``. These tests pin (1) that eval mode freezes the stats — the property
+the fix relies on — and (2) that ``train.py`` brackets the replay normalise with
+eval/train. The training script itself isn't runnable here (needs env + full
+stack), so the loop wiring is checked at the source level.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+_TRAIN = pathlib.Path(__file__).resolve().parents[1] / "roboverse_learn" / "rl" / "fast_td3" / "train.py"
+
+
+@pytest.mark.general
+def test_empirical_normalization_eval_freezes_stats():
+    pytest.importorskip("tensordict")  # fttd3_module imports tensordict
+    import torch
+
+    from roboverse_learn.rl.fast_td3.fttd3_module import EmpiricalNormalization
+
+    norm = EmpiricalNormalization(shape=(4,), device="cpu")
+    norm.train()
+    x = torch.ones(8, 4)
+    norm(x)
+    count_after_rollout = int(norm.count)
+    mean_after_rollout = norm._mean.clone()
+
+    # Replay-style reuse in eval mode must NOT change the running stats.
+    norm.eval()
+    for _ in range(5):
+        norm(x)
+    assert int(norm.count) == count_after_rollout
+    assert torch.equal(norm._mean, mean_after_rollout)
+
+    # Back in train mode, a fresh batch updates again (rollout path).
+    norm.train()
+    norm(x)
+    assert int(norm.count) > count_after_rollout
+
+
+@pytest.mark.general
+def test_replay_normalization_is_eval_bracketed_in_train_loop():
+    src = _TRAIN.read_text()
+    post = src[src.index('if global_step > cfg("learning_starts"):') :]
+    assert "obs_normalizer.eval()" in post and "obs_normalizer.train()" in post, (
+        "the replay-batch normalisation in the learning block must toggle "
+        "obs_normalizer.eval()/.train() so the running stats are not updated on replay"
+    )
+    eval_at = post.index("obs_normalizer.eval()")
+    norm_at = post.index('data["observations"] = normalize_obs(')
+    train_at = post.index("obs_normalizer.train()", norm_at)
+    assert eval_at < norm_at < train_at, (
+        "the replay-batch normalize_obs calls must be bracketed by "
+        "obs_normalizer.eval() ... obs_normalizer.train() so they don't update stats"
+    )


### PR DESCRIPTION
EmpiricalNormalization.forward updates the running mean/var whenever in training
mode. FastTD3 updates the stats once per rollout step (fresh obs), but the
per-gradient-step normalisation of the sampled replay batch (and of
next_observations) also ran in training mode — double-counting stale resampled
obs and folding next-obs into the input statistics.

Bracket the replay normalisation with obs_normalizer.eval() / .train() so only
the rollout obs drive the running stats. update_main/update_pol consume
pre-normalised data and never touch the normalizer, and no early-exit strands
eval mode. (This is stricter than upstream FastTD3, which updates on replay too.)

Adds general regression tests: eval mode freezes count/_mean while train resumes
updates, plus a source guard that the replay normalise is eval-bracketed.

**Backward compatibility:** API-compatible; the obs-normalizer running stats are now driven only by rollout obs (training statistics change, more correct).
