### PR TITLE
test(ci): run lint + the whole tests/ suite in CI; fix native LIBERO open/close on mujoco>=3.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,6 @@
 name: Tests
 
-# Runs the whole RoboVerse content suite (tests/) on CPU.
+# Runs lint + the whole RoboVerse content suite (tests/) on CPU.
 #
 # Until this existed, CI ran exactly one test file (see task-contract.yml), so regressions in
 # the other ~50 files went unnoticed. metasim is a declared git dependency, so a CPU job can
@@ -14,10 +14,29 @@ name: Tests
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, develop]
   workflow_dispatch:
 
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  lint:
+    # Same ruff version as .pre-commit-config.yaml so local pre-commit and CI agree.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install "ruff==0.14.5"
+      - name: ruff check
+        run: python -m ruff check --output-format=github .
+      - name: ruff format --check
+        run: python -m ruff format --check .
+
   tests:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -31,6 +50,10 @@ jobs:
       - name: Install RoboVerse (CPU) with test deps
         run: |
           python -m pip install --upgrade pip
+          # CPU torch first: with only --extra-index-url pip may still pick the CUDA wheel from PyPI
+          python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
           python -m pip install -e ".[dev,mujoco]"
       - name: Run test suite
-        run: python -m pytest tests/
+        env:
+          MUJOCO_GL: egl
+        run: python -m pytest tests/ -rs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,5 +55,8 @@ jobs:
           python -m pip install -e ".[dev,mujoco]"
       - name: Run test suite
         env:
-          MUJOCO_GL: egl
+          # Hosted runners have no EGL/GLX; with MUJOCO_GL=egl `import mujoco` itself fails
+          # (eglQueryString on a None library). `disable` skips GL context creation entirely;
+          # nothing in tests/ renders on MuJoCo, and the suite is identical locally with this value.
+          MUJOCO_GL: disable
         run: python -m pytest tests/ -rs

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+# Runs the whole RoboVerse content suite (tests/) on CPU.
+#
+# Until this existed, CI ran exactly one test file (see task-contract.yml), so regressions in
+# the other ~50 files went unnoticed. metasim is a declared git dependency, so a CPU job can
+# install the real thing and exercise the backend-free tasks/robots/learning code for real.
+#
+# GPU simulators (isaacgym/isaacsim/newton), the heavier optional extras (learn/examples/vla)
+# and the roboverse_data asset checkout are NOT available on a stock runner. Tests that need
+# them SKIP with a reason naming what is missing (see tests/conftest.py) — they must never be
+# skipped to paper over a real failure.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install RoboVerse (CPU) with test deps
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev,mujoco]"
+      - name: Run test suite
+        run: python -m pytest tests/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,4 +211,6 @@ convention = "google"
 testpaths = ["tests"]
 markers = [
     "general: lightweight test that needs no simulator backend",
+    "requires_optional(*modules, extra=None): skip unless the optional dependencies are installed",
+    "requires_asset(*relpaths): skip unless the roboverse_data assets are present",
 ]

--- a/roboverse_pack/tasks/libero/_native_util.py
+++ b/roboverse_pack/tasks/libero/_native_util.py
@@ -170,7 +170,9 @@ def _artic_qpos(model, data, region: str):
     base = _region_base(region)
     specific, generic = [], []
     for j in range(model.njnt):
-        if model.jnt_type[j] not in (mujoco.mjtJoint.mjJNT_HINGE, mujoco.mjtJoint.mjJNT_SLIDE):
+        # ``jnt_type`` is a numpy int32; membership against the pybind enum members is False on
+        # mujoco >= 3.x, so compare as plain ints (``==`` still works, ``in`` does not).
+        if int(model.jnt_type[j]) not in (int(mujoco.mjtJoint.mjJNT_HINGE), int(mujoco.mjtJoint.mjJNT_SLIDE)):
             continue
         jn = mujoco.mj_id2name(model, mujoco.mjtObj.mjOBJ_JOINT, j) or ""
         q = float(data.qpos[model.jnt_qposadr[j]])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,13 +36,15 @@ _HF_DATA_REPO = "https://huggingface.co/datasets/RoboVerseOrg/roboverse_data"
 
 
 def roboverse_data_root() -> Path:
-    """Return the ``roboverse_data`` asset root: ``$ROBOVERSE_DATA``, else the in-repo default.
+    """Return the ``roboverse_data`` asset root, else the in-repo default.
 
-    Mirrors how the packs themselves resolve assets (see
-    ``roboverse_pack.tasks.simpler_env._native._assets``) minus the HF download step — a test
-    must never trigger a multi-GB fetch as a side effect of being collected.
+    ``$ROBOVERSE_DATA_DIR`` is the canonical override (it is what MetaSim's
+    ``metasim.utils.hf_util`` honours); ``$ROBOVERSE_DATA`` is accepted as a legacy alias
+    (``roboverse_pack.tasks.simpler_env._native._assets``). This mirrors how the packs
+    resolve assets minus the HF download step — a test must never trigger a multi-GB fetch
+    as a side effect of being collected.
     """
-    env_root = os.environ.get("ROBOVERSE_DATA")
+    env_root = os.environ.get("ROBOVERSE_DATA_DIR") or os.environ.get("ROBOVERSE_DATA")
     return Path(env_root) if env_root else REPO_ROOT / "roboverse_data"
 
 
@@ -65,18 +67,6 @@ def missing_modules(names: tuple[str, ...]) -> list[str]:
     return missing
 
 
-def pytest_configure(config: pytest.Config) -> None:
-    """Register the RoboVerse-specific markers (also listed in ``pyproject.toml``)."""
-    config.addinivalue_line(
-        "markers",
-        "requires_optional(*modules, extra=None): skip unless the optional dependencies are installed",
-    )
-    config.addinivalue_line(
-        "markers",
-        "requires_asset(*relpaths): skip unless the roboverse_data assets are present",
-    )
-
-
 def pytest_runtest_setup(item: pytest.Item) -> None:
     """Skip tests whose optional dependencies or ``roboverse_data`` assets are absent."""
     for marker in item.iter_markers(name="requires_optional"):
@@ -91,6 +81,6 @@ def pytest_runtest_setup(item: pytest.Item) -> None:
         if missing:
             pytest.skip(
                 f"roboverse_data asset(s) not fetched: {', '.join(missing)} — "
-                f"looked under {roboverse_data_root()}; point $ROBOVERSE_DATA at a "
+                f"looked under {roboverse_data_root()}; point $ROBOVERSE_DATA_DIR at a "
                 f"roboverse_data checkout or fetch them from {_HF_DATA_REPO}"
             )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,96 @@
+"""Shared pytest configuration for the RoboVerse content test suite.
+
+``tests/`` runs in very different environments: a developer workstation with every optional
+extra installed and a full ``roboverse_data`` checkout, and a CPU-only CI container that
+installs only ``.[dev,mujoco]`` and fetches no assets. Two markers keep that difference
+honest instead of red:
+
+    @pytest.mark.requires_optional("zarr", extra="learn")
+    @pytest.mark.requires_asset("robots/openarm_wuji/openarm_wuji.xml")
+
+Each skips — naming what is missing and how to get it — when an optional dependency or a
+``roboverse_data`` asset is genuinely absent.
+
+The markers are evaluated at test *setup*, so they cover the common case of a test whose
+optional import happens inside the test body. When a test *module* imports an optional
+dependency at module scope, the import blows up at collection before any marker can run —
+use a module-level ``pytest.importorskip("<dep>", reason=...)`` there instead (as
+``test_fusion_pipeline.py`` and the ``mani_skill``/``sapien`` suites do).
+
+These markers are NOT a way to quiet a failing test. A test that fails because the code
+under test is wrong must stay red: skipping it would hide the defect, which is strictly
+worse than a red suite. Only a genuinely absent optional dependency or asset may skip.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_HF_DATA_REPO = "https://huggingface.co/datasets/RoboVerseOrg/roboverse_data"
+
+
+def roboverse_data_root() -> Path:
+    """Return the ``roboverse_data`` asset root: ``$ROBOVERSE_DATA``, else the in-repo default.
+
+    Mirrors how the packs themselves resolve assets (see
+    ``roboverse_pack.tasks.simpler_env._native._assets``) minus the HF download step — a test
+    must never trigger a multi-GB fetch as a side effect of being collected.
+    """
+    env_root = os.environ.get("ROBOVERSE_DATA")
+    return Path(env_root) if env_root else REPO_ROOT / "roboverse_data"
+
+
+def missing_assets(relpaths: tuple[str, ...]) -> list[str]:
+    """Return the subset of ``relpaths`` (relative to the data root) that is not on disk."""
+    root = roboverse_data_root()
+    return [relpath for relpath in relpaths if not (root / relpath).exists()]
+
+
+def missing_modules(names: tuple[str, ...]) -> list[str]:
+    """Return the subset of ``names`` that cannot be imported."""
+    missing = []
+    for name in names:
+        try:
+            found = importlib.util.find_spec(name) is not None
+        except (ImportError, ValueError):
+            found = False
+        if not found:
+            missing.append(name)
+    return missing
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the RoboVerse-specific markers (also listed in ``pyproject.toml``)."""
+    config.addinivalue_line(
+        "markers",
+        "requires_optional(*modules, extra=None): skip unless the optional dependencies are installed",
+    )
+    config.addinivalue_line(
+        "markers",
+        "requires_asset(*relpaths): skip unless the roboverse_data assets are present",
+    )
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Skip tests whose optional dependencies or ``roboverse_data`` assets are absent."""
+    for marker in item.iter_markers(name="requires_optional"):
+        missing = missing_modules(marker.args)
+        if missing:
+            extra = marker.kwargs.get("extra")
+            how = f'python -m pip install -e ".[{extra}]"' if extra else f"python -m pip install {' '.join(missing)}"
+            pytest.skip(f"optional dependency not installed: {', '.join(missing)} — install with: {how}")
+
+    for marker in item.iter_markers(name="requires_asset"):
+        missing = missing_assets(marker.args)
+        if missing:
+            pytest.skip(
+                f"roboverse_data asset(s) not fetched: {', '.join(missing)} — "
+                f"looked under {roboverse_data_root()}; point $ROBOVERSE_DATA at a "
+                f"roboverse_data checkout or fetch them from {_HF_DATA_REPO}"
+            )

--- a/tests/test_docs_split_contract.py
+++ b/tests/test_docs_split_contract.py
@@ -35,7 +35,28 @@ def test_docs_deployment_requirements_avoid_runtime_and_live_preview_packages():
         assert package not in requirements
 
 
-def test_split_site_build_script_assembles_landing_roboverse_and_metasim(tmp_path):
+def test_landing_page_links_into_the_metasim_subsite():
+    """The RoboVerse landing page deep-links into /metasim/, without double-prefixing.
+
+    The landing page is Sphinx-built from ``docs/source/index.md`` (it is no longer a
+    hand-assembled HTML file), so this contract is checked at the source level.
+    """
+    index = (REPO_ROOT / "docs/source/index.md").read_text(encoding="utf-8")
+
+    assert "/metasim/get_started/installation.html" in index
+    assert "/metasim/metasim/" not in index
+    # /roboverse/ is a page *within* the root site, not a separately built subsite.
+    assert (REPO_ROOT / "docs/source/roboverse/index.md").is_file()
+
+
+def test_build_script_puts_roboverse_at_site_root_and_metasim_under_metasim(tmp_path):
+    """Pin the layout ``scripts/docs/build_roboverse_wiki.sh`` actually ships.
+
+    RoboVerse docs are built directly at the site root (so roboverse.wiki/ lands on the
+    Sphinx intro) and MetaSim docs at /metasim/. This replaces an older assertion that the
+    script emitted a hand-written landing page plus a separate /roboverse/ subsite — the
+    script stopped doing that, and the test was never updated, so it had been failing.
+    """
     fake_pythonpath = tmp_path / "pythonpath"
     fake_sphinx = fake_pythonpath / "sphinx"
     fake_sphinx.mkdir(parents=True)
@@ -72,12 +93,14 @@ dst.mkdir(parents=True, exist_ok=True)
         check=True,
     )
 
-    assert (output_dir / "index.html").is_file()
-    landing = (output_dir / "index.html").read_text(encoding="utf-8")
-    assert 'href="/metasim/get_started/installation.html"' in landing
-    assert "/metasim/metasim/" not in landing
-    assert (output_dir / "roboverse/index.html").read_text(encoding="utf-8").endswith("docs/source</html>\n")
-    assert (output_dir / "metasim/index.html").read_text(encoding="utf-8").endswith("MetaSim/docs/source</html>\n")
+    # The fake sphinx above records which source tree it was asked to build, so each built
+    # site can be identified by the source dir it names.
+    root_site = (output_dir / "index.html").read_text(encoding="utf-8")
+    assert root_site.endswith(f"{REPO_ROOT / 'docs/source'}</html>\n")
+
+    metasim_site = (output_dir / "metasim/index.html").read_text(encoding="utf-8")
+    assert metasim_site.endswith("MetaSim/docs/source</html>\n")
+
     assert (output_dir / "metasim/_images/tea.jpg").read_bytes() == b"fake image"
     assert (output_dir / ".nojekyll").is_file()
     assert (output_dir / "CNAME").read_text(encoding="utf-8") == "roboverse.wiki\n"

--- a/tests/test_fusion_pipeline.py
+++ b/tests/test_fusion_pipeline.py
@@ -8,6 +8,14 @@ from __future__ import annotations
 
 import pytest
 
+# The orchestrator parses its CLI with tyro at module scope. This has to be an
+# importorskip rather than a `requires_optional` marker: the import below happens at
+# collection time, before any marker would get a chance to skip the test.
+pytest.importorskip(
+    "tyro",
+    reason='optional dependency not installed: tyro — install with: python -m pip install -e ".[examples]"',
+)
+
 from roboverse_learn.fusion.pipeline import Args, build_commands
 
 

--- a/tests/test_il_numba_optional.py
+++ b/tests/test_il_numba_optional.py
@@ -14,6 +14,10 @@ from __future__ import annotations
 import numpy as np
 import pytest
 
+# The modules under test import zarr/numcodecs at module scope (the replay-buffer format),
+# so they need the `learn` extra even though what is being tested here is numba-independence.
+pytestmark = pytest.mark.requires_optional("zarr", "numcodecs", extra="learn")
+
 
 @pytest.mark.general
 def test_dataset_and_sampler_import_without_numba():

--- a/tests/test_libero_base_empty_traj.py
+++ b/tests/test_libero_base_empty_traj.py
@@ -6,16 +6,20 @@ The previous _get_initial_states unconditionally indexed and divided by
 The reset() ordering was also flipped relative to checker init.
 
 These tests stub out get_traj and BaseTaskEnv to test the
-LiberoBaseTask methods in isolation.
+LiberoBaseTask methods in isolation. Because the BaseTaskEnv.reset stubs
+below must mirror core's real signature, ``test_reset_signature_matches_base_task_env``
+pins it — a stub that drifts out of sync stops checking anything.
 """
 
 from __future__ import annotations
 
+import inspect
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 
+from metasim.task.base import BaseTaskEnv
 from roboverse_pack.tasks.libero.libero_base import LiberoBaseTask
 
 
@@ -91,11 +95,27 @@ def test_get_initial_states_truncates_when_more_states_than_envs(monkeypatch):
 
 
 @pytest.mark.general
+def test_reset_signature_matches_base_task_env():
+    """``LiberoBaseTask.reset`` must keep accepting exactly what ``BaseTaskEnv.reset`` does.
+
+    The reset-ordering tests below monkeypatch ``BaseTaskEnv.reset`` with a stub. When core
+    grew a ``seed`` parameter, ``LiberoBaseTask.reset`` was updated to forward it but the
+    stubs were not, so they silently went stale and the ordering guarantee stopped being
+    checked. Pin the signature at the seam so that divergence fails loudly and points here.
+    """
+    base_params = list(inspect.signature(BaseTaskEnv.reset).parameters)
+    assert base_params == ["self", "states", "env_ids", "seed"]
+    assert list(inspect.signature(LiberoBaseTask.reset).parameters) == base_params
+
+
+@pytest.mark.general
 def test_reset_calls_checker_reset_before_super(monkeypatch):
     """checker.reset must run before super().reset so the latter's
-    callbacks see fresh checker state."""
+    callbacks see fresh checker state, and reset() must forward every
+    argument (including ``seed``) on to super()."""
     task = _instance_without_init(num_envs=1)
     order = []
+    forwarded = {}
 
     def _checker_reset(*a, **k):
         order.append("checker")
@@ -103,18 +123,19 @@ def test_reset_calls_checker_reset_before_super(monkeypatch):
     task.checker = MagicMock()
     task.checker.reset = _checker_reset
 
-    # Patch super().reset to record ordering.
-    from metasim.task.base import BaseTaskEnv
-
-    def _super_reset(self, states=None, env_ids=None):
+    # Patch super().reset to record ordering and the arguments it received.
+    def _super_reset(self, states=None, env_ids=None, seed=None):
         order.append("super")
+        forwarded.update(states=states, env_ids=env_ids, seed=seed)
         return "sentinel"
 
     monkeypatch.setattr(BaseTaskEnv, "reset", _super_reset)
 
-    result = task.reset(env_ids=[0])
+    result = task.reset(env_ids=[0], seed=7)
     assert result == "sentinel"
     assert order == ["checker", "super"]
+    # seed must reach BaseTaskEnv.reset, or the env.reset(seed=) contract dies here.
+    assert forwarded == {"states": None, "env_ids": [0], "seed": 7}
 
 
 @pytest.mark.general
@@ -124,8 +145,6 @@ def test_reset_tolerates_missing_checker(monkeypatch):
     task = _instance_without_init(num_envs=1)
     task.checker = None
 
-    from metasim.task.base import BaseTaskEnv
-
-    monkeypatch.setattr(BaseTaskEnv, "reset", lambda self, states=None, env_ids=None: "ok")
+    monkeypatch.setattr(BaseTaskEnv, "reset", lambda self, states=None, env_ids=None, seed=None: "ok")
 
     assert task.reset(env_ids=[0]) == "ok"

--- a/tests/test_multiagent_converters.py
+++ b/tests/test_multiagent_converters.py
@@ -22,6 +22,12 @@ import pytest
 
 _GET_STARTED = Path(__file__).resolve().parents[1] / "get_started"
 
+# The get_started examples are runnable scripts: they import the example-runner deps
+# (rootutils/tyro/rich) at module scope, and example 9 also needs h5py to read the demo.
+# Loading one therefore needs those extras, even though the converter logic under test is pure.
+requires_example_deps = pytest.mark.requires_optional("rootutils", "tyro", "rich", extra="examples")
+requires_h5py = pytest.mark.requires_optional("h5py", extra="learn")
+
 
 def _load_example(filename: str):
     """Import a ``get_started/NN_*.py`` example module by file path.
@@ -50,7 +56,8 @@ def _write_fake_ms_demo(path: Path, ex9, n_frames: int = 4) -> dict:
     The articulation row layout mirrors ManiSkill's
     ``hstack([pose.p(3), pose.q(4), lin_vel(3), ang_vel(3), qpos(9), qvel(9)])``.
     """
-    h5py = pytest.importorskip("h5py")
+    import h5py
+
     n_dof = len(ex9.PANDA_JOINTS)
     width = 13 + 2 * n_dof  # 31 for a 9-DOF panda
     qpos_by_agent = {}
@@ -78,6 +85,8 @@ def _write_fake_ms_demo(path: Path, ex9, n_frames: int = 4) -> dict:
 
 
 @pytest.mark.general
+@requires_example_deps
+@requires_h5py
 def test_convert_demo_to_v2_is_name_keyed_with_shared_objects(tmp_path):
     """convert_demo_to_v2 yields one entry per agent, shared objects, right qpos."""
     ex9 = _load_example("9_maniskill_two_robot_stack_cube.py")
@@ -120,9 +129,12 @@ def test_convert_demo_to_v2_is_name_keyed_with_shared_objects(tmp_path):
 
 
 @pytest.mark.general
+@requires_example_deps
+@requires_h5py
 def test_validate_schema_rejects_narrow_articulation(tmp_path):
     """A too-narrow articulation row must raise, not silently mis-slice qpos."""
-    h5py = pytest.importorskip("h5py")
+    import h5py
+
     ex9 = _load_example("9_maniskill_two_robot_stack_cube.py")
     bad = tmp_path / "bad.h5"
     with h5py.File(bad, "w") as f:
@@ -140,9 +152,12 @@ def test_validate_schema_rejects_narrow_articulation(tmp_path):
 
 
 @pytest.mark.general
+@requires_example_deps
+@requires_h5py
 def test_validate_schema_rejects_missing_agent_key(tmp_path):
     """A missing expected articulation key must raise a clear KeyError."""
-    h5py = pytest.importorskip("h5py")
+    import h5py
+
     ex9 = _load_example("9_maniskill_two_robot_stack_cube.py")
     bad = tmp_path / "bad.h5"
     n_dof = len(ex9.PANDA_JOINTS)
@@ -270,6 +285,7 @@ def test_bridge_to_v2_roundtrip_and_off_by_one(tmp_path):
 
 
 @pytest.mark.general
+@requires_example_deps
 def test_example10_imports_shared_converter():
     """Example 10 must consume the shared converter, not re-define its own."""
     ex10 = _load_example("10_robotwin_aloha_replay.py")

--- a/tests/test_openarm_wuji_mount.py
+++ b/tests/test_openarm_wuji_mount.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import struct
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -8,8 +9,11 @@ from typing import Callable
 import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-OPENARM_ROOT = REPO_ROOT / "roboverse_data" / "robots" / "openarm_wuji"
-ROBOT_DESCRIPTION_ROOT = REPO_ROOT / "roboverse_data" / "robots"
+# Same resolution as tests/conftest.py::roboverse_data_root (ROBOVERSE_DATA_DIR, legacy ROBOVERSE_DATA, in-repo default).
+_DATA_ENV = os.environ.get("ROBOVERSE_DATA_DIR") or os.environ.get("ROBOVERSE_DATA")
+DATA_ROOT = Path(_DATA_ENV) if _DATA_ENV else REPO_ROOT / "roboverse_data"
+OPENARM_ROOT = DATA_ROOT / "robots" / "openarm_wuji"
+ROBOT_DESCRIPTION_ROOT = DATA_ROOT / "robots"
 MJCF_PATH = OPENARM_ROOT / "openarm_wuji.xml"
 URDF_PATH = OPENARM_ROOT / "openarm_wuji.urdf"
 USD_PATH = OPENARM_ROOT / "openarm_wuji.usd"
@@ -131,7 +135,7 @@ def test_openarm_wuji_cfg_defaults_use_renamed_asset_directory() -> None:
     cfg = OpenarmBimanualWujiCfg()
 
     for attr, expected_path in EXPECTED_CFG_PATHS.items():
-        assert (REPO_ROOT / getattr(cfg, attr)).resolve() == expected_path
+        assert (REPO_ROOT / getattr(cfg, attr)).resolve() == expected_path.resolve()
 
 
 @requires_openarm_assets
@@ -142,7 +146,7 @@ def test_openarm_wuji_cfg_asset_files_exist_on_disk() -> None:
     cfg = OpenarmBimanualWujiCfg()
 
     for attr in EXPECTED_CFG_PATHS:
-        assert (REPO_ROOT / getattr(cfg, attr)).resolve().is_file()
+        assert EXPECTED_CFG_PATHS[attr].is_file()
 
 
 @requires_openarm_assets

--- a/tests/test_openarm_wuji_mount.py
+++ b/tests/test_openarm_wuji_mount.py
@@ -21,6 +21,18 @@ MAX_WRIST_PALM_VISUAL_OVERLAP_M = 0.001
 MAX_WRIST_PALM_VISUAL_GAP_M = 0.001
 WUJI_MOUNT_Z_M = 0.105
 
+# The mesh/MJCF/URDF geometry assertions below read real bytes out of roboverse_data, which a
+# fresh checkout (and CI) does not have. They skip there; the cfg-wiring contract does not
+# need the assets and keeps running everywhere.
+requires_openarm_assets = pytest.mark.requires_asset(
+    "robots/openarm_wuji/openarm_wuji.urdf",
+    "robots/openarm_wuji/openarm_wuji.xml",
+    "robots/openarm_wuji/openarm_wuji.usd",
+    "robots/openarm_description/meshes/arm/v10/visual/link7.stl",
+    "robots/wuji_hand_description/meshes/left/left_palm_link.STL",
+    "robots/wuji_hand_description/meshes/right/right_palm_link.STL",
+)
+
 
 def _binary_stl_bounds(path: Path) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
     data = path.read_bytes()
@@ -82,6 +94,7 @@ def _mesh_paths_from_mjcf(path: Path) -> list[Path]:
     return [(path.parent / mesh.attrib["file"]).resolve() for mesh in root.iter("mesh") if mesh.attrib.get("file")]
 
 
+@requires_openarm_assets
 @pytest.mark.parametrize(
     ("asset_file", "mesh_path_reader"),
     (
@@ -99,7 +112,15 @@ def test_openarm_wuji_mesh_paths_resolve_from_robot_descriptions(
     assert all(ROBOT_DESCRIPTION_ROOT in path.parents for path in mesh_paths)
 
 
+EXPECTED_CFG_PATHS = {
+    "urdf_path": OPENARM_ROOT / "openarm_wuji.urdf",
+    "mjcf_path": OPENARM_ROOT / "openarm_wuji.xml",
+    "usd_path": OPENARM_ROOT / "openarm_wuji.usd",
+}
+
+
 def test_openarm_wuji_cfg_defaults_use_renamed_asset_directory() -> None:
+    """The cfg points at the renamed asset dir. Pure source/config wiring — needs no assets."""
     old_module_path = REPO_ROOT / "roboverse_pack" / "robots" / "openarm_bimanual_wuji_cfg.py"
     new_module_path = REPO_ROOT / "roboverse_pack" / "robots" / "openarm_wuji_cfg.py"
     assert not old_module_path.exists()
@@ -109,17 +130,22 @@ def test_openarm_wuji_cfg_defaults_use_renamed_asset_directory() -> None:
 
     cfg = OpenarmBimanualWujiCfg()
 
-    expected_paths = {
-        "urdf_path": OPENARM_ROOT / "openarm_wuji.urdf",
-        "mjcf_path": OPENARM_ROOT / "openarm_wuji.xml",
-        "usd_path": OPENARM_ROOT / "openarm_wuji.usd",
-    }
-    for attr, expected_path in expected_paths.items():
-        actual_path = (REPO_ROOT / getattr(cfg, attr)).resolve()
-        assert actual_path == expected_path
-        assert actual_path.is_file()
+    for attr, expected_path in EXPECTED_CFG_PATHS.items():
+        assert (REPO_ROOT / getattr(cfg, attr)).resolve() == expected_path
 
 
+@requires_openarm_assets
+def test_openarm_wuji_cfg_asset_files_exist_on_disk() -> None:
+    """The paths the cfg points at are real files in a populated roboverse_data checkout."""
+    from roboverse_pack.robots.openarm_wuji_cfg import OpenarmBimanualWujiCfg
+
+    cfg = OpenarmBimanualWujiCfg()
+
+    for attr in EXPECTED_CFG_PATHS:
+        assert (REPO_ROOT / getattr(cfg, attr)).resolve().is_file()
+
+
+@requires_openarm_assets
 @pytest.mark.parametrize(
     ("side", "palm_mesh"),
     (
@@ -156,6 +182,7 @@ def test_openarm_wuji_palm_mount_sits_flush_with_wrist_visual(side: str, palm_me
     assert gap <= MAX_WRIST_PALM_VISUAL_GAP_M
 
 
+@requires_openarm_assets
 def test_openarm_wuji_usd_mount_matches_mjcf_and_urdf() -> None:
     Usd = pytest.importorskip("pxr.Usd")
 

--- a/tests/test_robot_image_dataset_val.py
+++ b/tests/test_robot_image_dataset_val.py
@@ -15,6 +15,10 @@ import numpy as np
 import pytest
 import torch
 
+# SequenceSampler is stubbed below, but importing the dataset module still pulls in
+# zarr/numcodecs at module scope, so the `learn` extra is required to get this far.
+pytestmark = pytest.mark.requires_optional("zarr", "numcodecs", extra="learn")
+
 
 @pytest.mark.general
 def test_validation_dataset_has_independent_buffers(monkeypatch):

--- a/tests/test_simpler_env_native.py
+++ b/tests/test_simpler_env_native.py
@@ -1,8 +1,10 @@
 """Tests for the MetaSim-native (zero-dependency) SimplerEnv registration.
 
-The registration test runs anywhere and must NOT need the cloned ``simpler_env`` /
-``mani_skill2_real2sim`` packages. The make/reset/step smoke test is gated on the migrated
-``roboverse_data`` assets being present (they ship via HF / a roboverse_data checkout).
+The registration test must NOT need the cloned ``simpler_env`` / ``mani_skill2_real2sim``
+packages — only ``ruckig``, which the native EE-delta controller imports (it is a genuine
+runtime dependency of the native port, not of the clone; note it is not declared in any
+pyproject extra today). The make/reset/step smoke test additionally needs sapien and the
+migrated ``roboverse_data`` assets (they ship via HF / a roboverse_data checkout).
 """
 
 from __future__ import annotations
@@ -11,22 +13,14 @@ import importlib.util
 
 import pytest
 
-
-def _assets_present() -> bool:
-    try:
-        from roboverse_pack.tasks.simpler_env._native._assets import data_root
-
-        data_root()
-        return True
-    except Exception:
-        return False
-
-
+# NB: probe the assets with the `requires_asset` marker (a plain on-disk check), NOT with
+# ``_native._assets.data_root()`` — that helper falls back to a multi-GB HuggingFace
+# snapshot_download, which this module used to trigger at *collection* time.
 sapien_available = importlib.util.find_spec("sapien") is not None
-assets_present = _assets_present()
 
 
 @pytest.mark.general
+@pytest.mark.requires_optional("ruckig")
 def test_metasim_registers_all_25_without_clone():
     """All 25 SimplerEnv ids register via the MetaSim-native registry, no cloned packages needed."""
     import gymnasium as gym
@@ -59,7 +53,9 @@ def test_native_env_path_has_zero_upstream_imports():
     assert not offenders, f"native code imports the clone: {offenders}"
 
 
-@pytest.mark.skipif(not (sapien_available and assets_present), reason="sapien / roboverse_data assets absent")
+@pytest.mark.skipif(not sapien_available, reason="sapien not installed")
+@pytest.mark.requires_optional("ruckig")
+@pytest.mark.requires_asset("assets/simpler_env")
 def test_metasim_make_reset_step():
     """Smoke-test the MetaSim-native gym.make + reset + step for one task (zero upstream)."""
     import gymnasium as gym

--- a/tests/test_simpler_env_native.py
+++ b/tests/test_simpler_env_native.py
@@ -1,9 +1,9 @@
 """Tests for the MetaSim-native (zero-dependency) SimplerEnv registration.
 
 The registration test must NOT need the cloned ``simpler_env`` / ``mani_skill2_real2sim``
-packages — only ``ruckig``, which the native EE-delta controller imports (it is a genuine
-runtime dependency of the native port, not of the clone; note it is not declared in any
-pyproject extra today). The make/reset/step smoke test additionally needs sapien and the
+packages — only ``sapien`` (``_metasim/coke_task.py`` imports ``sapien.core`` at module scope)
+and ``ruckig``, which the native EE-delta controller imports (a genuine runtime dependency of
+the native port, not of the clone; note it is not declared in any pyproject extra today). The make/reset/step smoke test additionally needs sapien and the
 migrated ``roboverse_data`` assets (they ship via HF / a roboverse_data checkout).
 """
 
@@ -20,6 +20,7 @@ sapien_available = importlib.util.find_spec("sapien") is not None
 
 
 @pytest.mark.general
+@pytest.mark.skipif(not sapien_available, reason="sapien not installed (coke_task imports sapien.core at module scope)")
 @pytest.mark.requires_optional("ruckig")
 def test_metasim_registers_all_25_without_clone():
     """All 25 SimplerEnv ids register via the MetaSim-native registry, no cloned packages needed."""


### PR DESCRIPTION
## Summary
Until now CI ran exactly one test file (`task-contract.yml`); the other ~50 files in `tests/` never ran and 17 of them failed on `main`. This PR:

- adopts the unmerged `deep-fix/ci-full-test-suite` work (3 cherry-picked commits): `tests/conftest.py` markers `requires_optional(*modules, extra=)` / `requires_asset(*relpaths)` that **skip with a reason** when optional deps or `roboverse_data` assets are absent (never to hide a failure), plus the stale-expectation fixes (docs build layout, `LiberoBaseTask.reset` stubs after the `seed` change);
- adds `.github/workflows/tests.yml`: a `lint` job (ruff 0.14.5, the pre-commit pin) and the whole `tests/` suite on CPU torch for every PR;
- fixes a real bug: native LIBERO `Open`/`Close`/`TurnOn`/`TurnOff` predicates always evaluated False on mujoco ≥ 3.x — `model.jnt_type[j]` is a `numpy.int32` and `in (mjtJoint.mjJNT_HINGE, mjtJoint.mjJNT_SLIDE)` is False for it (`==` works, membership does not). `test_open_close_thresholds_have_a_dead_zone` was failing for exactly this reason and now passes.

Review follow-ups applied: the SimplerEnv registration test also gates on `sapien` (its module imports `sapien.core`), CPU torch is installed before the extras so pip cannot pick a CUDA wheel, `tests/conftest.py` honours `ROBOVERSE_DATA_DIR` (MetaSim's canonical override) before the legacy `ROBOVERSE_DATA`, the openarm mount tests resolve assets from the same root, markers are registered once (pyproject).

## Verification
- `python -m pytest tests/` → 338 passed, 83 skipped (each with a reason), 9 xfailed, 0 failed (was 331 / 17 failed on `main`)
- `ruff check` / `ruff format --check` clean at 0.14.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw
