### PR TITLE
feat(examples): --sim superdex in the tutorials, cross-backend parity harness, multiple_cameras fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,25 @@ release.
 
 ## [Unreleased]
 
-Nothing yet — open a PR to add entries here.
+### Added
+
+- `--sim superdex` in every MuJoCo-capable `get_started` tutorial and a `roboverse-py[superdex]`
+  extra (needs the MetaSim SuperDex backend, Python >= 3.12).
+- `scripts/parity_superdex_tracking.py`: seeded joint-target tracking and rigid-object drop
+  comparisons between two backends (record per backend, compare + plot).
+- CI (`.github/workflows/tests.yml`): ruff lint job + the whole `tests/` suite on CPU for every PR;
+  `tests/conftest.py` markers `requires_optional` / `requires_asset` skip with a reason instead of
+  failing when optional deps or `roboverse_data` assets are absent.
+
+### Fixed
+
+- Native LIBERO `Open`/`Close`/`TurnOn`/`TurnOff` predicates always evaluated False on
+  mujoco >= 3.x (`numpy.int32 in (mjtJoint...)` membership).
+- `get_started/multiple_cameras.py` passed a removed `ScenarioCfg` kwarg.
+- Stale test expectations (docs build layout, `LiberoBaseTask.reset` stubs after the `seed` change).
+- Red flags: SSH submodule URL, dangling `release/metasim` symlink, silent `except: pass` around
+  passthrough registration, hard-coded personal paths in scripts/tests, untruthful
+  `requires-python >= 3.8` (now 3.10), wheels missing LIBERO json/npz bundles, stale ruff ignores.
 
 ## [1.0.0-beta] - 2026-05-31
 

--- a/get_started/0_static_scene.py
+++ b/get_started/0_static_scene.py
@@ -53,6 +53,7 @@ if __name__ == "__main__":
             "mujoco",
             "mjx",
             "newton",
+            "superdex",
         ] = "mujoco"
 
         ## Others

--- a/get_started/10_mount_camera.py
+++ b/get_started/10_mount_camera.py
@@ -50,6 +50,7 @@ class Args:
         "sapien2",
         "sapien3",
         "mujoco",
+        "superdex",
         "mjx",
     ] = "isaacsim"
 

--- a/get_started/13_get_exras.py
+++ b/get_started/13_get_exras.py
@@ -49,6 +49,7 @@ class Args:
         "sapien2",
         "sapien3",
         "mujoco",
+        "superdex",
         "mjx",
     ] = "mujoco"
 

--- a/get_started/14_real_assets.py
+++ b/get_started/14_real_assets.py
@@ -42,6 +42,7 @@ class RealAssetCfg:
         "pybullet",
         "sapien3",
         "mujoco",
+        "superdex",
     ] = "isaacsim"
     num_envs: int = 1
     headless: bool = True

--- a/get_started/15_gs_background.py
+++ b/get_started/15_gs_background.py
@@ -68,6 +68,7 @@ class RealAssetCfg:
         "pybullet",
         "sapien3",
         "mujoco",
+        "superdex",
     ] = "isaacsim"
     num_envs: int = 1  # only support single env for now
     assert num_envs == 1, "Only support single env for now"

--- a/get_started/16_embodiedgen_layout.py
+++ b/get_started/16_embodiedgen_layout.py
@@ -44,6 +44,7 @@ class LayoutInitCfg:
         "pybullet",
         "sapien3",
         "mujoco",
+        "superdex",
     ] = "isaacsim"
     num_envs: int = 1
     headless: bool = True

--- a/get_started/1_control_robot.py
+++ b/get_started/1_control_robot.py
@@ -52,6 +52,7 @@ if __name__ == "__main__":
             "sapien3",
             "mujoco",
             "newton",
+            "superdex",
         ] = "mujoco"
 
         ## Others

--- a/get_started/2_add_new_robot.py
+++ b/get_started/2_add_new_robot.py
@@ -51,6 +51,7 @@ if __name__ == "__main__":
             "mujoco",
             "mjx",
             "newton",
+            "superdex",
         ] = "mujoco"
 
         ## Others

--- a/get_started/3_parallel_envs.py
+++ b/get_started/3_parallel_envs.py
@@ -48,6 +48,7 @@ if __name__ == "__main__":
             "sapien2",
             "sapien3",
             "newton",
+            "superdex",
         ] = "mujoco"
 
         ## Others

--- a/get_started/4_motion_planning.py
+++ b/get_started/4_motion_planning.py
@@ -61,6 +61,7 @@ if __name__ == "__main__":
             "sapien2",
             "sapien3",
             "mujoco",
+            "superdex",
             "mjx",
         ] = "mujoco"
 

--- a/get_started/5_hybrid_sim.py
+++ b/get_started/5_hybrid_sim.py
@@ -44,7 +44,9 @@ if __name__ == "__main__":
         robot: str = "franka"
 
         ## Handlers
-        sim: Literal["isaacsim", "isaacgym", "genesis", "pybullet", "sapien2", "sapien3", "mujoco", "superdex"] = "mujoco"
+        sim: Literal["isaacsim", "isaacgym", "genesis", "pybullet", "sapien2", "sapien3", "mujoco", "superdex"] = (
+            "mujoco"
+        )
         renderer: (
             Literal[
                 "isaacsim",

--- a/get_started/5_hybrid_sim.py
+++ b/get_started/5_hybrid_sim.py
@@ -44,7 +44,7 @@ if __name__ == "__main__":
         robot: str = "franka"
 
         ## Handlers
-        sim: Literal["isaacsim", "isaacgym", "genesis", "pybullet", "sapien2", "sapien3", "mujoco"] = "mujoco"
+        sim: Literal["isaacsim", "isaacgym", "genesis", "pybullet", "sapien2", "sapien3", "mujoco", "superdex"] = "mujoco"
         renderer: (
             Literal[
                 "isaacsim",
@@ -54,6 +54,7 @@ if __name__ == "__main__":
                 "sapien2",
                 "sapien3",
                 "mujoco",
+                "superdex",
                 "blender",
             ]
             | None

--- a/get_started/9_cfg_task.py
+++ b/get_started/9_cfg_task.py
@@ -44,6 +44,7 @@ class Args:
         "sapien2",
         "sapien3",
         "mujoco",
+        "superdex",
         "mjx",
     ] = "mujoco"
 

--- a/get_started/multiple_cameras.py
+++ b/get_started/multiple_cameras.py
@@ -43,10 +43,10 @@ class Args:
     robot: str = "franka"
 
     ## Handlers
-    sim: Literal["isaaclab", "isaacgym", "genesis", "pybullet", "sapien2", "sapien3", "mujoco"] = "mujoco"
+    sim: Literal["isaacsim", "isaacgym", "genesis", "pybullet", "sapien2", "sapien3", "mujoco", "superdex"] = "mujoco"
 
     ## Others
-    num_handlers: int = 1
+    num_envs: int = 1
     headless: bool = False
 
     def __post_init__(self):
@@ -61,7 +61,7 @@ scenario = ScenarioCfg(
     robots=[args.robot],
     simulator=args.sim,
     headless=args.headless,
-    num_handlers=args.num_handlers,
+    num_envs=args.num_envs,
 )
 
 # add cameras

--- a/get_started/rerun/replay_task_demo.py
+++ b/get_started/rerun/replay_task_demo.py
@@ -67,6 +67,7 @@ class Args:
         "sapien2",
         "sapien3",
         "mujoco",
+        "superdex",
     ] = "mujoco"
     """Simulator backend."""
 

--- a/get_started/rerun/rerun_demo.py
+++ b/get_started/rerun/rerun_demo.py
@@ -67,6 +67,7 @@ class Args:
         "sapien2",
         "sapien3",
         "mujoco",
+        "superdex",
     ] = "mujoco"
     """Simulator backend to use."""
 

--- a/get_started/rerun/save_trajectory.py
+++ b/get_started/rerun/save_trajectory.py
@@ -60,6 +60,7 @@ class Args:
         "sapien2",
         "sapien3",
         "mujoco",
+        "superdex",
     ] = "mujoco"
     """Simulator backend."""
 

--- a/get_started/rerun/save_trajectory_simple.py
+++ b/get_started/rerun/save_trajectory_simple.py
@@ -59,6 +59,7 @@ class Args:
         "sapien2",
         "sapien3",
         "mujoco",
+        "superdex",
     ] = "mujoco"
     """Simulator backend."""
 

--- a/get_started/rl/0_ppo.py
+++ b/get_started/rl/0_ppo.py
@@ -36,7 +36,7 @@ class Args:
     task: str = "reach_origin"
     robot: str = "franka"
     num_envs: int = 128
-    sim: Literal["isaacsim", "isaaclab", "isaacgym", "mujoco", "genesis", "mjx"] = "isaacsim"
+    sim: Literal["isaacsim", "isaaclab", "isaacgym", "mujoco", "genesis", "mjx", "superdex"] = "isaacsim"
     headless: bool = True
     enable_viser: bool = True  # Enable real-time 3D visualization with Viser
     enable_rerun: bool = True  # Enable real-time 3D visualization with Rerun

--- a/get_started/viser/viser_demo.py
+++ b/get_started/viser/viser_demo.py
@@ -65,6 +65,7 @@ class Args:
         "sapien2",
         "sapien3",
         "mujoco",
+        "superdex",
     ] = "mujoco"
     """Simulator backend to use."""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ isaacsim211 = ["metasim[isaacsim211] @ git+https://github.com/RoboVerseOrg/MetaS
 mjx = ["metasim[mjx] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
 mujoco = ["metasim[mujoco] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
 newton = ["metasim[newton] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+superdex = ["metasim[superdex] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]  # Python 3.12 only
 pybullet = ["metasim[pybullet] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
 robosplatter = ["metasim[robosplatter] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
 sapien2 = ["metasim[sapien2] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]

--- a/scripts/parity_superdex_tracking.py
+++ b/scripts/parity_superdex_tracking.py
@@ -42,7 +42,7 @@ def _scenario(sim: str):
     )
 
 
-def record(sim: str, out: str, steps: int, seed: int, hold: int) -> None:
+def record(*, sim: str, out: str, steps: int, seed: int, hold: int) -> None:
     from metasim.utils.setup_util import get_handler
 
     scenario = _scenario(sim)
@@ -79,31 +79,54 @@ def record(sim: str, out: str, steps: int, seed: int, hold: int) -> None:
         measured.append([float(state[jn]) for jn in joint_names])
     handler.close()
 
+    out = out if out.endswith(".npz") else out + ".npz"  # np.savez appends the suffix itself
     os.makedirs(os.path.dirname(os.path.abspath(out)), exist_ok=True)
     np.savez(out, sim=sim, joint_names=np.array(joint_names), targets=np.array(targets), measured=np.array(measured))
-    err = np.abs(np.array(measured) - np.array(targets))
-    print(f"[{sim}] {steps} steps, hold={hold}: mean|err|={err.mean():.4f} rad, max|err|={err.max():.4f} rad -> {out}")
+    print(
+        f"[{sim}] {steps} steps, hold={hold}: {_summary(joint_names, np.array(measured), np.array(targets))} -> {out}"
+    )
 
 
-def compare(a_path: str, b_path: str, plot: str | None) -> None:
+def _summary(names: list[str], measured: np.ndarray, targets: np.ndarray) -> str:
+    """Per-unit tracking error summary: revolute/arm joints (rad) and prismatic/finger joints (m) never mixed."""
+    err = np.abs(measured - targets)
+    arm = [j for j, n in enumerate(names) if "finger" not in n]
+    fingers = [j for j, n in enumerate(names) if "finger" in n]
+    parts = []
+    if arm:
+        parts.append(f"arm mean|err|={err[:, arm].mean():.4f} rad, max={err[:, arm].max():.4f} rad")
+    if fingers:
+        parts.append(
+            f"finger mean|err|={err[:, fingers].mean() * 1000:.2f} mm, max={err[:, fingers].max() * 1000:.2f} mm"
+        )
+    return "; ".join(parts)
+
+
+def compare(a_path: str, b_path: str, *, plot: str | None = None) -> None:
     a, b = np.load(a_path), np.load(b_path)
-    assert list(a["joint_names"]) == list(b["joint_names"]), "joint order differs"
-    assert np.allclose(a["targets"], b["targets"]), "target sequences differ (different seed/hold?)"
     names = list(a["joint_names"])
+    if names != list(b["joint_names"]):
+        raise ValueError(f"joint order differs: {names} vs {list(b['joint_names'])}")
+    if a["targets"].shape != b["targets"].shape or not np.allclose(a["targets"], b["targets"]):
+        raise ValueError("target sequences differ: record both backends with the same --seed/--hold/--steps")
     for rec in (a, b):
-        err = np.abs(rec["measured"] - rec["targets"])
-        print(f"[{rec['sim']}] mean|q - q_target| = {err.mean():.4f} rad, max = {err.max():.4f} rad")
+        print(f"[{rec['sim']}] {_summary(names, rec['measured'], rec['targets'])}")
     diff = np.abs(a["measured"] - b["measured"])
-    print(f"[{a['sim']} vs {b['sim']}] mean|Δq| = {diff.mean():.4f} rad, max = {diff.max():.4f} rad")
+    print(f"[{a['sim']} vs {b['sim']}] {_summary(names, a['measured'], b['measured']).replace('err', 'Δq')}")
     for j, jn in enumerate(names):
-        print(f"  {jn:>20}: mean|Δq| = {diff[:, j].mean():.4f}  max = {diff[:, j].max():.4f}")
+        unit = "m" if "finger" in jn else "rad"
+        print(f"  {jn:>20}: mean|Δq| = {diff[:, j].mean():.4f} {unit}  max = {diff[:, j].max():.4f} {unit}")
     if plot:
         import matplotlib
 
         matplotlib.use("Agg")
         import matplotlib.pyplot as plt
 
-        fig, axes = plt.subplots(3, 3, figsize=(13, 9), sharex=True)
+        cols = 3
+        rows = -(-len(names) // cols)
+        fig, axes = plt.subplots(rows, cols, figsize=(13, 3 * rows), sharex=True, squeeze=False)
+        for ax in axes.ravel()[len(names) :]:
+            ax.set_visible(False)
         t = np.arange(len(a["targets"]))
         for j, (ax, jn) in enumerate(zip(axes.ravel(), names)):
             ax.plot(t, a["targets"][:, j], "k--", lw=1, label="target")
@@ -135,9 +158,9 @@ def main() -> None:
     cmp_.add_argument("--plot", default=None)
     args = parser.parse_args()
     if args.cmd == "record":
-        record(args.sim, args.out, args.steps, args.seed, args.hold)
+        record(sim=args.sim, out=args.out, steps=args.steps, seed=args.seed, hold=args.hold)
     else:
-        compare(args.a, args.b, args.plot)
+        compare(args.a, args.b, plot=args.plot)
 
 
 if __name__ == "__main__":

--- a/scripts/parity_superdex_tracking.py
+++ b/scripts/parity_superdex_tracking.py
@@ -12,6 +12,11 @@ its own environment and the two recordings are compared afterwards::
 ``compare`` prints, per backend, the mean / max absolute tracking error |q - q_target| over the run
 and the mean absolute difference between the two backends' joint trajectories. It does not claim
 parity: it measures it (see AGENTS.md, "Parity Is Load-Bearing").
+
+``record --mode drop`` records rigid-object dynamics instead of robot tracking: the cube, sphere and
+bbq-sauce bottle of the ``0_static_scene`` tutorial are released from the same poses and their root
+positions are logged per env step; ``compare`` then reports the per-object position difference
+(settling height, slide/roll distance) between the two backends.
 """
 
 from __future__ import annotations
@@ -42,10 +47,136 @@ def _scenario(sim: str):
     )
 
 
-def record(*, sim: str, out: str, steps: int, seed: int, hold: int) -> None:
+def _drop_scenario(sim: str):
+    from metasim.constants import PhysicStateType
+    from metasim.scenario.objects import PrimitiveCubeCfg, PrimitiveSphereCfg, RigidObjCfg
+    from metasim.scenario.scenario import ScenarioCfg
+
+    return ScenarioCfg(
+        robots=["franka"],
+        simulator=sim,
+        headless=True,
+        num_envs=1,
+        objects=[
+            PrimitiveCubeCfg(
+                name="cube", size=(0.1, 0.1, 0.1), color=[1.0, 0.0, 0.0], physics=PhysicStateType.RIGIDBODY
+            ),
+            PrimitiveSphereCfg(name="sphere", radius=0.1, color=[0.0, 0.0, 1.0], physics=PhysicStateType.RIGIDBODY),
+            RigidObjCfg(
+                name="bbq_sauce",
+                scale=(2, 2, 2),
+                physics=PhysicStateType.RIGIDBODY,
+                usd_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/bbq_sauce/usd/bbq_sauce.usd",
+                urdf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/bbq_sauce/urdf/bbq_sauce.urdf",
+                mjcf_path="roboverse_data/assets/libero/COMMON/stable_hope_objects/bbq_sauce/mjcf/bbq_sauce.xml",
+            ),
+        ],
+    )
+
+
+_DROP_INIT = {
+    "cube": ([0.3, -0.2, 0.30], [0.9239, 0.0, 0.3827, 0.0]),  # tilted 45 deg about y: lands on an edge, tips over
+    "sphere": ([0.4, -0.6, 0.40], [1.0, 0.0, 0.0, 0.0]),
+    "bbq_sauce": ([0.7, -0.3, 0.35], [0.7071, 0.7071, 0.0, 0.0]),  # lying on its side: rolls
+}
+
+
+def record_drop(*, sim: str, out: str, steps: int) -> None:
+    """Release the three tutorial objects from fixed poses and log their root positions per env step."""
+    from metasim.utils.setup_util import get_handler
+
+    scenario = _drop_scenario(sim)
+    handler = get_handler(scenario)
+    robot = scenario.robots[0]
+    init = {
+        "objects": {name: {"pos": torch.tensor(p), "rot": torch.tensor(q)} for name, (p, q) in _DROP_INIT.items()},
+        "robots": {
+            robot.name: {
+                "pos": torch.tensor([0.0, 0.0, 0.0]),
+                "rot": torch.tensor([1.0, 0.0, 0.0, 0.0]),
+                "dof_pos": dict(robot.default_joint_positions),
+            }
+        },
+    }
+    handler.set_states([init])
+    names = list(_DROP_INIT)
+    traj = []
+    for _ in range(steps):
+        handler.simulate()
+        objs = handler.get_states(mode="dict")[0]["objects"]
+        traj.append([np.asarray(objs[n]["pos"], dtype=np.float64) for n in names])
+    handler.close()
+    out = out if out.endswith(".npz") else out + ".npz"
+    os.makedirs(os.path.dirname(os.path.abspath(out)), exist_ok=True)
+    np.savez(out, sim=sim, mode="drop", object_names=np.array(names), positions=np.array(traj))
+    final = np.array(traj)[-1]
+    print(
+        f"[{sim}] drop {steps} steps: final z "
+        + ", ".join(f"{n}={final[i][2]:.4f}" for i, n in enumerate(names))
+        + f" -> {out}"
+    )
+
+
+def compare_drop(a, b, *, plot: str | None = None) -> None:
+    names = list(a["object_names"])
+    if names != list(b["object_names"]):
+        raise ValueError(f"object order differs: {names} vs {list(b['object_names'])}")
+    pa, pb = a["positions"], b["positions"]  # (T, n_obj, 3)
+    n = min(len(pa), len(pb))
+    for i, name in enumerate(names):
+        diff = np.linalg.norm(pa[:n, i] - pb[:n, i], axis=1)
+        print(
+            f"  {name:>10}: final pos {a['sim']}={np.round(pa[n - 1, i], 4).tolist()} {b['sim']}={np.round(pb[n - 1, i], 4).tolist()}"
+            f" | mean|Δpos|={diff.mean() * 1000:.1f} mm  max={diff.max() * 1000:.1f} mm  final={diff[-1] * 1000:.1f} mm"
+        )
+    if plot:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, axes = plt.subplots(len(names), 3, figsize=(13, 3 * len(names)), sharex=True, squeeze=False)
+        t = np.arange(n)
+        for i, name in enumerate(names):
+            for k, axis in enumerate("xyz"):
+                ax = axes[i, k]
+                ax.plot(t, pa[:n, i, k], lw=1.4, label=str(a["sim"]))
+                ax.plot(t, pb[:n, i, k], lw=1.4, label=str(b["sim"]))
+                ax.set_title(f"{name} {axis} [m]", fontsize=9)
+                ax.grid(alpha=0.3)
+        axes[0, 0].legend(fontsize=8)
+        fig.suptitle(f"Rigid-object drop dynamics: {a['sim']} vs {b['sim']}")
+        fig.supxlabel("env step")
+        fig.tight_layout()
+        fig.savefig(plot, dpi=110)
+        print(f"plot -> {plot}")
+
+
+def _apply_effort_limit(scenario, effort_limit: float | None) -> None:
+    """Give every arm actuator the same explicit ``effort_limit_sim`` on every backend.
+
+    Without it each backend clamps with whatever its asset file says (the Franka MJCF has
+    ``forcerange="-40 40"``, the URDF ``<limit effort="87">``), which is the dominant source of
+    closed-loop divergence — exactly what the MuJoCo backend warns about at launch.
+    """
+    if effort_limit is None:
+        return
+    from metasim.utils.setup_util import get_robot
+
+    robot = scenario.robots[0]
+    if isinstance(robot, str):
+        robot = get_robot(robot)
+        scenario.robots = [robot]
+    for name, act in robot.actuators.items():
+        if "finger" not in name:
+            act.effort_limit_sim = float(effort_limit)
+
+
+def record(*, sim: str, out: str, steps: int, seed: int, hold: int, effort_limit: float | None = None) -> None:
     from metasim.utils.setup_util import get_handler
 
     scenario = _scenario(sim)
+    _apply_effort_limit(scenario, effort_limit)
     handler = get_handler(scenario)
     robot = scenario.robots[0]
     joint_names = handler.get_joint_names(robot.name, sort=True)
@@ -104,6 +235,11 @@ def _summary(names: list[str], measured: np.ndarray, targets: np.ndarray) -> str
 
 def compare(a_path: str, b_path: str, *, plot: str | None = None) -> None:
     a, b = np.load(a_path), np.load(b_path)
+    if "positions" in a.files:
+        if "positions" not in b.files:
+            raise ValueError("cannot compare a drop recording with a tracking recording")
+        compare_drop(a, b, plot=plot)
+        return
     names = list(a["joint_names"])
     if names != list(b["joint_names"]):
         raise ValueError(f"joint order differs: {names} vs {list(b['joint_names'])}")
@@ -152,13 +288,24 @@ def main() -> None:
     rec.add_argument("--steps", type=int, default=120)
     rec.add_argument("--hold", type=int, default=20, help="env steps per random target")
     rec.add_argument("--seed", type=int, default=0)
+    rec.add_argument("--mode", choices=("tracking", "drop"), default="tracking")
+    rec.add_argument(
+        "--effort-limit",
+        type=float,
+        default=None,
+        help="explicit effort_limit_sim [N m] for every arm actuator on this backend (see _apply_effort_limit)",
+    )
     cmp_ = sub.add_parser("compare")
     cmp_.add_argument("a")
     cmp_.add_argument("b")
     cmp_.add_argument("--plot", default=None)
     args = parser.parse_args()
-    if args.cmd == "record":
-        record(sim=args.sim, out=args.out, steps=args.steps, seed=args.seed, hold=args.hold)
+    if args.cmd == "record" and args.mode == "drop":
+        record_drop(sim=args.sim, out=args.out, steps=args.steps)
+    elif args.cmd == "record":
+        record(
+            sim=args.sim, out=args.out, steps=args.steps, seed=args.seed, hold=args.hold, effort_limit=args.effort_limit
+        )
     else:
         compare(args.a, args.b, plot=args.plot)
 

--- a/scripts/parity_superdex_tracking.py
+++ b/scripts/parity_superdex_tracking.py
@@ -1,0 +1,144 @@
+"""Cross-sim joint-target tracking parity: SuperDex vs MuJoCo (or any two backends).
+
+Runs the ``get_started/1_control_robot.py`` scene with a *seeded* random joint-target sequence on one
+backend and records, per env step, the commanded targets and the measured joint positions. Because
+SuperDex ships Python 3.12-only wheels while the MuJoCo env here is 3.11, each backend is recorded in
+its own environment and the two recordings are compared afterwards::
+
+    python scripts/parity_superdex_tracking.py record --sim mujoco   --out /tmp/parity/mujoco.npz
+    python scripts/parity_superdex_tracking.py record --sim superdex --out /tmp/parity/superdex.npz
+    python scripts/parity_superdex_tracking.py compare /tmp/parity/mujoco.npz /tmp/parity/superdex.npz --plot /tmp/parity/tracking.png
+
+``compare`` prints, per backend, the mean / max absolute tracking error |q - q_target| over the run
+and the mean absolute difference between the two backends' joint trajectories. It does not claim
+parity: it measures it (see AGENTS.md, "Parity Is Load-Bearing").
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+import numpy as np
+import torch
+
+
+def _scenario(sim: str):
+    from metasim.constants import PhysicStateType
+    from metasim.scenario.objects import PrimitiveCubeCfg, PrimitiveSphereCfg
+    from metasim.scenario.scenario import ScenarioCfg
+
+    return ScenarioCfg(
+        robots=["franka"],
+        simulator=sim,
+        headless=True,
+        num_envs=1,
+        objects=[
+            PrimitiveCubeCfg(
+                name="cube", size=(0.1, 0.1, 0.1), color=[1.0, 0.0, 0.0], physics=PhysicStateType.RIGIDBODY
+            ),
+            PrimitiveSphereCfg(name="sphere", radius=0.1, color=[0.0, 0.0, 1.0], physics=PhysicStateType.RIGIDBODY),
+        ],
+    )
+
+
+def record(sim: str, out: str, steps: int, seed: int, hold: int) -> None:
+    from metasim.utils.setup_util import get_handler
+
+    scenario = _scenario(sim)
+    handler = get_handler(scenario)
+    robot = scenario.robots[0]
+    joint_names = handler.get_joint_names(robot.name, sort=True)
+    rng = np.random.default_rng(seed)
+    init = {
+        "objects": {
+            "cube": {"pos": torch.tensor([0.3, -0.2, 0.05]), "rot": torch.tensor([1.0, 0.0, 0.0, 0.0])},
+            "sphere": {"pos": torch.tensor([0.4, -0.6, 0.05]), "rot": torch.tensor([1.0, 0.0, 0.0, 0.0])},
+        },
+        "robots": {
+            robot.name: {
+                "pos": torch.tensor([0.0, 0.0, 0.0]),
+                "rot": torch.tensor([1.0, 0.0, 0.0, 0.0]),
+                "dof_pos": dict(robot.default_joint_positions),
+            }
+        },
+    }
+    handler.set_states([init])
+
+    targets, measured = [], []
+    target = None
+    for step in range(steps):
+        if step % hold == 0:  # new random target every ``hold`` env steps, same sequence on every backend
+            target = {
+                jn: float(rng.uniform(robot.joint_limits[jn][0], robot.joint_limits[jn][1])) for jn in joint_names
+            }
+        handler.set_dof_targets([{robot.name: {"dof_pos_target": target}}])
+        handler.simulate()
+        state = handler.get_states(mode="dict")[0]["robots"][robot.name]["dof_pos"]
+        targets.append([target[jn] for jn in joint_names])
+        measured.append([float(state[jn]) for jn in joint_names])
+    handler.close()
+
+    os.makedirs(os.path.dirname(os.path.abspath(out)), exist_ok=True)
+    np.savez(out, sim=sim, joint_names=np.array(joint_names), targets=np.array(targets), measured=np.array(measured))
+    err = np.abs(np.array(measured) - np.array(targets))
+    print(f"[{sim}] {steps} steps, hold={hold}: mean|err|={err.mean():.4f} rad, max|err|={err.max():.4f} rad -> {out}")
+
+
+def compare(a_path: str, b_path: str, plot: str | None) -> None:
+    a, b = np.load(a_path), np.load(b_path)
+    assert list(a["joint_names"]) == list(b["joint_names"]), "joint order differs"
+    assert np.allclose(a["targets"], b["targets"]), "target sequences differ (different seed/hold?)"
+    names = list(a["joint_names"])
+    for rec in (a, b):
+        err = np.abs(rec["measured"] - rec["targets"])
+        print(f"[{rec['sim']}] mean|q - q_target| = {err.mean():.4f} rad, max = {err.max():.4f} rad")
+    diff = np.abs(a["measured"] - b["measured"])
+    print(f"[{a['sim']} vs {b['sim']}] mean|Δq| = {diff.mean():.4f} rad, max = {diff.max():.4f} rad")
+    for j, jn in enumerate(names):
+        print(f"  {jn:>20}: mean|Δq| = {diff[:, j].mean():.4f}  max = {diff[:, j].max():.4f}")
+    if plot:
+        import matplotlib
+
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+
+        fig, axes = plt.subplots(3, 3, figsize=(13, 9), sharex=True)
+        t = np.arange(len(a["targets"]))
+        for j, (ax, jn) in enumerate(zip(axes.ravel(), names)):
+            ax.plot(t, a["targets"][:, j], "k--", lw=1, label="target")
+            ax.plot(t, a["measured"][:, j], lw=1.4, label=str(a["sim"]))
+            ax.plot(t, b["measured"][:, j], lw=1.4, label=str(b["sim"]))
+            ax.set_title(jn, fontsize=9)
+            ax.grid(alpha=0.3)
+        axes[0, 0].legend(fontsize=8)
+        fig.suptitle(f"Joint-target tracking, seeded random targets: {a['sim']} vs {b['sim']}")
+        fig.supxlabel("env step")
+        fig.supylabel("joint position [rad / m]")
+        fig.tight_layout()
+        fig.savefig(plot, dpi=110)
+        print(f"plot -> {plot}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    rec = sub.add_parser("record")
+    rec.add_argument("--sim", required=True)
+    rec.add_argument("--out", required=True)
+    rec.add_argument("--steps", type=int, default=120)
+    rec.add_argument("--hold", type=int, default=20, help="env steps per random target")
+    rec.add_argument("--seed", type=int, default=0)
+    cmp_ = sub.add_parser("compare")
+    cmp_.add_argument("a")
+    cmp_.add_argument("b")
+    cmp_.add_argument("--plot", default=None)
+    args = parser.parse_args()
+    if args.cmd == "record":
+        record(args.sim, args.out, args.steps, args.seed, args.hold)
+    else:
+        compare(args.a, args.b, args.plot)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
Companion to MetaSim's SuperDex backend PR RoboVerseOrg/MetaSim#29 (merge that first; this PR's `roboverse-py[superdex]` extra forwards to `metasim[superdex]`).

- `--sim superdex` in every MuJoCo-capable `get_started` tutorial (content needs no change: robots/objects already carry `urdf_path`).
- `scripts/parity_superdex_tracking.py`: seeded joint-target tracking (`record --sim … / compare … --plot`, optional `--effort-limit`) and rigid-object drop (`--mode drop`) comparisons between two backends; recordings are `.npz` so the two Python environments (SuperDex is 3.12-only) can be compared afterwards.
- `get_started/multiple_cameras.py` passed a removed `ScenarioCfg` kwarg (`num_handlers`) and failed on every backend; fixed.

## Measured (Franka, 120 env steps, new random target every 20, seed 0)
| | arm mean \|q − q\*\| | finger mean | cross-backend arm mean \|Δq\| |
|---|---|---|---|
| MuJoCo | 0.85 rad | 5.5 mm | — |
| SuperDex (`pd` mode) | 1.01 rad | 1.5 mm | 0.86 rad |

Rigid-object drop (cube / sphere / bottle): resting positions within 0.7–6 mm; the edge-dropped cube tips differently (40 mm). The remaining tracking gap is the torque-saturated slew regime, where small integrator differences compound; it is measured, not claimed away.

## Verification
- `get_started` 0/1/2/3/7/8/9_cfg_task/10_mount_camera/13/14/multiple_cameras run end to end with `--sim superdex` (py3.12) and `--sim mujoco` (py3.11)
- `python -m pytest tests/` → 338 passed on the combined branch; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw
