### PR TITLE
docs(tasks): task_template demonstrates _process_action instead of overriding step

### DIFF
--- a/roboverse_pack/tasks/task_template.py
+++ b/roboverse_pack/tasks/task_template.py
@@ -114,21 +114,20 @@ class MinimalTask(BaseTaskEnv):
         return torch.zeros(self.num_envs, dtype=torch.bool, device=self.device)
 
     # ========================================
-    # 4. (Optional) Override step and reset
+    # 4. (Optional) Transform actions, and reset custom state
     # ========================================
-    def step(self, actions: torch.Tensor):
-        """Execute one simulation step.
+    def _process_action(self, actions: torch.Tensor):
+        """Transform actions before they are applied (the sanctioned action hook).
 
-        Optional customizations:
-        - Action normalization/unnormalization
-        - End-effector control mapping
-        - Custom control logic
-        - Other logic
+        Prefer this over overriding ``step``: ``step`` calls ``_process_action``
+        first, then runs the shared clamp / apply / simulate pipeline. Examples:
+        - unnormalisation:  ``return self.unnormalise_action(actions)``
+        - delta control:    ``return self._last_action + actions * self._action_scale``
+        - end-effector / custom control mapping.
+
+        Default is identity (no transform).
         """
-        # Example: unnormalize actions from [-1,1] to joint limits
-        # actions = (actions + 1.0) / 2.0 * (action_high - action_low) + action_low
-
-        return super().step(actions)
+        return actions
 
     def reset(self, states=None, env_ids=None, seed=None):
         """Reset environment.

--- a/roboverse_pack/tasks/task_template.py
+++ b/roboverse_pack/tasks/task_template.py
@@ -120,9 +120,13 @@ class MinimalTask(BaseTaskEnv):
         """Transform actions before they are applied (the sanctioned action hook).
 
         Prefer this over overriding ``step``: ``step`` calls ``_process_action``
-        first, then runs the shared clamp / apply / simulate pipeline. Examples:
+        first, then runs the rest of the shared pipeline (for ``RLTaskEnv`` that
+        includes auto-clamping to joint limits). Example patterns to adapt:
         - unnormalisation:  ``return self.unnormalise_action(actions)``
+          (``unnormalise_action`` is provided by ``RLTaskEnv``; subclass that if
+          you need it — ``BaseTaskEnv`` does not define it)
         - delta control:    ``return self._last_action + actions * self._action_scale``
+          (define ``self._last_action`` / ``self._action_scale`` on your task)
         - end-effector / custom control mapping.
 
         Default is identity (no transform).

--- a/tests/test_task_reset_seed_contract.py
+++ b/tests/test_task_reset_seed_contract.py
@@ -87,7 +87,6 @@ KNOWN_STEP_OVERRIDES = frozenset({
     "simpler_env/_metasim/base.py",
     "simpler_env/_metasim/coke_task.py",
     "simpler_env/_metasim/place_task.py",
-    "task_template.py",
 })
 KNOWN_CLOSE_OVERRIDES = frozenset({
     "robosuite/robosuite_env.py",


### PR DESCRIPTION
The canonical task template (`MinimalTask`) showed an illustrative no-op `step()` override as the way to transform actions — teaching the anti-pattern the contract discourages. Replace it with a `_process_action` example (unnormalise / delta / ee-mapping), the sanctioned action hook.

The template no longer overrides `step`, so it leaves `KNOWN_STEP_OVERRIDES` (20→19) and new tasks copied from it model the unified contract. No real task behavior (template only). 7/7 guardrail checks pass; ruff clean. Part of #792.