### PR TITLE
fix(libero_90): harden Libero90BaseTask._get_initial_states like its sibling

### DIFF
--- a/roboverse_pack/tasks/libero_90/libero_90_base.py
+++ b/roboverse_pack/tasks/libero_90/libero_90_base.py
@@ -41,11 +41,29 @@ class Libero90BaseTask(BaseTaskEnv):
         return states
 
     def _get_initial_states(self) -> list[dict] | None:
-        """Give the initial states from traj file."""
-        # Keep it simple and leave robot states to defaults; just seed object poses.
-        # If the handler handles None gracefully, this can be set to None.
-        initial_states, _, _ = get_traj(self.traj_filepath, self.scenario.robots[0], self.handler)
-        # Duplicate / trim list so that its length matches num_envs
+        """Return per-env initial states sampled from the demo trajectory.
+
+        Returns None when the trajectory is missing or empty, letting the
+        handler fall back to its own defaults. Mirrors the hardened
+        ``LiberoBaseTask._get_initial_states``: the previous version indexed
+        ``self.scenario.robots[0]`` unconditionally and called ``get_traj``
+        with no guard, so a robotless scenario or a missing/empty traj file
+        raised (``IndexError``/``FileNotFoundError``/``KeyError``) instead of
+        degrading gracefully like its libero sibling.
+        """
+        if not self.traj_filepath:
+            return None
+        # scenario.robots may legitimately be empty (perception-only tasks).
+        robot_ref = self.scenario.robots[0] if self.scenario.robots else None
+        try:
+            initial_states, _, _ = get_traj(self.traj_filepath, robot_ref, self.handler)
+        except (FileNotFoundError, KeyError, ValueError):
+            return None
+
+        if not initial_states:
+            return None
+
+        # Duplicate / trim list so that its length matches num_envs (n > 0 here).
         if len(initial_states) < self.num_envs:
             k = self.num_envs // len(initial_states)
             initial_states = initial_states * k + initial_states[: self.num_envs % len(initial_states)]

--- a/tests/test_libero_fixes.py
+++ b/tests/test_libero_fixes.py
@@ -1,0 +1,46 @@
+"""Regression test (backend-free) for Libero90BaseTask._get_initial_states hardening.
+
+The method must degrade to None (handler defaults) when the trajectory is
+missing/empty or the scenario is robotless, matching the already-hardened
+LiberoBaseTask. Previously it indexed ``scenario.robots[0]`` and called get_traj
+with no guard, so those cases crashed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.general
+def test_libero_90_get_initial_states_degrades_gracefully(monkeypatch):
+    """Libero90BaseTask._get_initial_states must degrade to None (handler
+    defaults) when the traj is missing/empty or the scenario is robotless,
+    matching the hardened LiberoBaseTask. Previously it indexed
+    ``scenario.robots[0]`` and called get_traj with no guard → crashed.
+    """
+    from types import SimpleNamespace
+
+    import roboverse_pack.tasks.libero_90.libero_90_base as mod
+    from roboverse_pack.tasks.libero_90.libero_90_base import Libero90BaseTask
+
+    t = Libero90BaseTask.__new__(Libero90BaseTask)
+    t.scenario = SimpleNamespace(robots=[])  # robotless
+    t.num_envs = 1
+    t.handler = None
+
+    # 1. No traj_filepath → None (new guard; previously len(None) / robots[0] crash)
+    t.traj_filepath = None
+    assert t._get_initial_states() is None
+
+    # 2. get_traj raises (missing file / bad key) → None (try/except)
+    t.traj_filepath = "does/not/exist.pkl.gz"
+
+    def _raise(*a, **k):
+        raise FileNotFoundError("missing")
+
+    monkeypatch.setattr(mod, "get_traj", _raise)
+    assert t._get_initial_states() is None
+
+    # 3. get_traj returns empty → None (empty guard before len())
+    monkeypatch.setattr(mod, "get_traj", lambda *a, **k: ([], None, None))
+    assert t._get_initial_states() is None


### PR DESCRIPTION
`Libero90BaseTask._get_initial_states` called
`get_traj(self.traj_filepath, self.scenario.robots[0], self.handler)` with no
guards, so a missing/empty trajectory raised an uncaught
FileNotFoundError/ValueError and a robotless scenario raised IndexError —
unlike the already-hardened `LiberoBaseTask._get_initial_states`, which
degrades to None (handler defaults) in those cases. The missing/empty-traj
crash is a real reachable path (e.g. a failed/absent demo download); the
robotless one is latent (all real libero_90 tasks declare robots=["franka"];
the only robotless files are empty 0-byte stubs).

Fix: lift the hardened pattern verbatim — return None when traj_filepath is
falsy, resolve `robot_ref` defensively, wrap `get_traj` in
`try/except (FileNotFoundError, KeyError, ValueError)`, and return None on an
empty result, before the unchanged replicate-to-num_envs logic. None is the
established base contract (`BaseTaskEnv._get_initial_states` already returns
None; `set_states(None)` is a no-op fallback), so no downstream regression;
the happy path is byte-identical.

Test: new `test_libero_90_get_initial_states_degrades_gracefully` exercises
all three guards (no-traj, get_traj raises, empty result) — red before the
fix (IndexError at robots[0]). `tests/test_libero_fixes.py` 4 passed; the
libero suite 22 passed, 14 skipped. Reviewed by 3 fresh-context agents.

**Backward compatibility:** Fully compatible; the happy path is byte-identical and the method now degrades to None (handler defaults) on a missing/empty trajectory instead of crashing.

> **Note:** Adds `tests/test_libero_fixes.py`, also added by the sibling libero PRs (`libero-stove-termination-ids`, `libero-pick-robots-franka`) — expect a trivial test-only rebase if merged after them.
