### PR TITLE
refactor(tasks): mujoco_playground pick/open_cabinet delta control via _process_action

### DIFF
--- a/roboverse_pack/tasks/mujoco_playground/open_cabinet.py
+++ b/roboverse_pack/tasks/mujoco_playground/open_cabinet.py
@@ -161,17 +161,21 @@ class PandaOpenCabinet(RLTaskEnv):
 
         return super().reset(states=states, env_ids=env_ids, seed=seed)
 
-    def step(self, actions):
-        """Step with delta control."""
+    def _process_action(self, actions):
+        """Delta position control (sanctioned action hook).
+
+        Replaces the old ``step`` override: ``RLTaskEnv.step`` calls
+        ``_process_action`` before clamping/applying, so behaviour is identical
+        (delta + clamp, latch ``_last_action``) without overriding step.
+        """
         # mj: delta = action * self._config.action_scale
         # mj: ctrl = state.data.ctrl + delta
         # mj: ctrl = jp.clip(ctrl, self._lowers, self._uppers)
         delta_actions = actions * self._action_scale
         new_actions = self._last_action + delta_actions
         real_actions = torch.maximum(torch.minimum(new_actions, self._action_high), self._action_low)
-        obs, reward, terminated, time_out, info = super().step(real_actions)
         self._last_action = real_actions
-        return obs, reward, terminated, time_out, info
+        return real_actions
 
     def _reward_handle_target(self, env_states) -> torch.Tensor:
         """Reward for bringing handle to target position."""

--- a/roboverse_pack/tasks/mujoco_playground/pick.py
+++ b/roboverse_pack/tasks/mujoco_playground/pick.py
@@ -125,14 +125,18 @@ class PandaPickCube(RLTaskEnv):
             self._last_action[env_ids] = self._initial_states.robots[self.robot_name].joint_pos[env_ids, :]
         return super().reset(states=states, env_ids=env_ids, seed=seed)
 
-    def step(self, actions):
-        """Step with delta control."""
+    def _process_action(self, actions):
+        """Delta position control (sanctioned action hook).
+
+        Replaces the old ``step`` override: ``RLTaskEnv.step`` calls
+        ``_process_action`` before clamping/applying, so behaviour is identical
+        (delta + clamp, latch ``_last_action``) without overriding step.
+        """
         delta_actions = actions * self._action_scale
         new_actions = self._last_action + delta_actions
         real_actions = torch.maximum(torch.minimum(new_actions, self._action_high), self._action_low)
-        obs, reward, terminated, time_out, info = super().step(real_actions)
         self._last_action = real_actions
-        return obs, reward, terminated, time_out, info
+        return real_actions
 
     def _reward_box_target(self, env_states) -> torch.Tensor:
         """Reward for bringing box to target position and orientation."""

--- a/tests/test_task_reset_seed_contract.py
+++ b/tests/test_task_reset_seed_contract.py
@@ -73,8 +73,6 @@ KNOWN_STEP_OVERRIDES = frozenset({
     "humanoid/base/base_legged_robot.py",
     "mjlab/cartpole_train.py",
     "mujoco_playground/handover.py",
-    "mujoco_playground/open_cabinet.py",
-    "mujoco_playground/pick.py",
     "pick_place/approach_grasp.py",
     "pick_place/approach_grasp_ceramic_teapot.py",
     "pick_place/approach_grasp_knife.py",


### PR DESCRIPTION
Migrates two pure delta-control `step()` overrides onto the `_process_action` hook.

`PandaPickCube`/`PandaOpenCabinet` overrode `step()` only for delta position control. Move it to `_process_action` and drop the override. **Behaviour identical** — `RLTaskEnv.step` runs `_process_action` (delta + clamp, latch `_last_action`) then the same clamp + simulate; `_last_action` is latched to the same value (read only next step).

`handover.py` is **intentionally not migrated** — its `step` also does post-step reward/episode tracking, so it stays allowlisted pending a parity-checked refactor.

Allowlist `KNOWN_STEP_OVERRIDES` 22→20; 7/7 guardrail checks pass; ruff clean. Part of #792. **Pending clean-context review.**