### PR TITLE
fix(tasks): unify reset(seed) contract across task base classes + conformance guardrail

### DIFF
--- a/roboverse_pack/tasks/calvin/base_table.py
+++ b/roboverse_pack/tasks/calvin/base_table.py
@@ -190,7 +190,7 @@ class BaseCalvinTableTask(BaseTaskEnv):
 
         return True
 
-    def reset(self, states, env_ids=None):
+    def reset(self, states, env_ids=None, seed=None):
 
         if env_ids is None:
             env_ids = list(range(self.num_envs))
@@ -220,7 +220,7 @@ class BaseCalvinTableTask(BaseTaskEnv):
         for i, env_id in enumerate(env_ids):
             self.done_states[env_id] = incoming_done_states[i]
 
-        return super().reset(states=states, env_ids=env_ids)
+        return super().reset(states=states, env_ids=env_ids, seed=seed)
 
     def step(self, action):
         try:

--- a/roboverse_pack/tasks/embodiedgen/base.py
+++ b/roboverse_pack/tasks/embodiedgen/base.py
@@ -35,9 +35,9 @@ class EmbodiedGenBaseTask(BaseTaskEnv):
             return torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
         return self.checker.check(self.handler, states)
 
-    def reset(self, states=None, env_ids=None):
-        """Reset the checker."""
-        states = super().reset(states, env_ids)
+    def reset(self, states=None, env_ids=None, seed=None):
+        """Reset the checker. ``seed`` is forwarded to ``super().reset``."""
+        states = super().reset(states, env_ids, seed)
         if self.checker is not None:
             self.checker.reset(self.handler, env_ids=env_ids)
         return states

--- a/roboverse_pack/tasks/humanoid/base/base_legged_robot.py
+++ b/roboverse_pack/tasks/humanoid/base/base_legged_robot.py
@@ -253,8 +253,17 @@ class LeggedRobotTask(AgentTask):
         effort = torch.clip(effort, -self.torque_limits, self.torque_limits)
         return effort.to(torch.float32)
 
-    def reset(self, env_ids: torch.Tensor | list[int] | None = None):
-        """Reset selected envs (defaults to all)."""
+    def reset(self, env_ids: torch.Tensor | list[int] | None = None, seed: int | None = None):
+        """Reset selected envs (defaults to all).
+
+        ``seed`` is forwarded to the handler when supported, so the
+        ``env.reset(seed=)`` contract reaches the simulator (this base
+        reimplements ``reset`` and does not call ``super().reset``).
+        """
+        if seed is not None:
+            set_seed = getattr(self.handler, "set_seed", None)
+            if callable(set_seed):
+                set_seed(seed)
         if env_ids is None:
             env_ids = torch.tensor(list(range(self.num_envs)), device=self.device)
 

--- a/roboverse_pack/tasks/libero/libero_base.py
+++ b/roboverse_pack/tasks/libero/libero_base.py
@@ -30,16 +30,19 @@ class LiberoBaseTask(BaseTaskEnv):
         """Success when cube is detected in the bbox above base."""
         return self.checker.check(self.handler, states)
 
-    def reset(self, states=None, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset the checker, then the environment.
 
         The checker is reset *before* ``super().reset()`` — super().reset()
         may invoke reset-callbacks that read termination state (computed
         via the checker), which would otherwise see stale checker state.
+
+        ``seed`` is forwarded to ``super().reset`` so the ``env.reset(seed=)``
+        contract reaches the handler (see ``BaseTaskEnv.reset``).
         """
         if self.checker is not None:
             self.checker.reset(self.handler, env_ids=env_ids)
-        return super().reset(states, env_ids)
+        return super().reset(states, env_ids, seed)
 
     def _get_initial_states(self) -> list[dict] | None:
         """Return per-env initial states sampled from the demo trajectory.

--- a/roboverse_pack/tasks/libero_90/libero_90_base.py
+++ b/roboverse_pack/tasks/libero_90/libero_90_base.py
@@ -34,9 +34,9 @@ class Libero90BaseTask(BaseTaskEnv):
         """Success when task conditions are met."""
         return self.checker.check(self.handler, states)
 
-    def reset(self, states=None, env_ids=None):
-        """Reset the checker."""
-        states = super().reset(states, env_ids)
+    def reset(self, states=None, env_ids=None, seed=None):
+        """Reset the checker. ``seed`` is forwarded to ``super().reset``."""
+        states = super().reset(states, env_ids, seed)
         self.checker.reset(self.handler, env_ids=env_ids)
         return states
 

--- a/roboverse_pack/tasks/maniskill/maniskill_base.py
+++ b/roboverse_pack/tasks/maniskill/maniskill_base.py
@@ -26,9 +26,9 @@ class ManiskillBaseTask(BaseTaskEnv):
         """Task success when the cube has been lifted sufficiently along z from its reset height."""
         return self.checker.check(self.handler, states)
 
-    def reset(self, states=None, env_ids=None):
-        """Reset the checker."""
-        states = super().reset(states, env_ids)
+    def reset(self, states=None, env_ids=None, seed=None):
+        """Reset the checker. ``seed`` is forwarded to ``super().reset``."""
+        states = super().reset(states, env_ids, seed)
         self.checker.reset(self.handler, env_ids=env_ids)
         return states
 

--- a/roboverse_pack/tasks/pick_place/base.py
+++ b/roboverse_pack/tasks/pick_place/base.py
@@ -194,7 +194,7 @@ class PickPlaceBase(RLTaskEnv):
 
         return states
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment and last actions."""
         if env_ids is None or self._last_action is None:
             self._last_action = self._initial_states.robots[self.robot_name].joint_pos[:, :]
@@ -213,7 +213,7 @@ class PickPlaceBase(RLTaskEnv):
         self.prev_distance_to_waypoint[env_ids_tensor] = 0.0
         self.object_grasped[env_ids_tensor] = False
 
-        obs, info = super().reset(env_ids=env_ids)
+        obs, info = super().reset(states=states, env_ids=env_ids, seed=seed)
 
         states = self.handler.get_states(mode="tensor")
 

--- a/roboverse_pack/tasks/rlbench/rl_bench.py
+++ b/roboverse_pack/tasks/rlbench/rl_bench.py
@@ -40,8 +40,8 @@ class RLBenchTask(BaseTaskEnv):
         self._initial_states = initial_states[: self.num_envs]
         return self._initial_states
 
-    def reset(self, states=None, env_ids=None):
-        """Reset the checker."""
-        states = super().reset(states, env_ids)
+    def reset(self, states=None, env_ids=None, seed=None):
+        """Reset the checker. ``seed`` is forwarded to ``super().reset``."""
+        states = super().reset(states, env_ids, seed)
         self.checker.reset(self.handler, env_ids=env_ids)
         return states

--- a/roboverse_pack/tasks/task_template.py
+++ b/roboverse_pack/tasks/task_template.py
@@ -130,12 +130,14 @@ class MinimalTask(BaseTaskEnv):
 
         return super().step(actions)
 
-    def reset(self, states=None, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment.
 
-        Use this to reset custom member variables.
+        Use this to reset custom member variables. Always keep ``seed`` in the
+        signature and forward it to ``super().reset`` so the
+        ``env.reset(seed=)`` reproducibility contract reaches the handler.
         """
-        states = super().reset(states, env_ids)
+        states = super().reset(states, env_ids, seed)
 
         # Reset custom variables， e.g.
         # if env_ids is None:

--- a/tests/test_task_reset_seed_contract.py
+++ b/tests/test_task_reset_seed_contract.py
@@ -1,0 +1,186 @@
+"""Backend-free conformance guardrail: every task ``reset`` must accept ``seed``.
+
+The gym bridge (``metasim.task.gym_registration``) forwards ``env.reset(seed=)``
+to a task only when the task's ``reset`` signature accepts it — tasks that
+override ``reset`` without a ``seed`` parameter silently drop the seed, so
+rollouts are not reproducible on the simulator side.
+
+This test statically (no sim backend, no instantiation) scans every task file
+and asserts:
+
+* no *new* ``reset`` override lacks ``seed`` beyond the known P1-cleanup
+  allowlist (ratchet: the set may only shrink);
+* the allowlist has no stale entries (forces it to shrink as P1 lands);
+* the unified family base classes already honor the contract.
+
+When you fix a file's ``reset`` to accept ``seed`` (or stop overriding
+``reset``), delete it from ``KNOWN_NO_SEED_RESET`` below.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+_TASKS = pathlib.Path(__file__).resolve().parents[1] / "roboverse_pack" / "tasks"
+
+# Family base classes fixed in the reset(seed) unification — must stay conformant.
+_FIXED_BASES = {
+    "libero/libero_base.py",
+    "libero_90/libero_90_base.py",
+    "maniskill/maniskill_base.py",
+    "rlbench/rl_bench.py",
+    "embodiedgen/base.py",
+    "calvin/base_table.py",
+    "pick_place/base.py",
+    "humanoid/base/base_legged_robot.py",
+}
+
+# P1 cleanup targets: task files whose ``reset`` override still drops ``seed``.
+# This list may only SHRINK. Remove an entry when you fix that file.
+KNOWN_NO_SEED_RESET = frozenset({
+    "benchmark/base.py",
+    "beyondmimic/isaaclab/robots/actuator.py",
+    "beyondmimic/metasim/envs/base_legged_robot.py",
+    "beyondmimic/metasim/mdp/commands.py",
+    "libero/native_libero.py",
+    "libero_90/libero_kitchen_scene10_close_the_top_drawer_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene10_close_the_top_drawer_of_the_cabinet_and_put_the_black_bowl_on_top_of_it.py",
+    "libero_90/libero_kitchen_scene10_put_the_black_bowl_in_the_top_drawer_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene10_put_the_butter_at_the_back_in_the_top_drawer_of_the_cabinet_and_close_it.py",
+    "libero_90/libero_kitchen_scene10_put_the_butter_at_the_front_in_the_top_drawer_of_the_cabinet_and_close_it.py",
+    "libero_90/libero_kitchen_scene10_put_the_chocolate_pudding_in_the_top_drawer_of_the_cabinet_and_close_it.py",
+    "libero_90/libero_kitchen_scene1_open_drawer_put_bowl.py",
+    "libero_90/libero_kitchen_scene1_put_the_black_bowl_on_the_plate.py",
+    "libero_90/libero_kitchen_scene1_put_the_black_bowl_on_top_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene2_put_the_black_bowl_at_the_back_on_the_plate.py",
+    "libero_90/libero_kitchen_scene2_put_the_black_bowl_at_the_front_on_the_plate.py",
+    "libero_90/libero_kitchen_scene2_put_the_black_bowl_in_the_middle_on_the_plate.py",
+    "libero_90/libero_kitchen_scene2_put_the_middle_black_bowl_on_top_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene2_stack_the_black_bowl_at_the_front_on_the_black_bowl_in_the_middle.py",
+    "libero_90/libero_kitchen_scene2_stack_the_middle_black_bowl_on_the_back_black_bowl.py",
+    "libero_90/libero_kitchen_scene3_put_the_frying_pan_on_the_stove.py",
+    "libero_90/libero_kitchen_scene3_put_the_moka_pot_on_the_stove.py",
+    "libero_90/libero_kitchen_scene3_turn_on_the_stove.py",
+    "libero_90/libero_kitchen_scene3_turn_on_the_stove_and_put_the_frying_pan_on_it.py",
+    "libero_90/libero_kitchen_scene4_close_the_bottom_drawer_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene4_close_the_bottom_drawer_of_the_cabinet_and_open_the_top_drawer.py",
+    "libero_90/libero_kitchen_scene4_put_the_black_bowl_in_the_bottom_drawer_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene4_put_the_black_bowl_on_top_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene4_put_the_wine_bottle_in_the_bottom_drawer_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene4_put_the_wine_bottle_on_the_wine_rack.py",
+    "libero_90/libero_kitchen_scene5_close_the_top_drawer_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene5_put_the_black_bowl_in_the_top_drawer_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene5_put_the_black_bowl_on_the_plate.py",
+    "libero_90/libero_kitchen_scene5_put_the_black_bowl_on_top_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene5_put_the_ketchup_in_the_top_drawer_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene6_close_the_microwave.py",
+    "libero_90/libero_kitchen_scene6_put_the_yellow_and_white_mug_to_the_front_of_the_white_mug.py",
+    "libero_90/libero_kitchen_scene7_open_the_microwave.py",
+    "libero_90/libero_kitchen_scene7_put_the_white_bowl_on_the_plate.py",
+    "libero_90/libero_kitchen_scene7_put_the_white_bowl_to_the_right_of_the_plate.py",
+    "libero_90/libero_kitchen_scene8_put_the_right_moka_pot_on_the_stove.py",
+    "libero_90/libero_kitchen_scene8_turn_off_the_stove.py",
+    "libero_90/libero_kitchen_scene9_put_the_frying_pan_on_the_cabinet_shelf.py",
+    "libero_90/libero_kitchen_scene9_put_the_frying_pan_on_top_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene9_put_the_frying_pan_under_the_cabinet_shelf.py",
+    "libero_90/libero_kitchen_scene9_put_the_white_bowl_on_top_of_the_cabinet.py",
+    "libero_90/libero_kitchen_scene9_turn_on_the_stove.py",
+    "libero_90/libero_kitchen_scene9_turn_on_the_stove_and_put_the_frying_pan_on_it.py",
+    "libero_90/living_room_scene1_pick_up_the_alphabet_soup_and_put_it_in_the_basket.py",
+    "libero_90/living_room_scene1_pick_up_the_cream_cheese_box_and_put_it_in_the_basket.py",
+    "libero_90/living_room_scene1_pick_up_the_ketchup_and_put_it_in_the_basket.py",
+    "libero_90/living_room_scene1_pick_up_the_tomato_sauce_and_put_it_in_the_basket.py",
+    "libero_90/living_room_scene2_pick_up_the_alphabet_soup_and_put_it_in_the_basket.py",
+    "libero_90/living_room_scene2_pick_up_the_butter_and_put_it_in_the_basket.py",
+    "libero_90/living_room_scene2_pick_up_the_milk_and_put_it_in_the_basket.py",
+    "libero_90/living_room_scene2_pick_up_the_orange_juice_and_put_it_in_the_basket.py",
+    "libero_90/living_room_scene2_pick_up_the_tomato_sauce_and_put_it_in_the_basket.py",
+    "libero_90/living_room_scene3_pick_up_the_alphabet_soup_and_put_it_in_the_tray.py",
+    "libero_90/living_room_scene3_pick_up_the_butter_and_put_it_in_the_tray.py",
+    "libero_90/living_room_scene3_pick_up_the_cream_cheese_and_put_it_in_the_tray.py",
+    "libero_90/living_room_scene3_pick_up_the_ketchup_and_put_it_in_the_tray.py",
+    "libero_90/living_room_scene3_pick_up_the_tomato_sauce_and_put_it_in_the_tray.py",
+    "libero_90/living_room_scene4_pick_up_the_black_bowl_on_the_left_and_put_it_in_the_tray.py",
+    "libero_90/living_room_scene4_pick_up_the_chocolate_pudding_and_put_it_in_the_tray.py",
+    "libero_90/living_room_scene4_pick_up_the_salad_dressing_and_put_it_in_the_tray.py",
+    "libero_90/living_room_scene4_stack_the_left_bowl_on_the_right_bowl_and_place_them_in_the_tray.py",
+    "libero_90/living_room_scene4_stack_the_right_bowl_on_the_left_bowl_and_place_them_in_the_tray.py",
+    "maniskill/draw_svg.py",
+    "maniskill/draw_triangle.py",
+    "maniskill/lift_peg_upright.py",
+    "maniskill/roll_ball.py",
+    "mjlab/cartpole_train.py",
+    "mjlab/mdp/commands.py",
+    "mjlab/mdp/sensors.py",
+    "mujoco_playground/handover.py",
+    "mujoco_playground/open_cabinet.py",
+    "mujoco_playground/pick.py",
+    "pick_place/approach_grasp.py",
+    "pick_place/approach_grasp_ceramic_teapot.py",
+    "pick_place/approach_grasp_knife.py",
+    "pick_place/hand_trajectory.py",
+    "pick_place/track_banana.py",
+    "pick_place/track_screwdriver.py",
+    "pick_place/track_spoon.py",
+    "robosuite/native.py",
+    "robosuite/robosuite_env.py",
+    "simpler_env/_native/control/base_controller.py",
+    "simpler_env/_native/control/pd_ee_pose.py",
+    "simpler_env/_native/control/pd_joint_pos.py",
+    "simpler_env/_native/grasp.py",
+})
+
+
+def _reset_methods_without_seed(path: pathlib.Path) -> bool:
+    """True if the file defines a class method ``reset`` lacking a ``seed`` arg."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return False
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or node.name != "reset":
+            continue
+        a = node.args
+        names = {p.arg for p in (*a.posonlyargs, *a.args, *a.kwonlyargs)}
+        if "seed" in names or a.kwarg is not None:  # explicit seed= or **kwargs
+            continue
+        return True
+    return False
+
+
+def _all_violators() -> set[str]:
+    out = set()
+    for path in _TASKS.rglob("*.py"):
+        if _reset_methods_without_seed(path):
+            out.add(path.relative_to(_TASKS).as_posix())
+    return out
+
+
+@pytest.mark.general
+def test_no_new_reset_without_seed():
+    """No task may add a ``reset`` override that drops ``seed`` (ratchet)."""
+    new = sorted(_all_violators() - KNOWN_NO_SEED_RESET)
+    assert not new, (
+        "These task files override reset() without a seed parameter, breaking the "
+        "env.reset(seed=) contract. Add seed=None and forward it to super().reset:\n  " + "\n  ".join(new)
+    )
+
+
+@pytest.mark.general
+def test_reset_seed_allowlist_has_no_stale_entries():
+    """Allowlisted files must still be violators — forces the list to shrink."""
+    stale = sorted(KNOWN_NO_SEED_RESET - _all_violators())
+    assert not stale, (
+        "These files no longer violate the reset(seed) contract — remove them from "
+        "KNOWN_NO_SEED_RESET:\n  " + "\n  ".join(stale)
+    )
+
+
+@pytest.mark.general
+def test_unified_bases_accept_seed():
+    """The fixed family base classes must keep accepting seed (regression guard)."""
+    regressed = sorted(f for f in _FIXED_BASES if _reset_methods_without_seed(_TASKS / f))
+    assert not regressed, f"Base classes regressed to reset() without seed: {regressed}"


### PR DESCRIPTION
## What
Eight task **family base classes** overrode `reset()` without a `seed` parameter, so `env.reset(seed=)` was silently dropped on the simulator side — the gym bridge (`metasim.task.gym_registration`) only forwards `seed` when the signature accepts it. This broke rollout reproducibility for **every task** in those families and was the single largest task-format divergence in the infra audit (**109 of ~128 `reset` overrides dropped `seed`**).

## Change (minimal — base classes only)
Add `seed=None` and forward to `super().reset` in: `libero`, `libero_90`, `maniskill`, `rlbench`, `embodiedgen`, `calvin`, `pick_place`. The humanoid `LeggedRobotTask` base reimplements `reset` (no super), so it forwards to `handler.set_seed`. Fixing the bases cascades the contract to ~100 leaf tasks that don't override `reset` themselves. Also fixes `task_template.py` so the canonical example models the contract.

## Guardrail (the maintenance lever)
Adds `tests/test_task_reset_seed_contract.py` — a **backend-free `general` test** that statically (AST, no instantiation) asserts:
- no **new** `reset` override drops `seed` (ratchet over a 90-file P1-cleanup allowlist that may only shrink);
- the allowlist has no stale entries (forces it to shrink as P1 lands);
- the fixed base classes stay conformant.

## Scope
This is **P0** of the task-infra unification effort. The remaining 90 leaf `reset` overrides are allowlisted as **P1** targets (removing the `step`/`reset` overrides via sanctioned hooks). Architectural items (P2–P4) are tracked separately.

## Verification
`ruff check` + `ruff format --check` pass; the 3 guardrail tests pass locally (pure static analysis, validated without sim backends).