### PR TITLE
refactor(tasks): humanoid_bench transforms actions via _process_action, not step()

### DIFF
--- a/roboverse_pack/tasks/humanoid_bench/humanoid_env.py
+++ b/roboverse_pack/tasks/humanoid_bench/humanoid_env.py
@@ -109,10 +109,14 @@ class BaseLocomotionEnv(RLTaskEnv):
         )
         super().__init__(scenario, device)
 
-    def step(self, actions):
-        """Step with unnomormalization."""
-        actions = self.unnormalise_action(actions)
-        return super().step(actions)
+    def _process_action(self, actions):
+        """Unnormalise actions from [-1, 1] to joint limits (sanctioned action hook).
+
+        Replaces the old ``step`` override: ``RLTaskEnv.step`` calls
+        ``_process_action`` before clamping/applying, so behaviour is identical
+        (unnormalise, then the shared clamp + simulate) without overriding step.
+        """
+        return self.unnormalise_action(actions)
 
     def _observation(self, states: TensorState) -> torch.Tensor:
         results_state = []

--- a/tests/test_task_reset_seed_contract.py
+++ b/tests/test_task_reset_seed_contract.py
@@ -71,7 +71,6 @@ KNOWN_STEP_OVERRIDES = frozenset({
     "beyondmimic/metasim/envs/base_legged_robot.py",
     "calvin/base_table.py",
     "humanoid/base/base_legged_robot.py",
-    "humanoid_bench/humanoid_env.py",
     "mjlab/cartpole_train.py",
     "mujoco_playground/handover.py",
     "mujoco_playground/open_cabinet.py",


### PR DESCRIPTION
First `step()`-override migration onto the unified contract, using MetaSim's new `_process_action` hook (RoboVerseOrg/MetaSim#22).

`BaseLocomotionEnv` overrode `step()` only to unnormalise actions. Move that into `_process_action` and drop the `step` override. **Behaviour identical** — `RLTaskEnv.step` calls `_process_action` (unnormalise) then the same clamp + simulate.

Removes `humanoid_bench` from the guardrail `KNOWN_STEP_OVERRIDES` (23→22). 7/7 guardrail checks pass; ruff clean. Part of #792. **Pending clean-context review.**