### PR TITLE
fix(robots): repair g1_feet actuator fields and dex3 thumb limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ release.
 
 ### Fixed
 
+- `g1_feet` robot cfg crashed at import (wrong `BaseActuatorCfg` keywords) and `unitree_dex3_1` had a degenerate thumb joint limit; a config validation test now guards both.
 - Native LIBERO `Open`/`Close`/`TurnOn`/`TurnOff` predicates always evaluated False on
   mujoco >= 3.x (`numpy.int32 in (mjtJoint...)` membership).
 - `get_started/multiple_cameras.py` passed a removed `ScenarioCfg` kwarg.

--- a/roboverse_pack/robots/g1_feet.py
+++ b/roboverse_pack/robots/g1_feet.py
@@ -34,28 +34,32 @@ class Go1FeetCfg(RobotCfg):
     # ------------------------------------------------------------------
     # Global XML defaults: kp=35, kd=0.5, force= ±23.7
     # Knee class overrides: force= ±35.55
-    _HIP_KP = 35.0
-    _HIP_KD = 0.5
-    _HIP_FMAX = 23.7
-    _KNEE_FMAX = 35.55
+    #
+    # ``BaseActuatorCfg`` exposes the PD gains as ``stiffness`` (position gain, kp) and
+    # ``damping`` (velocity gain, kd), and the torque cap as ``effort_limit_sim`` (the
+    # per-backend force limit). The XML's kp/kd/force values map onto those fields.
+    _HIP_KP = 35.0  # -> stiffness
+    _HIP_KD = 0.5  # -> damping
+    _HIP_FMAX = 23.7  # -> effort_limit_sim
+    _KNEE_FMAX = 35.55  # -> effort_limit_sim (knee override)
 
     actuators: dict[str, BaseActuatorCfg] = {
         # Front-Right (FR)
-        "FR_hip": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_HIP_FMAX),
-        "FR_thigh": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_HIP_FMAX),
-        "FR_calf": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_KNEE_FMAX),
+        "FR_hip": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_HIP_FMAX),
+        "FR_thigh": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_HIP_FMAX),
+        "FR_calf": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_KNEE_FMAX),
         # Front-Left (FL)
-        "FL_hip": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_HIP_FMAX),
-        "FL_thigh": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_HIP_FMAX),
-        "FL_calf": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_KNEE_FMAX),
+        "FL_hip": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_HIP_FMAX),
+        "FL_thigh": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_HIP_FMAX),
+        "FL_calf": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_KNEE_FMAX),
         # Rear-Right (RR)
-        "RR_hip": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_HIP_FMAX),
-        "RR_thigh": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_HIP_FMAX),
-        "RR_calf": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_KNEE_FMAX),
+        "RR_hip": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_HIP_FMAX),
+        "RR_thigh": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_HIP_FMAX),
+        "RR_calf": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_KNEE_FMAX),
         # Rear-Left (RL)
-        "RL_hip": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_HIP_FMAX),
-        "RL_thigh": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_HIP_FMAX),
-        "RL_calf": BaseActuatorCfg(kp=_HIP_KP, kd=_HIP_KD, force_limit=_KNEE_FMAX),
+        "RL_hip": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_HIP_FMAX),
+        "RL_thigh": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_HIP_FMAX),
+        "RL_calf": BaseActuatorCfg(stiffness=_HIP_KP, damping=_HIP_KD, effort_limit_sim=_KNEE_FMAX),
     }
 
     # ------------------------------------------------------------------

--- a/roboverse_pack/robots/unitree_dex3_1_cfg.py
+++ b/roboverse_pack/robots/unitree_dex3_1_cfg.py
@@ -26,7 +26,7 @@ class UnitreeDex31LeftCfg(RobotCfg):
     }
 
     joint_limits: dict[str, tuple[float, float]] = {
-        "left_hand_thumb_0_joint": (-1.04, -1.04),
+        "left_hand_thumb_0_joint": (-1.04, 1.04),
         "left_hand_thumb_1_joint": (-0.72, 0.92),
         "left_hand_thumb_2_joint": (0.0, 1.74),
         "left_hand_middle_0_joint": (-1.57, 0.0),

--- a/tests/test_roboverse_robot_cfg_validation.py
+++ b/tests/test_roboverse_robot_cfg_validation.py
@@ -240,3 +240,98 @@ def test_anymal_default_orientation_is_wxyz_identity():
         f"expected wxyz identity [1,0,0,0], got {cfg.default_orientation} "
         f"(w must be the largest component for an identity quaternion)"
     )
+
+
+@pytest.mark.general
+def test_g1_feet_cfg_imports_and_constructs():
+    """Regression: ``roboverse_pack.robots.g1_feet`` must import and construct.
+
+    Every ``BaseActuatorCfg`` in that file used to pass ``kp=/kd=/force_limit=`` —
+    none of which are fields of ``BaseActuatorCfg`` — so *importing the module*
+    raised ``TypeError`` at class-body evaluation. Because the crash happened at
+    import time, ``roboverse_pack.robots.__init__`` swallowed it and ``Go1FeetCfg``
+    silently never registered as a ``RobotCfg`` subclass. The correct field names
+    are ``stiffness`` (kp), ``damping`` (kd), and ``effort_limit_sim`` (force limit),
+    as consumed by the mujoco/isaacgym/newton/pybullet handlers.
+    """
+    import importlib
+
+    mod = importlib.import_module("roboverse_pack.robots.g1_feet")
+    cfg = mod.Go1FeetCfg()
+    assert cfg.name == "go1_feet"
+    assert len(cfg.actuators) == 12
+    # Gains/limits from the XML must survive under the correct field names.
+    hip = cfg.actuators["FR_hip"]
+    assert (hip.stiffness, hip.damping, hip.effort_limit_sim) == (35.0, 0.5, 23.7)
+    assert cfg.actuators["FR_calf"].effort_limit_sim == 35.55
+
+
+# Joints that are *deliberately* pinned to a single point (lo == hi). These are
+# intentional design choices (locked/unused DoF, or a fixed offset expressed as a
+# degenerate range), not the unintended dropped-sign bug the test below hunts for.
+# Keyed by cfg class name -> set of joint names that are allowed to be degenerate.
+_DELIBERATELY_LOCKED_JOINTS: dict[str, set[str]] = {
+    # VegaCfg locks its wheels, right arm/hand, and unused torso DoF; torso_j1 is a
+    # fixed offset [0.2, 0.2]. All intentional — see vega_cfg.py.
+    "VegaCfg": {
+        "B_wheel_j1",
+        "B_wheel_j2",
+        "R_wheel_j1",
+        "R_wheel_j2",
+        "L_wheel_j1",
+        "L_wheel_j2",
+        "torso_j1",
+        "torso_j3",
+        "R_arm_j1",
+        "R_arm_j2",
+        "R_arm_j3",
+        "R_arm_j4",
+        "R_arm_j5",
+        "R_arm_j6",
+        "R_arm_j7",
+        "R_th_j0",
+        "R_th_j1",
+        "R_th_j2",
+        "R_ff_j1",
+        "R_ff_j2",
+        "R_mf_j1",
+        "R_mf_j2",
+        "R_rf_j1",
+        "R_rf_j2",
+        "R_lf_j1",
+        "R_lf_j2",
+    },
+}
+
+
+@pytest.mark.skipif(not _CFG_PARAMS, reason="roboverse_pack not importable")
+@pytest.mark.parametrize("cls", _CFG_PARAMS)
+def test_robot_cfg_no_unintended_degenerate_joint_limits(cls: type[RobotCfg]):
+    """No joint limit may be degenerate (``lo == hi``) unless deliberately locked.
+
+    A ``lo == hi`` limit pins the joint to a single point, so it cannot move — for a
+    real DoF this is almost always a dropped sign (e.g. dex3's thumb-yaw was
+    ``(-1.04, -1.04)`` instead of ``(-1.04, 1.04)``, leaving the thumb unable to
+    oppose the fingers → no pinch grasp). Intentionally locked joints are listed in
+    ``_DELIBERATELY_LOCKED_JOINTS``.
+    """
+    instance = _try_instantiate(cls)
+    if instance is None:
+        pytest.skip(f"{cls.__name__} abstract template")
+    limits = getattr(instance, "joint_limits", None)
+    if not limits:
+        pytest.skip(f"{cls.__name__} has no joint_limits")
+
+    allowed = _DELIBERATELY_LOCKED_JOINTS.get(cls.__name__, set())
+    degenerate: list[str] = []
+    for jn, bounds in limits.items():
+        if not (isinstance(bounds, (tuple, list)) and len(bounds) == 2):
+            continue
+        lo, hi = bounds
+        if lo == hi and jn not in allowed:
+            degenerate.append(f"{jn}={bounds}")
+    assert not degenerate, (
+        f"{cls.__name__}: degenerate (lo == hi) joint limits pin these joints to a point: "
+        f"{degenerate}. If this is intentional, add the joint to "
+        f"_DELIBERATELY_LOCKED_JOINTS; otherwise a sign was likely dropped."
+    )


### PR DESCRIPTION
Two robot configs shipped values under names the config type does not
accept, so the intended behavior was silently lost.

g1_feet.py built every actuator with BaseActuatorCfg(kp=, kd=,
force_limit=), but none of those are fields of BaseActuatorCfg. Because
the bad kwargs were evaluated in the class body, importing the module
raised TypeError at definition time, and roboverse_pack.robots.__init__
swallowed the import error — so Go1FeetCfg never registered as a RobotCfg
subclass and quietly disappeared from the pack. Map the XML gains onto the
real fields the handlers read: kp -> stiffness, kd -> damping, force ->
effort_limit_sim (consumed by the mujoco/isaacgym/newton/pybullet
backends). The documented values (kp=35, kd=0.5, force +/-23.7, knees
+/-35.55) are preserved.

unitree_dex3_1_cfg.py had left_hand_thumb_0_joint limited to
(-1.04, -1.04) — a dropped sign that pins the thumb-yaw DoF to a single
point. With lo == hi the thumb cannot swing across to oppose the fingers,
so no pinch grasp is possible. The sibling thumb/finger joints all carry
real ranges and the g1 full-body cfg mirrors this joint symmetrically at
+/-1.047 on both hands, so the intended range is (-1.04, 1.04).

Add regression coverage in tests/test_roboverse_robot_cfg_validation.py:
one test asserts g1_feet imports and Go1FeetCfg constructs with the gains
intact, and another asserts no robot cfg carries a degenerate (lo == hi)
joint limit except joints on an explicit deliberately-locked allowlist
(Vega's locked wheels/arm/hand and fixed torso offset), so the check
targets only unintended dropped-sign limits.

Review: independently reviewed against current main (verdict MERGE AS-IS); rebased, re-verified: 262 passed, 48 skipped, 9 xfailed in 3.71s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw