### PR TITLE
fix(pack): break the benchmark import cycle; stop mjlab from downloading assets at import time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ release.
 
 ## [Unreleased]
 
+### Fixed
+
+- `import roboverse_pack.tasks.benchmark` raised a circular-import error when the tasks package was
+  imported first (task discovery); `roboverse_pack.benchmark` now resolves its two helpers lazily.
+- `roboverse_pack.tasks.mjlab` no longer downloads assets from HuggingFace at import time; the
+  handler's `check_assets()` fetches them when a task is used.
+
 ### Changed
 
 - MetaSim dependency renamed to `roboverse-metasim @ git+...` (MetaSim's distribution was renamed;

--- a/roboverse_pack/benchmark/__init__.py
+++ b/roboverse_pack/benchmark/__init__.py
@@ -9,7 +9,6 @@ from roboverse_pack.benchmark.spec import (
     BenchmarkSceneSpec,
     BenchmarkTaskSpec,
 )
-from roboverse_pack.tasks.benchmark import get_benchmark_task_spec, list_benchmark_task_specs
 
 __all__ = [
     "BenchmarkCameraPreset",
@@ -20,3 +19,14 @@ __all__ = [
     "get_benchmark_task_spec",
     "list_benchmark_task_specs",
 ]
+
+
+def __getattr__(name: str):
+    # ``roboverse_pack.tasks.benchmark`` imports ``roboverse_pack.benchmark.spec`` at module scope;
+    # importing it eagerly here made ``import roboverse_pack.tasks.benchmark`` (e.g. during task
+    # discovery) a circular import. Resolve the two helpers on first access instead.
+    if name in ("get_benchmark_task_spec", "list_benchmark_task_specs"):
+        from roboverse_pack.tasks import benchmark as _tasks_benchmark
+
+        return getattr(_tasks_benchmark, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/roboverse_pack/tasks/mjlab/_locator.py
+++ b/roboverse_pack/tasks/mjlab/_locator.py
@@ -67,12 +67,8 @@ def mjlab_asset(relpath: str) -> str:
     except FileNotFoundError:
         pass
 
-    # 2. HuggingFace fallback — download XML + meshes into roboverse_data/.
-    local = hf_mjlab_path(relpath)
-    if not os.path.exists(local):
-        # Lazy import: hf_util pulls in heavy deps and we only need it on a
-        # cold (clone-less) machine.
-        from metasim.utils.hf_util import check_and_download_recursive
-
-        check_and_download_recursive([local])
-    return local
+    # 2. roboverse_data path. Not downloaded here: ``mjlab_asset`` is evaluated at import time (cfg
+    # defaults), and a network fetch inside ``import roboverse_pack.tasks.mjlab`` is a side effect that
+    # slowed task discovery and broke offline imports. ``ScenarioCfg.check_assets()`` (run by every
+    # handler at construction) fetches the MJCF and its referenced meshes when the task is used.
+    return hf_mjlab_path(relpath)


### PR DESCRIPTION
- `roboverse_pack.benchmark` imported `roboverse_pack.tasks.benchmark` at module scope while that
  package imports `roboverse_pack.benchmark.spec`; importing the tasks package first (task discovery
  does) raised "cannot import name 'get_benchmark_task_spec' from partially initialized module". The
  two helpers are now resolved lazily via module `__getattr__`.
- `roboverse_pack.tasks.mjlab._locator.mjlab_asset` is evaluated in cfg defaults at import time and
  triggered a HuggingFace download inside `import roboverse_pack.tasks.mjlab` (slow discovery,
  offline imports failing). It now only returns the roboverse_data path; `ScenarioCfg.check_assets()`
  fetches the MJCF and its meshes when the task is used, as for every other asset.

Verified: `import roboverse_pack.tasks.benchmark` first works; importing the mjlab tasks with the
downloader patched to raise does not download; `pytest tests/` -> 338 passed.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw