### PR TITLE
fix(humanoid_bench): override _extra_spec hook, not the extra_spec property

### DIFF
--- a/roboverse_pack/tasks/humanoid_bench/sit.py
+++ b/roboverse_pack/tasks/humanoid_bench/sit.py
@@ -126,7 +126,7 @@ class SitEnv(BaseLocomotionEnv):
         self.reward_functions = [SitReward(self.robot_name)]
         self.reward_weights = [1.0]
 
-    def extra_spec(self):
+    def _extra_spec(self):
         """Declare extra observations needed by SitReward."""
         return {
             "imu_pos": SitePos("imu"),

--- a/roboverse_pack/tasks/humanoid_bench/slide.py
+++ b/roboverse_pack/tasks/humanoid_bench/slide.py
@@ -102,7 +102,7 @@ class SlideEnv(BaseLocomotionEnv):
         self.reward_functions = [SlideReward(self.robot_name)]
         self.reward_weights = [1.0]
 
-    def extra_spec(self):
+    def _extra_spec(self):
         """Declare extra observations needed by SlideReward."""
         return {
             "head_pos": SitePos("head"),

--- a/roboverse_pack/tasks/humanoid_bench/stair.py
+++ b/roboverse_pack/tasks/humanoid_bench/stair.py
@@ -102,7 +102,7 @@ class StairEnv(BaseLocomotionEnv):
         self.reward_functions = [StairReward(self.robot_name)]
         self.reward_weights = [1.0]
 
-    def extra_spec(self):
+    def _extra_spec(self):
         """Declare extra observations needed by StairReward."""
         return {
             "head_pos": SitePos("head"),

--- a/tests/test_humanoid_bench_extra_spec.py
+++ b/tests/test_humanoid_bench_extra_spec.py
@@ -1,0 +1,39 @@
+"""Regression: humanoid_bench tasks must override _extra_spec, not shadow extra_spec.
+
+``BaseTaskEnv.extra_spec`` is a *property* (returns ``self._extra_spec()``) that the
+base reads as ``queries = self.extra_spec`` to register optional site queries. The
+sit/slide/stair tasks defined a plain method ``extra_spec`` instead of the
+``_extra_spec`` hook, which shadowed the property — so ``self.extra_spec`` was a
+bound method (never called), the SitePos queries were never registered, and the
+rewards' ``states.extras["head_pos"]`` / ``["imu_pos"]`` lookups would KeyError.
+crawl.py used the correct ``_extra_spec`` name. Backend-free: a pure class-level
+check (no construction needed).
+"""
+
+from __future__ import annotations
+
+import importlib
+import inspect
+
+import pytest
+
+
+@pytest.mark.general
+@pytest.mark.parametrize(
+    "module_name,class_name",
+    [
+        ("roboverse_pack.tasks.humanoid_bench.sit", "SitEnv"),
+        ("roboverse_pack.tasks.humanoid_bench.slide", "SlideEnv"),
+        ("roboverse_pack.tasks.humanoid_bench.stair", "StairEnv"),
+    ],
+)
+def test_uses_underscore_extra_spec_hook(module_name, class_name):
+    cls = getattr(importlib.import_module(module_name), class_name)
+
+    # The subclass must override the _extra_spec hook, not the extra_spec property.
+    assert "_extra_spec" in cls.__dict__, f"{class_name} must override _extra_spec"
+    assert "extra_spec" not in cls.__dict__, (
+        f"{class_name} defines a plain extra_spec method, shadowing the base property; rename it to _extra_spec"
+    )
+    # extra_spec must still resolve to the base property (so the base reads the dict).
+    assert isinstance(inspect.getattr_static(cls, "extra_spec"), property)


### PR DESCRIPTION
sit/slide/stair defined a plain method extra_spec(), which shadowed the
BaseTaskEnv.extra_spec @property (it returns self._extra_spec()). The base reads
queries = self.extra_spec, so it got a bound method instead of the query dict —
the SitePos site queries were never registered and the rewards'
states.extras['head_pos']/['imu_pos'] lookups would KeyError. crawl.py already
used the correct _extra_spec name. Rename the three to _extra_spec.

Adds a general regression test (class-level: _extra_spec overridden, extra_spec
not shadowed and still resolves to the base property). Red on pre-fix.

**Backward compatibility:** Fully compatible; fixes sit/slide/stair which previously KeyError'd (the SitePos site queries now register).
