### PR TITLE
chore(release): development & release protocol, PR-title/changelog/release workflows, MetaSim dependency rename

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Reviewers auto-requested on PRs. Add people per area as the team grows.
+*                         @geng-haoran
+/roboverse_pack/            @geng-haoran
+/roboverse_learn/           @geng-haoran
+/.github/                 @geng-haoran

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,33 @@
+name: changelog
+
+# Every PR that changes the library must add its line under "## [Unreleased]" in CHANGELOG.md,
+# unless it carries the `no-changelog` label (tests-only, refactors with no user-visible change).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Require a CHANGELOG entry for library changes
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [[ ",$LABELS," == *",no-changelog,"* ]]; then echo "no-changelog label present"; exit 0; fi
+          changed=$(git diff --name-only "$BASE" "$HEAD")
+          if ! grep -qP '^(roboverse_pack|roboverse_learn|scripts|get_started)/' <<<"$changed"; then
+            echo "no library files changed"; exit 0
+          fi
+          if grep -qx 'CHANGELOG.md' <<<"$changed" && git diff "$BASE" "$HEAD" -- CHANGELOG.md | grep -q '^+.*- '; then
+            echo "CHANGELOG entry found"; exit 0
+          fi
+          echo "::error::This PR changes roboverse_pack/, roboverse_learn/, scripts/ or get_started/ but adds no line under '## [Unreleased]' in CHANGELOG.md (or add the no-changelog label)."
+          exit 1

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,31 @@
+name: pr-title
+
+# The squash-merge commit takes the PR title, so the title must be a Conventional Commit.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            test
+            chore
+            ci
+            perf
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: 'Start the summary in lower case, e.g. "fix(mujoco): reserve a 512M arena".'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,79 @@
+name: release
+
+# Tag vX.Y.Z on main -> verify version, build, GitHub Release, PyPI (trusted publishing, when the
+# `pypi` environment exists). See RELEASING.md.
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Tag must equal pyproject version
+        id: ver
+        run: |
+          python -m pip install tomli
+          pv=$(python -c "import tomli; print(tomli.load(open('pyproject.toml','rb'))['project']['version'])")
+          tag="${GITHUB_REF_NAME#v}"
+          if [[ "$pv" != "$tag" ]]; then echo "::error::tag v$tag != pyproject version $pv"; exit 1; fi
+          echo "version=$pv" >> "$GITHUB_OUTPUT"
+      - run: python -m pip install build twine
+      - run: python -m build
+      - run: python -m twine check dist/*
+      - name: Extract this version's CHANGELOG section
+        run: |
+          python - <<'PY'
+          import re, os
+          v = os.environ["VERSION"]; text = open("CHANGELOG.md", encoding="utf-8").read()
+          m = re.search(rf"^## \[{re.escape(v)}\][^\n]*\n(.*?)(?=^## \[|\Z)", text, re.S | re.M)
+          body = m.group(1).strip() if m else f"See CHANGELOG.md for {v}."
+          open("release_notes.md", "w", encoding="utf-8").write(body + "\n")
+          PY
+        env:
+          VERSION: ${{ steps.ver.outputs.version }}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: |
+            dist/*
+            release_notes.md
+
+  github-release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+      - uses: softprops/action-gh-release@v2
+        with:
+          body_path: release_notes.md
+          prerelease: ${{ contains(github.ref_name, 'rc') || contains(github.ref_name, 'a') || contains(github.ref_name, 'b') }}
+          files: dist/*.whl dist/*.tar.gz
+
+  pypi:
+    # Runs only after the `pypi` environment with a trusted publisher exists (RELEASING.md §5);
+    # without it the job fails on the OIDC exchange and the GitHub Release above still stands.
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+      - run: rm -f dist/release_notes.md
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ release.
 
 ## [Unreleased]
 
+### Changed
+
+- MetaSim dependency renamed to `roboverse-metasim @ git+...` (MetaSim's distribution was renamed;
+  import name `metasim` unchanged). The pin moves to a MetaSim tag with the next release.
+
 ### Added
 
 - `--sim superdex` in every MuJoCo-capable `get_started` tutorial and a `roboverse-py[superdex]`
@@ -21,6 +26,8 @@ release.
 - CI (`.github/workflows/tests.yml`): ruff lint job + the whole `tests/` suite on CPU for every PR;
   `tests/conftest.py` markers `requires_optional` / `requires_asset` skip with a reason instead of
   failing when optional deps or `roboverse_data` assets are absent.
+- `RELEASING.md`: branches, PR gates, SemVer, release checklist, PyPI publishing, branch
+  protection. `pr-title.yml`, `changelog.yml`, `release.yml`, `CODEOWNERS`.
 
 ### Fixed
 
@@ -31,6 +38,7 @@ release.
 - Red flags: SSH submodule URL, dangling `release/metasim` symlink, silent `except: pass` around
   passthrough registration, hard-coded personal paths in scripts/tests, untruthful
   `requires-python >= 3.8` (now 3.10), wheels missing LIBERO json/npz bundles, stale ruff ignores.
+
 
 ## [1.0.0-beta] - 2026-05-31
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,3 +25,5 @@ And install the [ruff vscode extension](https://marketplace.visualstudio.com/ite
 The `.vscode/settings.json` is configured aligning with the pre-commit hooks. Whenever you save the file, it will be formatted automatically.
 
 To migrate new tasks, please refer to the [developer guide](https://roboverse.wiki/metasim/developer_guide/new_task).
+
+Branches, pull-request gates, versioning and the release checklist are defined in [`RELEASING.md`](./RELEASING.md); engineering rules in [`AGENTS.md`](./AGENTS.md).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,109 @@
+# Development and release protocol
+
+This is the contract for how code reaches `main` and how `main` reaches users, for **RoboVerse**
+(this repo, distribution `roboverse-py`) and its core dependency **MetaSim**
+(`roboverse-metasim`, import name `metasim`). The same protocol lives in MetaSim's `RELEASING.md`;
+keep both in sync.
+
+## 1. Branches
+
+- `main` is always releasable: every commit on it passed the required checks below.
+- Work happens on short-lived branches named `<type>/<scope>-<slug>`, e.g. `feat/superdex-backend`,
+  `fix/hf-util-lock`, `maint/lint`. Types are the Conventional Commits types
+  (`feat|fix|docs|style|refactor|test|chore|ci|perf`).
+- No long-lived `develop`. Backports go to `release/vX.Y` branches created from the tag only when a
+  patch release is needed.
+- Branch protection on `main` (configured through the GitHub API, see §6): pull requests only, no
+  force pushes, no deletion, required status checks must pass, conversations must be resolved.
+
+## 2. Pull requests
+
+- One concern per PR. Title is a Conventional Commit (`type(scope): summary`); the `pr-title`
+  check enforces it because the squash-merge commit takes the PR title.
+- Required checks: `lint` (ruff check + format at the pre-commit pin), `tests` (the whole
+  `tests/` suite on CPU; tests that need a GPU simulator or `roboverse_data` skip with a reason),
+  `task-contract`, `pr-title`, and `changelog` (every PR that touches `roboverse_pack/`,
+  `roboverse_learn/`, `scripts/` or `get_started/` adds a line under `## [Unreleased]` in
+  `CHANGELOG.md`, or carries the `no-changelog` label).
+- Simulator-backed parity runs (`scripts/parity_*.py`, `scripts/eval_*_cross_sim.py`) are executed
+  locally before a release (§4) and their numbers go into the release notes.
+- Every behaviour change ships with a test; every public API change ships with docs and a
+  `CHANGELOG.md` entry that says what a user must do (migration line) if anything breaks.
+- Reviews: at least one maintainer review before merge once a second maintainer is active
+  (`required_approving_review_count` in §6 is 0 today for a single-maintainer repo; raise it then).
+- Merge method: **squash** (linear history, one commit per PR, commit message = PR title + body).
+
+## 3. Versioning
+
+- Semantic Versioning. `MAJOR.MINOR.PATCH`; pre-releases `X.Y.ZrcN`.
+  - PATCH: fixes only, no API change.
+  - MINOR: new backends, new config fields, new queries; existing call sites keep working.
+  - MAJOR: a documented breaking change to `BaseSimHandler`, the scenario cfg types, or the task
+    registry contract.
+- The version is stored **once**, in `pyproject.toml` (`[project] version`). Never hand-edit a
+  version elsewhere. RoboVerse `MAJOR.MINOR` tracks the MetaSim `MAJOR.MINOR` it is built against
+  (RoboVerse 1.x ↔ MetaSim 0.x today; the mapping is stated in `README.md` and the changelog).
+- Tags are `vX.Y.Z` on `main` and are immutable. A tag that turns out broken gets a new patch
+  release, never a moved tag.
+- MetaSim pin: `pyproject.toml` depends on `roboverse-metasim @ git+https://github.com/RoboVerseOrg/MetaSim.git@vX.Y.Z`
+  (a **tag**, not `main`) and, once PyPI publishing is enabled, on `roboverse-metasim>=X.Y,<X.Y+1`.
+  The pin moves only through a `chore(deps): bump MetaSim to vX.Y.Z` PR whose CI runs the full
+  suite against the new MetaSim. (The pin is `@main` until the first tagged MetaSim release that
+  contains the SuperDex backend; the first release PR replaces it.)
+
+## 4. Release checklist (RoboVerse)
+
+1. `main` is green and the merge queue is empty.
+2. MetaSim has been released first; the pin-bump PR is merged and CI is green against it. Run
+   the `get_started` tutorials on MuJoCo and at least one other backend (`--headless`) and the
+   parity scripts; record pass/skip/xfail counts and parity numbers in the release notes.
+3. Open a `chore(release): vX.Y.Z` PR that
+   - bumps `[project] version` in `pyproject.toml`,
+   - renames `## [Unreleased]` in `CHANGELOG.md` to `## [X.Y.Z] - YYYY-MM-DD` and adds a fresh
+     empty `## [Unreleased]`,
+   - updates `RELEASE_NOTES_NEXT.md` if it is used for the GitHub release text.
+4. Merge it, then tag the squash commit: `git tag -a vX.Y.Z -m "RoboVerse vX.Y.Z" && git push origin vX.Y.Z`.
+5. `release.yml` runs on the tag: it verifies the tag equals the `pyproject.toml` version, builds
+   the sdist and wheel, checks them with `twine`, creates the GitHub Release with the matching
+   `CHANGELOG.md` section as body, and (when the `pypi` environment is configured, §5) publishes
+   to PyPI through trusted publishing.
+6. Announce in Discussions / Discord with the changelog link and the MetaSim version it pairs with.
+
+Patch releases: branch `release/vX.Y` from the tag, cherry-pick fixes, repeat steps 3-5 with
+`base = release/vX.Y`.
+
+## 5. Publishing to PyPI (one-time setup)
+
+- The distribution name is `roboverse-py`. PyPI already lists `roboverse-py` 0.1.17 with no
+  author metadata; confirm the RoboVerseOrg account owns that project before the first automated
+  upload (if it does not, pick `roboverse-pack` and update `pyproject.toml`).
+- Add a *trusted publisher* on the PyPI project: owner `RoboVerseOrg`, repository `RoboVerse`,
+  workflow `release.yml`, environment `pypi`.
+- In the GitHub repo create the `pypi` environment (Settings → Environments), restricted to tags
+  `v*`, with required reviewers = the release managers. Until this exists the publish job is
+  skipped and the GitHub Release still happens.
+
+## 6. Repository settings (applied through `gh api`; re-apply after any change)
+
+```bash
+gh api -X PUT repos/RoboVerseOrg/RoboVerse/branches/main/protection --input - <<'JSON'
+{
+  "required_status_checks": {"strict": true, "contexts": ["lint", "tests", "task-contract", "pr-title", "changelog"]},
+  "enforce_admins": false,
+  "required_pull_request_reviews": {"required_approving_review_count": 0, "dismiss_stale_reviews": true},
+  "restrictions": null,
+  "allow_force_pushes": false,
+  "allow_deletions": false,
+  "required_linear_history": true,
+  "required_conversation_resolution": true
+}
+JSON
+gh api -X PATCH repos/RoboVerseOrg/RoboVerse -f allow_squash_merge=true -f allow_merge_commit=false -f allow_rebase_merge=false -f delete_branch_on_merge=true -f squash_merge_commit_title=PR_TITLE -f squash_merge_commit_message=PR_BODY
+```
+
+## 7. Cross-repo rule
+
+MetaSim owns the simulator contract, config types and the registry; RoboVerse owns content,
+learning code and examples (see `AGENTS.md`). A feature that spans both lands in MetaSim first,
+gets released (or at least tagged as a pre-release), and only then does the RoboVerse PR bump the
+pin and use it. RoboVerse `main` must never depend on MetaSim `main`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "RoboVerse content, learning, and examples built on MetaSim"
 requires-python = ">=3.10"
 license = { file = "LICENSE" }
 dependencies = [
-    "metasim @ git+https://github.com/RoboVerseOrg/MetaSim.git@main",
+    "roboverse-metasim @ git+https://github.com/RoboVerseOrg/MetaSim.git@main",
     "gymnasium",
     "loguru",
     "numpy",
@@ -23,7 +23,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "ruff",
-    "metasim[dev] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main",
+    "roboverse-metasim[dev] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main",
 ]
 assets = ["huggingface-hub", "rootutils", "tyro"]
 examples = [
@@ -70,18 +70,18 @@ vla = [
     "tensorflow-hub",
     "transformers",
 ]
-genesis = ["metasim[genesis] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
-isaacgym = ["metasim[isaacgym] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
-isaacsim = ["metasim[isaacsim] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
-isaacsim211 = ["metasim[isaacsim211] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
-mjx = ["metasim[mjx] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
-mujoco = ["metasim[mujoco] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
-newton = ["metasim[newton] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
-superdex = ["metasim[superdex] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]  # Python 3.12 only
-pybullet = ["metasim[pybullet] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
-robosplatter = ["metasim[robosplatter] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
-sapien2 = ["metasim[sapien2] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
-sapien3 = ["metasim[sapien3] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+genesis = ["roboverse-metasim[genesis] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+isaacgym = ["roboverse-metasim[isaacgym] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+isaacsim = ["roboverse-metasim[isaacsim] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+isaacsim211 = ["roboverse-metasim[isaacsim211] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+mjx = ["roboverse-metasim[mjx] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+mujoco = ["roboverse-metasim[mujoco] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+newton = ["roboverse-metasim[newton] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+superdex = ["roboverse-metasim[superdex] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]  # Python 3.12 only
+pybullet = ["roboverse-metasim[pybullet] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+robosplatter = ["roboverse-metasim[robosplatter] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+sapien2 = ["roboverse-metasim[sapien2] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
+sapien3 = ["roboverse-metasim[sapien3] @ git+https://github.com/RoboVerseOrg/MetaSim.git@main"]
 
 [project.entry-points."metasim.packages"]
 roboverse_pack = "roboverse_pack"


### PR DESCRIPTION
- RELEASING.md (RoboVerse edition of the shared protocol) + CONTRIBUTING.md link: branches, PR
  gates (lint, tests, task-contract, pr-title, changelog), SemVer with MAJOR.MINOR tracking MetaSim,
  release checklist, MetaSim pin policy (tag, never main), PyPI ownership check for roboverse-py,
  branch-protection settings.
- .github/workflows: pr-title.yml, changelog.yml (entry required when roboverse_pack/,
  roboverse_learn/, scripts/ or get_started/ change), release.yml (tag → GitHub Release + PyPI).
  CODEOWNERS.
- pyproject: `metasim @ git+...` → `roboverse-metasim @ git+...` in all 13 requirement strings
  (MetaSim's distribution was renamed; pip refuses a renamed distribution under the old name).

Merge order: MetaSim's protocol PR first, then this one.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw