### PR TITLE
fix(tasks): correct embodiedgen put_banana max_episode_steps (250000 -> 250)

### DIFF
--- a/roboverse_pack/tasks/embodiedgen/put_banana.py
+++ b/roboverse_pack/tasks/embodiedgen/put_banana.py
@@ -21,7 +21,7 @@ class PutBananaTask(EmbodiedGenBaseTask):
     The scene contains multiple objects on the table to make it more realistic and challenging.
     """
 
-    max_episode_steps = 250000
+    max_episode_steps = 250
 
     scenario = ScenarioCfg(
         objects=[

--- a/tests/test_embodiedgen_episode_steps.py
+++ b/tests/test_embodiedgen_episode_steps.py
@@ -1,0 +1,37 @@
+"""Backend-free regression: embodiedgen tasks use a sane max_episode_steps.
+
+``put_banana`` carried ``max_episode_steps = 250000`` (a typo — base and the
+``put_mug`` sibling both use 250), which would let an unsolved episode run for
+250k steps. This statically (no sim backend) pins every embodiedgen task's
+declared ``max_episode_steps`` to the base value.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+_EMBODIEDGEN = pathlib.Path(__file__).resolve().parents[1] / "roboverse_pack" / "tasks" / "embodiedgen"
+_EXPECTED = 250  # base.py / put_mug.py convention
+
+
+def _max_episode_steps(path: pathlib.Path) -> int | None:
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for t in node.targets:
+                if isinstance(t, ast.Name) and t.id == "max_episode_steps" and isinstance(node.value, ast.Constant):
+                    return node.value.value
+    return None
+
+
+@pytest.mark.general
+def test_embodiedgen_max_episode_steps_are_sane():
+    offenders = {}
+    for path in sorted(_EMBODIEDGEN.glob("*.py")):
+        val = _max_episode_steps(path)
+        if val is not None and val != _EXPECTED:
+            offenders[path.name] = val
+    assert not offenders, f"embodiedgen tasks with off-convention max_episode_steps (expected {_EXPECTED}): {offenders}"


### PR DESCRIPTION
`put_banana` declared `max_episode_steps = 250000` — a typo (extra `000`); the `EmbodiedGenBaseTask` base and the `put_mug` sibling both use **250**, so an unsolved episode could run 1000× too long before timing out.

Fixes the value and adds a backend-free (`general`) regression test pinning every embodiedgen task's `max_episode_steps` to the base convention.

Part of the task-infra unification effort (P0 correctness sweep).