### PR TITLE
fix(il): give the validation dataset independent buffers and a robust val-loss reduction

### DIFF
--- a/roboverse_learn/il/datasets/robot_image_dataset.py
+++ b/roboverse_learn/il/datasets/robot_image_dataset.py
@@ -99,6 +99,14 @@ class RobotImageDataset(BaseImageDataset):
             episode_mask=~self.train_mask,
         )
         val_set.train_mask = ~self.train_mask
+        # copy.copy is shallow, so the val set would otherwise share the train
+        # set's IO buffers — the in-place destination of the ndarray-index
+        # __getitem__ fast path. Give val its own buffers so a val pass cannot
+        # scribble over a train batch (and vice-versa).
+        val_set.buffers = {k: v.copy() for k, v in self.buffers.items()}
+        val_set.buffers_torch = {k: torch.from_numpy(v) for k, v in val_set.buffers.items()}
+        for v in val_set.buffers_torch.values():
+            v.pin_memory()
         return val_set
 
     def get_normalizer(self, mode="limits", **kwargs):

--- a/roboverse_learn/il/runners/default_runner.py
+++ b/roboverse_learn/il/runners/default_runner.py
@@ -320,7 +320,7 @@ class DefaultRunner(BaseRunner):
                             for batch_idx, batch in enumerate(tepoch):
                                 batch = dataset.postprocess(batch, device)
                                 loss = self.model.compute_loss(batch)
-                                val_losses.append(loss)
+                                val_losses.append(loss.item())
                                 if (
                                     cfg.train_config.training_params.max_val_steps
                                     is not None
@@ -329,7 +329,10 @@ class DefaultRunner(BaseRunner):
                                 ):
                                     break
                         if len(val_losses) > 0:
-                            val_loss = torch.mean(torch.tensor(val_losses)).item()
+                            # Mirror the train loop: accumulate python floats (loss.item())
+                            # and average with np.mean. torch.tensor(list_of_0d_tensors)
+                            # warns/copies and is fragile for CUDA/grad tensors.
+                            val_loss = np.mean(val_losses)
                             # log epoch average validation loss
                             step_log["val_loss"] = val_loss
 

--- a/tests/test_default_runner_val_loss.py
+++ b/tests/test_default_runner_val_loss.py
@@ -1,0 +1,43 @@
+"""Regression: the IL val-loss reduction must accumulate floats, not 0-d tensors.
+
+The validation loop did ``val_losses.append(loss)`` (0-d CUDA tensors) then
+``torch.mean(torch.tensor(val_losses))`` — ``torch.tensor`` over a list of
+existing tensors emits a copy-construct UserWarning and is fragile for
+CUDA/grad tensors. The train loop already uses ``.item()`` + ``np.mean``; the fix
+makes the val loop consistent. The runner isn't importable/runnable here (needs a
+model + dataloader), so the loop wiring is pinned at the source level and the
+reduction pattern's warning-freeness is demonstrated directly.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import warnings
+
+import numpy as np
+import pytest
+import torch
+
+_RUNNER = pathlib.Path(__file__).resolve().parents[1] / "roboverse_learn" / "il" / "runners" / "default_runner.py"
+
+
+@pytest.mark.general
+def test_val_loss_reduction_uses_item_and_npmean():
+    src = _RUNNER.read_text()
+    assert "val_losses.append(loss.item())" in src, "val losses must be accumulated as python floats"
+    assert "torch.tensor(val_losses)" not in src, "torch.tensor over a list of 0-d tensors is fragile; use np.mean"
+    assert "np.mean(val_losses)" in src, "val loss should be averaged with np.mean (consistent with train loop)"
+
+
+@pytest.mark.general
+def test_item_then_npmean_is_warning_free_and_correct():
+    """The new pattern (item() + np.mean) averages correctly with no warnings.
+
+    (The old ``torch.tensor(list_of_0d_tensors)`` form is fragile for CUDA/grad
+    tensors and warns on some torch versions — the fix sidesteps it entirely.)
+    """
+    losses = [torch.tensor(1.0), torch.tensor(3.0)]
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning becomes an error
+        result = np.mean([loss.item() for loss in losses])
+    assert result == 2.0

--- a/tests/test_robot_image_dataset_val.py
+++ b/tests/test_robot_image_dataset_val.py
@@ -1,0 +1,43 @@
+"""Regression: the IL validation dataset must not share IO buffers with train.
+
+``RobotImageDataset.get_validation_dataset`` does ``copy.copy(self)`` (shallow),
+so ``buffers`` / ``buffers_torch`` — the in-place destination of the
+ndarray-index ``__getitem__`` fast path — were shared between the train and val
+datasets. A val pass would scribble over a train batch (and vice-versa). The fix
+re-allocates independent buffers for the val set. Backend-free: the dataset is
+built via ``__new__`` with only the fields ``get_validation_dataset`` touches,
+and ``SequenceSampler`` is stubbed so no replay buffer / zarr is needed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+
+@pytest.mark.general
+def test_validation_dataset_has_independent_buffers(monkeypatch):
+    import roboverse_learn.il.datasets.robot_image_dataset as mod
+
+    # Stub the sampler so get_validation_dataset needs no real replay buffer.
+    monkeypatch.setattr(mod, "SequenceSampler", lambda **kw: object())
+
+    ds = mod.RobotImageDataset.__new__(mod.RobotImageDataset)
+    ds.replay_buffer = object()
+    ds.horizon = 3
+    ds.pad_before = 0
+    ds.pad_after = 0
+    ds.train_mask = np.array([True, True, False])
+    ds.buffers = {"state": np.zeros((2, 3, 4), dtype=np.float32)}
+    ds.buffers_torch = {k: torch.from_numpy(v) for k, v in ds.buffers.items()}
+
+    val = ds.get_validation_dataset()
+
+    # Independent memory (not the same objects).
+    assert val.buffers["state"] is not ds.buffers["state"]
+    assert val.buffers_torch["state"] is not ds.buffers_torch["state"]
+
+    # Writing into val's buffer must not corrupt the train buffer.
+    val.buffers["state"][:] = 7.0
+    assert (ds.buffers["state"] == 0.0).all(), "val buffer write leaked into the train buffer"


### PR DESCRIPTION
get_validation_dataset did copy.copy(self) (shallow), so the val set shared the
train set's buffers/buffers_torch — the in-place destination of the ndarray-index
__getitem__ fast path. A val pass could scribble over a train batch (and
vice-versa). Re-allocate independent buffers for the val set.

The validation loop also appended raw 0-d (CUDA) loss tensors and reduced them
with torch.mean(torch.tensor(val_losses)) — fragile for CUDA/grad tensors and
inconsistent with the train loop. Accumulate loss.item() floats and average with
np.mean, mirroring the train loop.

Adds general regression tests (independent buffers + no cross-write; val-loss
reduction source guard + warning-free pattern). Red on pre-fix.

**Backward compatibility:** Fully compatible; fixes a data-corruption bug (the val set no longer shares/overwrites the train set's in-place buffers).
