### PR TITLE
fix(libero): declare robots=["franka"] on the 9 robotless libero_pick tasks

### DIFF
--- a/roboverse_pack/tasks/libero/libero_pick_alphabet_soup.py
+++ b/roboverse_pack/tasks/libero/libero_pick_alphabet_soup.py
@@ -67,11 +67,12 @@ class LiberoPickAlphabetSoupTask(LiberoBaseTask):
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/butter/urdf/butter.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/butter/mjcf/butter.xml",
             ),
-        ]
+        ],
+        robots=["franka"],
     )
 
     # task horizon
-    max_max_episode_steps = 250
+    max_episode_steps = 250
     task_desc = "Pick the alphabet soup and place it in the basket"
     checker = DetectedChecker(
         obj_name="alphabet_soup",

--- a/roboverse_pack/tasks/libero/libero_pick_bbq_sauce.py
+++ b/roboverse_pack/tasks/libero/libero_pick_bbq_sauce.py
@@ -67,7 +67,8 @@ class LiberoPickBbqSauceTask(LiberoBaseTask):
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/cream_cheese/urdf/cream_cheese.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/cream_cheese/mjcf/cream_cheese.xml",
             ),
-        ]
+        ],
+        robots=["franka"],
     )
 
     # task horizon

--- a/roboverse_pack/tasks/libero/libero_pick_chocolate_pudding.py
+++ b/roboverse_pack/tasks/libero/libero_pick_chocolate_pudding.py
@@ -67,7 +67,8 @@ class LiberoPickChocolatePuddingCfg(LiberoBaseTask):
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/alphabet_soup/urdf/alphabet_soup.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/alphabet_soup/mjcf/alphabet_soup.xml",
             ),
-        ]
+        ],
+        robots=["franka"],
     )
     objects = [
         RigidObjCfg(

--- a/roboverse_pack/tasks/libero/libero_pick_cream_cheese.py
+++ b/roboverse_pack/tasks/libero/libero_pick_cream_cheese.py
@@ -67,7 +67,8 @@ class LiberoPickCreamCheeseTask(LiberoBaseTask):
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/orange_juice/urdf/orange_juice.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/orange_juice/mjcf/orange_juice.xml",
             ),
-        ]
+        ],
+        robots=["franka"],
     )
 
     # task horizon

--- a/roboverse_pack/tasks/libero/libero_pick_ketchup.py
+++ b/roboverse_pack/tasks/libero/libero_pick_ketchup.py
@@ -67,7 +67,8 @@ class LiberoPickKetchupTask(LiberoBaseTask):
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/milk/urdf/milk.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/milk/mjcf/milk.xml",
             ),
-        ]
+        ],
+        robots=["franka"],
     )
 
     # task horizon

--- a/roboverse_pack/tasks/libero/libero_pick_milk.py
+++ b/roboverse_pack/tasks/libero/libero_pick_milk.py
@@ -67,7 +67,8 @@ class LiberoPickMilkTask(LiberoBaseTask):
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/chocolate_pudding/urdf/chocolate_pudding.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/chocolate_pudding/mjcf/chocolate_pudding.xml",
             ),
-        ]
+        ],
+        robots=["franka"],
     )
 
     # task horizon

--- a/roboverse_pack/tasks/libero/libero_pick_orange_juice.py
+++ b/roboverse_pack/tasks/libero/libero_pick_orange_juice.py
@@ -67,7 +67,8 @@ class LiberoPickOrangeJuiceCfg(LiberoBaseTask):
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/salad_dressing/urdf/salad_dressing.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/salad_dressing/mjcf/salad_dressing.xml",
             ),
-        ]
+        ],
+        robots=["franka"],
     )
 
     # task horizon

--- a/roboverse_pack/tasks/libero/libero_pick_salad_dressing.py
+++ b/roboverse_pack/tasks/libero/libero_pick_salad_dressing.py
@@ -67,7 +67,8 @@ class LiberoPickSaladDressingTask(LiberoBaseTask):
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/tomato_sauce/urdf/tomato_sauce.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/tomato_sauce/mjcf/tomato_sauce.xml",
             ),
-        ]
+        ],
+        robots=["franka"],
     )
 
     # task horizon

--- a/roboverse_pack/tasks/libero/libero_pick_tomato_sauce.py
+++ b/roboverse_pack/tasks/libero/libero_pick_tomato_sauce.py
@@ -67,7 +67,8 @@ class LiberoPickTomatoSauceTask(LiberoBaseTask):
                 urdf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/bbq_sauce/urdf/bbq_sauce.urdf",
                 mjcf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/bbq_sauce/mjcf/bbq_sauce.xml",
             ),
-        ]
+        ],
+        robots=["franka"],
     )
 
     # task horizon

--- a/tests/test_libero_fixes.py
+++ b/tests/test_libero_fixes.py
@@ -1,14 +1,24 @@
-"""Regression test (backend-free) for Libero90BaseTask._get_initial_states hardening.
+"""Regression tests (backend-free) for the libero task fixes.
 
-The method must degrade to None (handler defaults) when the trajectory is
-missing/empty or the scenario is robotless, matching the already-hardened
-LiberoBaseTask. Previously it indexed ``scenario.robots[0]`` and called get_traj
-with no guard, so those cases crashed.
+Covers two independent hardening fixes:
+
+* ``Libero90BaseTask._get_initial_states`` must degrade to None (handler
+  defaults) when the trajectory is missing/empty or the scenario is robotless,
+  matching the already-hardened ``LiberoBaseTask``. Previously it indexed
+  ``scenario.robots[0]`` and called get_traj with no guard, so those cases
+  crashed.
+* Every ``libero_pick_*`` task must declare ``robots=["franka"]``. 9 of 10
+  omitted it, so they instantiated with an empty robot list — a robotless pick
+  task can never succeed and eval scores a silent 0%.
 """
 
 from __future__ import annotations
 
+import pathlib
+
 import pytest
+
+_LIBERO = pathlib.Path(__file__).resolve().parents[1] / "roboverse_pack" / "tasks" / "libero"
 
 
 @pytest.mark.general
@@ -44,3 +54,28 @@ def test_libero_90_get_initial_states_degrades_gracefully(monkeypatch):
     # 3. get_traj returns empty → None (empty guard before len())
     monkeypatch.setattr(mod, "get_traj", lambda *a, **k: ([], None, None))
     assert t._get_initial_states() is None
+
+
+@pytest.mark.general
+def test_all_libero_pick_tasks_have_a_robot():
+    """Every ``libero_pick_*`` task is a "pick up X and place in basket" task and
+    therefore MUST declare a robot arm. Previously 9 of 10 omitted
+    ``robots=["franka"]`` (only butter had it), so the scenario instantiated with
+    an empty robot list — a robotless pick task can never succeed and eval scores
+    a silent 0%. This pins every sibling to declare a robot.
+    """
+    import importlib
+
+    pick_files = sorted(_LIBERO.glob("libero_pick_*.py"))
+    assert pick_files, "no libero_pick_* task files found"
+    missing = []
+    for f in pick_files:
+        mod = importlib.import_module(f"roboverse_pack.tasks.libero.{f.stem}")
+        # the task class defines a class-level ScenarioCfg
+        for obj in vars(mod).values():
+            scen = getattr(obj, "scenario", None)
+            if scen is not None and hasattr(scen, "robots"):
+                if not scen.robots:
+                    missing.append(f.stem)
+                break
+    assert not missing, f"libero_pick tasks with no robot (robotless pick can never succeed): {missing}"


### PR DESCRIPTION
9 of the 10 `libero_pick_*` "pick up X and place it in the basket" tasks
omitted `robots=["franka"]` from their ScenarioCfg (only libero_pick_butter
had it), so they instantiated with an empty robot list. A pick task with no
arm is doubly broken: (1) nothing can move the object, so the
DetectedChecker/RelativeBboxDetector can never fire → eval silently scores
0%; (2) `LiberoBaseTask._get_initial_states` loads a franka-keyed trajectory
(`franka_v2.pkl.gz`) via `get_traj(traj, scenario.robots[0], ...)`, which on
an empty robot list hits the `else None` path and silently fails to apply
the demo init states. The "robots may be empty (perception-only)" guard in
libero_base is what made both failures silent rather than a hard error.

Fix: add `robots=["franka"]` to the 9 missing ScenarioCfgs, mirroring the
correct sibling butter. `"franka"` resolves to FrankaCfg (mjcf present) and
matches the franka-keyed trajectories. Also fixes a latent typo in
alphabet_soup (`max_max_episode_steps` → `max_episode_steps`, which silently
failed to override the base horizon). Edits preserve the files' CRLF endings
so the diff stays surgical.

Scope: complete for the libero_pick_* family. libero_90 already declares the
robot; native_libero/native_liberoplus intentionally use robots=[] (the arm
is baked into the vendored robosuite MJCF); the *_single.py stubs are empty.

Test: new `test_all_libero_pick_tasks_have_a_robot` asserts every
libero_pick_* declares a non-empty robot list (red before the fix on any
file that omits it). `tests/test_libero_fixes.py` 3 passed; the libero
test trio 9 passed, 3 skipped. Reviewed by 3 fresh-context agents.

**Backward compatibility:** Fully compatible; fixes 9 `libero_pick_*` tasks that instantiated with an empty robot list and silently scored 0%.

> **Note:** Adds `tests/test_libero_fixes.py`, also added by the sibling libero PRs (`libero-stove-termination-ids`, `libero90-initial-states-harden`) — expect a trivial test-only rebase if merged after them.
