### PR TITLE
refactor(tasks): complete reset(seed) contract across all Tier-1 tasks + scope guardrail

### DIFF
--- a/roboverse_pack/tasks/beyondmimic/metasim/envs/base_legged_robot.py
+++ b/roboverse_pack/tasks/beyondmimic/metasim/envs/base_legged_robot.py
@@ -130,8 +130,7 @@ class LeggedRobotTask(RLTaskEnv):
 
         # per-actuator action scale
         self.action_scale = (
-            torch
-            .tensor(list(self.robot.action_scale.values()), device=self.device)
+            torch.tensor(list(self.robot.action_scale.values()), device=self.device)
             .unsqueeze(0)
             .repeat(self.num_envs, 1)
         )

--- a/roboverse_pack/tasks/beyondmimic/metasim/envs/base_legged_robot.py
+++ b/roboverse_pack/tasks/beyondmimic/metasim/envs/base_legged_robot.py
@@ -130,7 +130,8 @@ class LeggedRobotTask(RLTaskEnv):
 
         # per-actuator action scale
         self.action_scale = (
-            torch.tensor(list(self.robot.action_scale.values()), device=self.device)
+            torch
+            .tensor(list(self.robot.action_scale.values()), device=self.device)
             .unsqueeze(0)
             .repeat(self.num_envs, 1)
         )
@@ -184,8 +185,17 @@ class LeggedRobotTask(RLTaskEnv):
         # NOTE corresponds to action clipping in `RslRlVecEnvWrapper.step()` in Isaac Lab
         return torch.clip(actions, -self.action_clip, self.action_clip) if self.action_clip else actions
 
-    def reset(self, env_ids: Sequence[int] | None = None):
-        """Reset the specified environments. Only called once when the task class is initialized."""
+    def reset(self, env_ids: Sequence[int] | None = None, seed: int | None = None):
+        """Reset the specified environments.
+
+        ``seed`` is forwarded to the handler when supported (this base
+        reimplements ``reset`` and does not call ``super().reset``), honoring
+        the ``env.reset(seed=)`` contract.
+        """
+        if seed is not None:
+            set_seed = getattr(self.handler, "set_seed", None)
+            if callable(set_seed):
+                set_seed(seed)
         if env_ids is None:
             env_ids = torch.arange(self.num_envs, dtype=torch.int64, device=self.device)
 

--- a/roboverse_pack/tasks/mjlab/cartpole_train.py
+++ b/roboverse_pack/tasks/mjlab/cartpole_train.py
@@ -170,7 +170,11 @@ class _MjlabCartpoleTrainBase(BaseTaskEnv):
         info: dict[str, Any] = {}
         return obs, reward, terminated, timeout, info
 
-    def reset(self, states=None, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
+        if seed is not None:
+            set_seed = getattr(self.handler, "set_seed", None)
+            if callable(set_seed):
+                set_seed(seed)
         if env_ids is None:
             env_ids = list(range(self.num_envs))
         # dm_control's Physics has a reset() that calls mj_resetData internally.

--- a/roboverse_pack/tasks/mujoco_playground/handover.py
+++ b/roboverse_pack/tasks/mujoco_playground/handover.py
@@ -142,7 +142,7 @@ class HandOver(RLTaskEnv):
 
         return states
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment and episode tracking."""
         if env_ids is None or self._last_action is None:
             # Initialize with home position
@@ -156,7 +156,7 @@ class HandOver(RLTaskEnv):
             self._prev_potential[env_ids] = 0.0
             self._last_action[env_ids] = self._initial_states.robots[self.robot_name].joint_pos[env_ids].clone()
 
-        return super().reset(env_ids=env_ids)
+        return super().reset(states=states, env_ids=env_ids, seed=seed)
 
     def step(self, actions):
         """Step with delta control and progress tracking."""

--- a/roboverse_pack/tasks/mujoco_playground/open_cabinet.py
+++ b/roboverse_pack/tasks/mujoco_playground/open_cabinet.py
@@ -121,7 +121,7 @@ class PandaOpenCabinet(RLTaskEnv):
 
         return states
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment and last actions."""
         if env_ids is None or self._last_action is None:
             # mj: Set initial qpos. Arm joints only with perturbation
@@ -159,7 +159,7 @@ class PandaOpenCabinet(RLTaskEnv):
             # Reset latched gate for selected envs
             self._reached_handle[env_ids] = 0.0
 
-        return super().reset(env_ids=env_ids)
+        return super().reset(states=states, env_ids=env_ids, seed=seed)
 
     def step(self, actions):
         """Step with delta control."""

--- a/roboverse_pack/tasks/mujoco_playground/pick.py
+++ b/roboverse_pack/tasks/mujoco_playground/pick.py
@@ -115,7 +115,7 @@ class PandaPickCube(RLTaskEnv):
 
         return states
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment and last actions."""
         # Initialize _last_action if not exists (first reset)
         # Reset last action for delta control
@@ -123,7 +123,7 @@ class PandaPickCube(RLTaskEnv):
             self._last_action = self._initial_states.robots[self.robot_name].joint_pos[:, :]
         else:
             self._last_action[env_ids] = self._initial_states.robots[self.robot_name].joint_pos[env_ids, :]
-        return super().reset(env_ids=env_ids)
+        return super().reset(states=states, env_ids=env_ids, seed=seed)
 
     def step(self, actions):
         """Step with delta control."""

--- a/roboverse_pack/tasks/pick_place/approach_grasp.py
+++ b/roboverse_pack/tasks/pick_place/approach_grasp.py
@@ -177,9 +177,9 @@ class PickPlaceApproachGraspSimple(PickPlaceBase):
         else:
             log.warning(f"Joint {self.joint2_name} not found, joint2 lift disabled")
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment and tracking variables."""
-        obs, info = super().reset(env_ids=env_ids)
+        obs, info = super().reset(states=states, env_ids=env_ids, seed=seed)
 
         if env_ids is None:
             env_ids_tensor = torch.arange(self.num_envs, device=self.device)

--- a/roboverse_pack/tasks/pick_place/approach_grasp_ceramic_teapot.py
+++ b/roboverse_pack/tasks/pick_place/approach_grasp_ceramic_teapot.py
@@ -236,9 +236,9 @@ class PickPlaceApproachGraspHu(PickPlaceBase):
 
         return center_pos
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment and tracking variables."""
-        obs, info = super().reset(env_ids=env_ids)
+        obs, info = super().reset(states=states, env_ids=env_ids, seed=seed)
 
         if env_ids is None:
             env_ids_tensor = torch.arange(self.num_envs, device=self.device)

--- a/roboverse_pack/tasks/pick_place/approach_grasp_knife.py
+++ b/roboverse_pack/tasks/pick_place/approach_grasp_knife.py
@@ -225,9 +225,9 @@ class PickPlaceApproachGraspKnife(PickPlaceBase):
         else:
             log.warning(f"Joint {self.joint2_name} not found, joint2 lift disabled")
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment and tracking variables."""
-        obs, info = super().reset(env_ids=env_ids)
+        obs, info = super().reset(states=states, env_ids=env_ids, seed=seed)
 
         if env_ids is None:
             env_ids_tensor = torch.arange(self.num_envs, device=self.device)

--- a/roboverse_pack/tasks/pick_place/hand_trajectory.py
+++ b/roboverse_pack/tasks/pick_place/hand_trajectory.py
@@ -298,7 +298,7 @@ class TrajectoryTrackingTaskBase(RLTaskEnv):
 
         return states
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment and last actions."""
         if env_ids is None or self._last_action is None:
             self._last_action = self._initial_states.robots[self.robot_name].joint_pos[:, :]
@@ -317,7 +317,7 @@ class TrajectoryTrackingTaskBase(RLTaskEnv):
         self.prev_distance_to_waypoint[env_ids_tensor] = 0.0
         self.object_grasped[env_ids_tensor] = False
 
-        obs, info = super().reset(env_ids=env_ids)
+        obs, info = super().reset(states=states, env_ids=env_ids, seed=seed)
 
         states = self.handler.get_states(mode="tensor")
 

--- a/roboverse_pack/tasks/pick_place/track_banana.py
+++ b/roboverse_pack/tasks/pick_place/track_banana.py
@@ -370,7 +370,7 @@ class PickPlaceTrackBanana(PickPlaceBase):
         log.info(f"Loaded {len(initial_states)} initial states from {self.state_file_path}")
         return initial_states
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment, keeping object grasped."""
         if env_ids is None or self._last_action is None:
             self._last_action = self._initial_states.robots[self.robot_name].joint_pos[:, :]
@@ -392,7 +392,7 @@ class PickPlaceTrackBanana(PickPlaceBase):
 
         self.object_grasped[env_ids_tensor] = True
 
-        obs, info = super(PickPlaceBase, self).reset(env_ids=env_ids)
+        obs, info = super(PickPlaceBase, self).reset(states=states, env_ids=env_ids, seed=seed)
 
         states = self.handler.get_states(mode="tensor")
         if env_ids is None:

--- a/roboverse_pack/tasks/pick_place/track_screwdriver.py
+++ b/roboverse_pack/tasks/pick_place/track_screwdriver.py
@@ -371,7 +371,7 @@ class PickPlaceTrackScrewDriver(PickPlaceBase):
         log.info(f"Loaded {len(initial_states)} initial states from {self.state_file_path}")
         return initial_states
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment, keeping object grasped."""
         if env_ids is None or self._last_action is None:
             self._last_action = self._initial_states.robots[self.robot_name].joint_pos[:, :]
@@ -393,7 +393,7 @@ class PickPlaceTrackScrewDriver(PickPlaceBase):
 
         self.object_grasped[env_ids_tensor] = True
 
-        obs, info = super(PickPlaceBase, self).reset(env_ids=env_ids)
+        obs, info = super(PickPlaceBase, self).reset(states=states, env_ids=env_ids, seed=seed)
 
         states = self.handler.get_states(mode="tensor")
         if env_ids is None:

--- a/roboverse_pack/tasks/pick_place/track_spoon.py
+++ b/roboverse_pack/tasks/pick_place/track_spoon.py
@@ -438,7 +438,7 @@ class PickPlaceTrackSpoon(PickPlaceBase):
         log.info(f"Loaded {len(initial_states)} initial states from {self.state_file_path}")
         return initial_states
 
-    def reset(self, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment, keeping object grasped."""
         if env_ids is None or self._last_action is None:
             self._last_action = self._initial_states.robots[self.robot_name].joint_pos[:, :]
@@ -466,7 +466,7 @@ class PickPlaceTrackSpoon(PickPlaceBase):
 
         self.object_grasped[env_ids_tensor] = True
 
-        obs, info = super(PickPlaceBase, self).reset(env_ids=env_ids)
+        obs, info = super(PickPlaceBase, self).reset(states=states, env_ids=env_ids, seed=seed)
 
         states = self.handler.get_states(mode="tensor")
         if env_ids is None:

--- a/roboverse_pack/tasks/robosuite/robosuite_env.py
+++ b/roboverse_pack/tasks/robosuite/robosuite_env.py
@@ -201,7 +201,11 @@ class RobosuiteEnv(BaseTaskEnv):
     def _to_obs_tensor(self, obs_dict: dict) -> torch.Tensor:
         return torch.from_numpy(self._obs_vector(obs_dict)).to(self.device).unsqueeze(0)
 
-    def reset(self, states=None, env_ids=None):
+    def reset(self, states=None, env_ids=None, seed=None):
+        # Honor the env.reset(seed=) contract: robosuite's oracle is seeded via
+        # numpy's global RNG, so a passed seed updates the stored seed used here.
+        if seed is not None:
+            self._seed = seed
         np.random.seed(self._seed)
         obs_dict = self._oracle.reset()
         self._sync_oracle_to_handler()

--- a/tests/test_task_reset_seed_contract.py
+++ b/tests/test_task_reset_seed_contract.py
@@ -55,22 +55,10 @@ _FIXED_BASES = {
 }
 
 # P1 cleanup targets: Tier-1 task files whose ``reset`` override still drops
-# ``seed``. This list may only SHRINK. Remove an entry when you fix that file.
-KNOWN_NO_SEED_RESET = frozenset({
-    "beyondmimic/metasim/envs/base_legged_robot.py",
-    "mjlab/cartpole_train.py",
-    "mujoco_playground/handover.py",
-    "mujoco_playground/open_cabinet.py",
-    "mujoco_playground/pick.py",
-    "pick_place/approach_grasp.py",
-    "pick_place/approach_grasp_ceramic_teapot.py",
-    "pick_place/approach_grasp_knife.py",
-    "pick_place/hand_trajectory.py",
-    "pick_place/track_banana.py",
-    "pick_place/track_screwdriver.py",
-    "pick_place/track_spoon.py",
-    "robosuite/robosuite_env.py",
-})
+# ``seed``. The contract is now COMPLETE — every Tier-1 task accepts ``seed`` —
+# so this is empty and the guardrail is zero-tolerance. It may only ever be
+# extended with a NEW genuine violator pending its fix; prefer fixing instead.
+KNOWN_NO_SEED_RESET = frozenset()
 
 
 def _base_name(node: ast.expr) -> str | None:

--- a/tests/test_task_reset_seed_contract.py
+++ b/tests/test_task_reset_seed_contract.py
@@ -1,4 +1,4 @@
-"""Backend-free conformance guardrail: every task ``reset`` must accept ``seed``.
+"""Backend-free conformance guardrail: every Tier-1 task ``reset`` accepts ``seed``.
 
 The gym bridge (``metasim.task.gym_registration``) forwards ``env.reset(seed=)``
 to a task only when the task's ``reset`` signature accepts it — tasks that
@@ -6,9 +6,20 @@ override ``reset`` without a ``seed`` parameter silently drop the seed, so
 rollouts are not reproducible on the simulator side.
 
 This test statically (no sim backend, no instantiation) scans every task file
-and asserts:
+and asserts the contract on **Tier-1 tasks only**:
 
-* no *new* ``reset`` override lacks ``seed`` beyond the known P1-cleanup
+* **Tier 1** — classes in the unified contract: they (transitively) subclass
+  ``BaseTaskEnv`` / ``RLTaskEnv`` / ``ManagerBasedRVEnv``. Only these are checked.
+* **Tier 3** — external/native passthrough adapters (modules under ``_native``/
+  ``_passthrough`` or classes named ``Native*``/``Passthrough*``) are an
+  explicitly-exempt compatibility tier and are skipped.
+* Non-task helpers (controllers, sensors, command/actuator managers, success
+  evaluators, sessions) are not in the inheritance graph to ``BaseTaskEnv`` and
+  are therefore ignored.
+
+Assertions:
+
+* no *new* Tier-1 ``reset`` override lacks ``seed`` beyond the P1-cleanup
   allowlist (ratchet: the set may only shrink);
 * the allowlist has no stale entries (forces it to shrink as P1 lands);
 * the unified family base classes already honor the contract.
@@ -26,6 +37,11 @@ import pytest
 
 _TASKS = pathlib.Path(__file__).resolve().parents[1] / "roboverse_pack" / "tasks"
 
+# Terminal in-contract roots: a class is Tier-1 if it transitively subclasses one
+# of these. BaseTaskEnv/RLTaskEnv live in MetaSim; ManagerBasedRVEnv in
+# roboverse_learn — they are not defined under tasks/, so they anchor the graph.
+_CONTRACT_ROOTS = {"BaseTaskEnv", "RLTaskEnv", "ManagerBasedRVEnv"}
+
 # Family base classes fixed in the reset(seed) unification — must stay conformant.
 _FIXED_BASES = {
     "libero/libero_base.py",
@@ -38,17 +54,11 @@ _FIXED_BASES = {
     "humanoid/base/base_legged_robot.py",
 }
 
-# P1 cleanup targets: task files whose ``reset`` override still drops ``seed``.
-# This list may only SHRINK. Remove an entry when you fix that file.
+# P1 cleanup targets: Tier-1 task files whose ``reset`` override still drops
+# ``seed``. This list may only SHRINK. Remove an entry when you fix that file.
 KNOWN_NO_SEED_RESET = frozenset({
-    "benchmark/base.py",
-    "beyondmimic/isaaclab/robots/actuator.py",
     "beyondmimic/metasim/envs/base_legged_robot.py",
-    "beyondmimic/metasim/mdp/commands.py",
-    "libero/native_libero.py",
     "mjlab/cartpole_train.py",
-    "mjlab/mdp/commands.py",
-    "mjlab/mdp/sensors.py",
     "mujoco_playground/handover.py",
     "mujoco_playground/open_cabinet.py",
     "mujoco_playground/pick.py",
@@ -59,47 +69,85 @@ KNOWN_NO_SEED_RESET = frozenset({
     "pick_place/track_banana.py",
     "pick_place/track_screwdriver.py",
     "pick_place/track_spoon.py",
-    "robosuite/native.py",
     "robosuite/robosuite_env.py",
-    "simpler_env/_native/control/base_controller.py",
-    "simpler_env/_native/control/pd_ee_pose.py",
-    "simpler_env/_native/control/pd_joint_pos.py",
-    "simpler_env/_native/grasp.py",
 })
 
 
-def _reset_methods_without_seed(path: pathlib.Path) -> bool:
-    """True if the file defines a class method ``reset`` lacking a ``seed`` arg."""
-    try:
-        tree = ast.parse(path.read_text(encoding="utf-8"))
-    except (SyntaxError, UnicodeDecodeError):
-        return False
-    for node in ast.walk(tree):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) or node.name != "reset":
+def _base_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _build_class_graph() -> dict[str, set[str]]:
+    """Map every class defined under tasks/ to its (immediate) base-class names."""
+    graph: dict[str, set[str]] = {}
+    for path in _TASKS.rglob("*.py"):
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
             continue
-        a = node.args
-        names = {p.arg for p in (*a.posonlyargs, *a.args, *a.kwonlyargs)}
-        if "seed" in names or a.kwarg is not None:  # explicit seed= or **kwargs
-            continue
+        for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+            graph.setdefault(cls.name, set()).update(b for b in (_base_name(x) for x in cls.bases) if b is not None)
+    return graph
+
+
+def _in_contract(name: str, graph: dict[str, set[str]], seen: set[str] | None = None) -> bool:
+    """True if ``name`` transitively subclasses a contract root (Tier-1)."""
+    if name in _CONTRACT_ROOTS:
         return True
-    return False
+    seen = seen or set()
+    if name in seen or name not in graph:
+        return False
+    seen.add(name)
+    return any(_in_contract(b, graph, seen) for b in graph[name])
+
+
+def _is_tier3(rel_path: str, class_name: str) -> bool:
+    """Native/passthrough adapters are an explicitly-exempt compatibility tier."""
+    p = "/" + rel_path
+    if "/_native/" in p or "_passthrough" in rel_path:
+        return True
+    return class_name.startswith(("Native", "Passthrough"))
+
+
+def _reset_lacks_seed(fn: ast.FunctionDef) -> bool:
+    a = fn.args
+    names = {p.arg for p in (*a.posonlyargs, *a.args, *a.kwonlyargs)}
+    return "seed" not in names and a.kwarg is None  # no seed= and no **kwargs
 
 
 def _all_violators() -> set[str]:
-    out = set()
+    graph = _build_class_graph()
+    out: set[str] = set()
     for path in _TASKS.rglob("*.py"):
-        if _reset_methods_without_seed(path):
-            out.add(path.relative_to(_TASKS).as_posix())
+        rel = path.relative_to(_TASKS).as_posix()
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except (SyntaxError, UnicodeDecodeError):
+            continue
+        for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+            if _is_tier3(rel, cls.name) or not _in_contract(cls.name, graph):
+                continue
+            for fn in cls.body:
+                if (
+                    isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+                    and fn.name == "reset"
+                    and _reset_lacks_seed(fn)
+                ):
+                    out.add(rel)
     return out
 
 
 @pytest.mark.general
 def test_no_new_reset_without_seed():
-    """No task may add a ``reset`` override that drops ``seed`` (ratchet)."""
+    """No Tier-1 task may add a ``reset`` override that drops ``seed`` (ratchet)."""
     new = sorted(_all_violators() - KNOWN_NO_SEED_RESET)
     assert not new, (
-        "These task files override reset() without a seed parameter, breaking the "
-        "env.reset(seed=) contract. Add seed=None and forward it to super().reset:\n  " + "\n  ".join(new)
+        "These Tier-1 task files override reset() without a seed parameter, breaking "
+        "the env.reset(seed=) contract. Add seed=None and forward it to super().reset:\n  " + "\n  ".join(new)
     )
 
 
@@ -116,5 +164,11 @@ def test_reset_seed_allowlist_has_no_stale_entries():
 @pytest.mark.general
 def test_unified_bases_accept_seed():
     """The fixed family base classes must keep accepting seed (regression guard)."""
-    regressed = sorted(f for f in _FIXED_BASES if _reset_methods_without_seed(_TASKS / f))
-    assert not regressed, f"Base classes regressed to reset() without seed: {regressed}"
+    regressed = []
+    for rel in sorted(_FIXED_BASES):
+        tree = ast.parse((_TASKS / rel).read_text(encoding="utf-8"))
+        for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
+            for fn in cls.body:
+                if isinstance(fn, ast.FunctionDef) and fn.name == "reset" and _reset_lacks_seed(fn):
+                    regressed.append(rel)
+    assert not regressed, f"Base classes regressed to reset() without seed: {sorted(set(regressed))}"


### PR DESCRIPTION
## What
**Completes the `env.reset(seed=)` contract** for every Tier-1 task and makes the guardrail zero-tolerance.

### Task fixes (13 remaining Tier-1 violators)
- **10 super-forwarding leaves** (mujoco_playground ×3, pick_place ×7): widen signature to `(states=None, env_ids=None, seed=None)` and forward `states`/`seed` to `super().reset`. **Purely additive** — no reward/step/tracking logic touched.
- **3 reimplementing bases** (beyondmimic `LeggedRobotTask`, mjlab `cartpole_train`, `robosuite_env`): forward `seed` to `handler.set_seed` (robosuite updates its stored `_seed` since its oracle uses numpy's global RNG).

### Guardrail precision
Scopes `tests/test_task_reset_seed_contract.py` to **Tier-1 classes** via a static inheritance graph (transitive `BaseTaskEnv`/`RLTaskEnv`/`ManagerBasedRVEnv`), with an explicit **Tier-3 exemption** (native/passthrough adapters under `_native`/`_passthrough` or `Native*`/`Passthrough*`). Removes ~11 non-task false positives (controllers, sensors, command/actuator managers, sessions).

## Result
The reset(seed) allowlist is now **EMPTY** — the contract is complete and the guardrail rejects any new Tier-1 `reset` without `seed`. Backend-free; all 3 guardrail checks pass; ruff clean.

P1 (seed half) of #792. **Pending clean-context deep review before merge.**