### PR TITLE
fix(managers): ManagerBasedRVEnv.reset accepts seed (honor env.reset(seed=) contract)

### DIFF
--- a/roboverse_learn/managers/manager_based_rv_env.py
+++ b/roboverse_learn/managers/manager_based_rv_env.py
@@ -336,8 +336,18 @@ class ManagerBasedRVEnv(RLTaskEnv):
     # env api
     # ------------------------------------------------------------------
 
-    def reset(self, env_ids: Sequence[int] | None = None):
-        """Reset selected envs (or all)."""
+    def reset(self, env_ids: Sequence[int] | None = None, seed: int | None = None):
+        """Reset selected envs (or all).
+
+        ``seed`` is forwarded to the handler when supported, honoring the
+        ``env.reset(seed=)`` contract (this base reimplements ``reset`` and does
+        not call ``super().reset``). Without this, ``gym.make(...).reset(seed=)``
+        raised ``TypeError`` for every manager-based (mjlab v2) task.
+        """
+        if seed is not None:
+            set_seed = getattr(self.handler, "set_seed", None)
+            if callable(set_seed):
+                set_seed(seed)
         if env_ids is None:
             env_ids = torch.arange(self.num_envs, dtype=torch.int64, device=self.device)
         elif not isinstance(env_ids, torch.Tensor):


### PR DESCRIPTION
Surfaced by the MuJoCo benchmark: **12 mjlab v2 tasks failed** with `TypeError: ManagerBasedRVEnv.reset() got an unexpected keyword argument 'seed'`. The manager-based RL base (mjlab v2 / Isaac-Lab-style) overrode `reset(self, env_ids=None)` without `seed`, breaking `gym.make(task).reset(seed=)`.

Add `seed=None` + forward to `handler.set_seed` (this base reimplements `reset`, no `super`), matching the seed-contract fix already applied to the other reimplementing bases (humanoid `LeggedRobotTask`, beyondmimic).

**Verified on MuJoCo (8×RTX5090):** `mjlab.cartpole_swingup_v2` / `cartpole_balance_v2` / `velocity_flat_g1_v2` now load + `reset(seed=0)` + run a rollout (previously `TypeError`). Part of #792. **Pending clean-context review.**