### PR TITLE
fix(libero): per-env stove termination and corrected task registration ids

### DIFF
--- a/roboverse_pack/tasks/libero/libero_pick_alphabet_soup.py
+++ b/roboverse_pack/tasks/libero/libero_pick_alphabet_soup.py
@@ -9,7 +9,7 @@ from metasim.task.registry import register_task
 from .libero_base import LiberoBaseTask
 
 
-@register_task("libero.pick_alphabet_soup", "pick_alphnabet_soup")
+@register_task("libero.pick_alphabet_soup", "pick_alphabet_soup")
 class LiberoPickAlphabetSoupTask(LiberoBaseTask):
     """Configuration for the Libero pick alphabet soup task.
 

--- a/roboverse_pack/tasks/libero/libero_pick_orange_juice.py
+++ b/roboverse_pack/tasks/libero/libero_pick_orange_juice.py
@@ -9,7 +9,7 @@ from metasim.task.registry import register_task
 from .libero_base import LiberoBaseTask
 
 
-@register_task("libero.orange_juice", "pick_orange_juice")
+@register_task("libero.pick_orange_juice", "pick_orange_juice")
 class LiberoPickOrangeJuiceCfg(LiberoBaseTask):
     """Configuration for the Libero pick orange juice task.
 

--- a/roboverse_pack/tasks/libero_90/libero_kitchen_scene3_turn_on_the_stove.py
+++ b/roboverse_pack/tasks/libero_90/libero_kitchen_scene3_turn_on_the_stove.py
@@ -88,7 +88,9 @@ class LiberoKitchenScene3TurnOnStoveTask(Libero90BaseTask):
         knob_index = 0  # 示例：第一个关节为旋钮
         threshold = 0.5  # 示例：大于 0.5 视为打开
         stove_joint_state = states.objects["flat_stove"].joint_pos[:, 0]  # (N,)
-        is_on = (stove_joint_state > threshold).all(dim=-1)  # (N,)
+        # joint_pos[:, 0] is already (N,); .all(dim=-1) collapsed it to a scalar
+        # (reducing over the batch). Compare element-wise to keep per-env shape.
+        is_on = stove_joint_state > threshold  # (N,)
         return is_on
 
     def reset(self, states=None, env_ids=None):

--- a/tests/test_libero_fixes.py
+++ b/tests/test_libero_fixes.py
@@ -1,15 +1,10 @@
-"""Regression tests (backend-free) for the libero task fixes.
+"""Regression tests for two LIBERO content bugs (backend-free).
 
-Covers two independent hardening fixes:
-
-* ``Libero90BaseTask._get_initial_states`` must degrade to None (handler
-  defaults) when the trajectory is missing/empty or the scenario is robotless,
-  matching the already-hardened ``LiberoBaseTask``. Previously it indexed
-  ``scenario.robots[0]`` and called get_traj with no guard, so those cases
-  crashed.
-* Every ``libero_pick_*`` task must declare ``robots=["franka"]``. 9 of 10
-  omitted it, so they instantiated with an empty robot list — a robotless pick
-  task can never succeed and eval scores a silent 0%.
+- scene3 "turn on the stove" termination did ``(stove_joint > thr).all(dim=-1)``
+  on a ``(N,)`` tensor, collapsing the per-env result to a scalar (reducing over
+  the batch). The sibling scene9 does it correctly.
+- two pick tasks had registration-id typos (a misspelled alias and a primary id
+  missing the ``pick_`` prefix that every sibling uses).
 """
 
 from __future__ import annotations
@@ -17,8 +12,70 @@ from __future__ import annotations
 import pathlib
 
 import pytest
+import torch
+
+from metasim.types import ObjectState, TensorState
 
 _LIBERO = pathlib.Path(__file__).resolve().parents[1] / "roboverse_pack" / "tasks" / "libero"
+
+
+@pytest.mark.general
+def test_stove_terminated_is_per_env():
+    from roboverse_pack.tasks.libero_90.libero_kitchen_scene3_turn_on_the_stove import (
+        LiberoKitchenScene3TurnOnStoveTask,
+    )
+
+    states = TensorState(
+        objects={
+            "flat_stove": ObjectState(
+                root_state=torch.zeros(2, 13),
+                joint_pos=torch.tensor([[0.6], [0.1]]),  # env0 on, env1 off
+                joint_vel=torch.zeros(2, 1),
+            )
+        },
+        robots={},
+        cameras={},
+    )
+    task = LiberoKitchenScene3TurnOnStoveTask.__new__(LiberoKitchenScene3TurnOnStoveTask)
+    out = task._terminated(states)
+    assert out.shape == (2,), f"_terminated must be per-env (2,), got {tuple(out.shape)}"
+    assert out.tolist() == [True, False]
+
+
+@pytest.mark.general
+def test_libero_pick_registration_ids_are_correct():
+    soup = (_LIBERO / "libero_pick_alphabet_soup.py").read_text()
+    assert "pick_alphnabet_soup" not in soup, "misspelled alias 'pick_alphnabet_soup'"
+    assert '"libero.pick_alphabet_soup", "pick_alphabet_soup"' in soup
+
+    juice = (_LIBERO / "libero_pick_orange_juice.py").read_text()
+    assert '"libero.orange_juice"' not in juice, "primary id is missing the 'pick_' prefix"
+    assert '"libero.pick_orange_juice", "pick_orange_juice"' in juice
+
+
+@pytest.mark.general
+def test_all_libero_pick_tasks_have_a_robot():
+    """Every ``libero_pick_*`` task is a "pick up X and place in basket" task and
+    therefore MUST declare a robot arm. Previously 9 of 10 omitted
+    ``robots=["franka"]`` (only butter had it), so the scenario instantiated with
+    an empty robot list — a robotless pick task can never succeed and eval scores
+    a silent 0%. This pins every sibling to declare a robot.
+    """
+    import importlib
+
+    pick_files = sorted(_LIBERO.glob("libero_pick_*.py"))
+    assert pick_files, "no libero_pick_* task files found"
+    missing = []
+    for f in pick_files:
+        mod = importlib.import_module(f"roboverse_pack.tasks.libero.{f.stem}")
+        # the task class defines a class-level ScenarioCfg
+        for obj in vars(mod).values():
+            scen = getattr(obj, "scenario", None)
+            if scen is not None and hasattr(scen, "robots"):
+                if not scen.robots:
+                    missing.append(f.stem)
+                break
+    assert not missing, f"libero_pick tasks with no robot (robotless pick can never succeed): {missing}"
 
 
 @pytest.mark.general
@@ -54,28 +111,3 @@ def test_libero_90_get_initial_states_degrades_gracefully(monkeypatch):
     # 3. get_traj returns empty → None (empty guard before len())
     monkeypatch.setattr(mod, "get_traj", lambda *a, **k: ([], None, None))
     assert t._get_initial_states() is None
-
-
-@pytest.mark.general
-def test_all_libero_pick_tasks_have_a_robot():
-    """Every ``libero_pick_*`` task is a "pick up X and place in basket" task and
-    therefore MUST declare a robot arm. Previously 9 of 10 omitted
-    ``robots=["franka"]`` (only butter had it), so the scenario instantiated with
-    an empty robot list — a robotless pick task can never succeed and eval scores
-    a silent 0%. This pins every sibling to declare a robot.
-    """
-    import importlib
-
-    pick_files = sorted(_LIBERO.glob("libero_pick_*.py"))
-    assert pick_files, "no libero_pick_* task files found"
-    missing = []
-    for f in pick_files:
-        mod = importlib.import_module(f"roboverse_pack.tasks.libero.{f.stem}")
-        # the task class defines a class-level ScenarioCfg
-        for obj in vars(mod).values():
-            scen = getattr(obj, "scenario", None)
-            if scen is not None and hasattr(scen, "robots"):
-                if not scen.robots:
-                    missing.append(f.stem)
-                break
-    assert not missing, f"libero_pick tasks with no robot (robotless pick can never succeed): {missing}"


### PR DESCRIPTION
libero_kitchen_scene3_turn_on_the_stove._terminated did
(stove_joint_state > threshold).all(dim=-1) on a (N,) tensor, collapsing the
per-env result to a scalar (reducing over the batch). Drop .all to keep the
(num_envs,) bool contract, matching the correct sibling scene9.

Two pick tasks had registration-id typos: a misspelled alias
('pick_alphnabet_soup') and a primary id missing the 'pick_' prefix
('libero.orange_juice'). Correct both (no other file references the old ids; no
collision).

Adds general regression tests (per-env stove termination; registration ids).

**Backward compatibility:** Shape fix is compatible; two mistyped registration ids are corrected (no internal references to the old typos).

> **Note:** Adds `tests/test_libero_fixes.py`, also added by the sibling libero PRs (`libero-pick-robots-franka`, `libero90-initial-states-harden`) — expect a trivial test-only rebase if merged after them.
