### PR TITLE
fix(tasks): honor reset(states=) contract in eight Tier-1 task overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ release.
 ### Fixed
 
 - `g1_feet` robot cfg crashed at import (wrong `BaseActuatorCfg` keywords) and `unitree_dex3_1` had a degenerate thumb joint limit; a config validation test now guards both.
+- Eight Tier-1 task `reset` overrides (humanoid, beyondmimic, six SimplerEnv tasks) dropped `states=`, so `env.reset(states=...)` from the IL/VLA eval runners raised `TypeError`; the contract test now checks full signature substitutability.
 - Native LIBERO `Open`/`Close`/`TurnOn`/`TurnOff` predicates always evaluated False on
   mujoco >= 3.x (`numpy.int32 in (mjtJoint...)` membership).
 - `get_started/multiple_cameras.py` passed a removed `ScenarioCfg` kwarg.

--- a/roboverse_pack/tasks/beyondmimic/metasim/envs/base_legged_robot.py
+++ b/roboverse_pack/tasks/beyondmimic/metasim/envs/base_legged_robot.py
@@ -184,12 +184,22 @@ class LeggedRobotTask(RLTaskEnv):
         # NOTE corresponds to action clipping in `RslRlVecEnvWrapper.step()` in Isaac Lab
         return torch.clip(actions, -self.action_clip, self.action_clip) if self.action_clip else actions
 
-    def reset(self, env_ids: Sequence[int] | None = None, seed: int | None = None):
+    def reset(
+        self,
+        states: TensorState | None = None,
+        env_ids: Sequence[int] | None = None,
+        seed: int | None = None,
+    ):
         """Reset the specified environments.
 
-        ``seed`` is forwarded to the handler when supported (this base
-        reimplements ``reset`` and does not call ``super().reset``), honoring
-        the ``env.reset(seed=)`` contract.
+        Args:
+            states: Optional external states to set for the selected envs, per the
+                ``BaseTaskEnv.reset`` contract. If None, the reset events own the initial
+                state. IL/VLA eval runners replay demos through this argument.
+            env_ids: The environment ids to reset (defaults to all).
+            seed: Optional reproducibility seed, forwarded to the handler when supported
+                (this base reimplements ``reset`` and does not call ``super().reset``),
+                honoring the ``env.reset(seed=)`` contract.
         """
         if seed is not None:
             set_seed = getattr(self.handler, "set_seed", None)
@@ -198,8 +208,12 @@ class LeggedRobotTask(RLTaskEnv):
         if env_ids is None:
             env_ids = torch.arange(self.num_envs, dtype=torch.int64, device=self.device)
 
-        # reset state of scene
+        # reset state of scene (reset events randomize the initial state)
         self._reset_idx(env_ids)
+
+        # caller-supplied states win over the reset events, so demo replay is exact
+        if states is not None:
+            self.handler.set_states(states=states, env_ids=env_ids)
 
         # update articulation kinematics
         # self.handler.scene.write_data_to_sim()

--- a/roboverse_pack/tasks/humanoid/base/base_legged_robot.py
+++ b/roboverse_pack/tasks/humanoid/base/base_legged_robot.py
@@ -253,12 +253,22 @@ class LeggedRobotTask(AgentTask):
         effort = torch.clip(effort, -self.torque_limits, self.torque_limits)
         return effort.to(torch.float32)
 
-    def reset(self, env_ids: torch.Tensor | list[int] | None = None, seed: int | None = None):
+    def reset(
+        self,
+        states: TensorState | None = None,
+        env_ids: torch.Tensor | list[int] | None = None,
+        seed: int | None = None,
+    ):
         """Reset selected envs (defaults to all).
 
-        ``seed`` is forwarded to the handler when supported, so the
-        ``env.reset(seed=)`` contract reaches the simulator (this base
-        reimplements ``reset`` and does not call ``super().reset``).
+        Args:
+            states: Optional external states to set for the selected envs, per the
+                ``BaseTaskEnv.reset`` contract. If None, the task's own initial states are
+                used. IL/VLA eval runners replay demos through this argument.
+            env_ids: The environment ids to reset (defaults to all).
+            seed: Optional reproducibility seed, forwarded to the handler when supported so
+                the ``env.reset(seed=)`` contract reaches the simulator (this base
+                reimplements ``reset`` and does not call ``super().reset``).
         """
         if seed is not None:
             set_seed = getattr(self.handler, "set_seed", None)
@@ -276,7 +286,8 @@ class LeggedRobotTask(AgentTask):
         for _reset_fn, _params in self.reset_callback.values():
             _ = _reset_fn(self, env_ids, **_params)
 
-        self.set_states(states=self.setup_initial_env_states, env_ids=env_ids)
+        states_to_set = self.setup_initial_env_states if states is None else states
+        self.set_states(states=states_to_set, env_ids=env_ids)
 
         for history in self.history_buffer.values():
             for item in history:
@@ -302,8 +313,8 @@ class LeggedRobotTask(AgentTask):
                 torch.mean(self.episode_not_terminations[key][env_ids]) / self.max_episode_steps
             )
             self.episode_not_terminations[key][env_ids] = 0.0
-        states = self.handler.get_states(mode="tensor")
-        info = {"privileged_observation": self._privileged_observation(states)}
+        env_states = self.handler.get_states(mode="tensor")
+        info = {"privileged_observation": self._privileged_observation(env_states)}
         return self.obs_buf, info
 
     def step(

--- a/roboverse_pack/tasks/simpler_env/_metasim/base.py
+++ b/roboverse_pack/tasks/simpler_env/_metasim/base.py
@@ -61,6 +61,31 @@ def candidate_mesh_objects(models_dir, model_ids, *, friction=None, damping=0.1,
     return cfgs
 
 
+def apply_external_states(task, states, env_ids=None) -> bool:
+    """Apply caller-supplied ``states`` on top of a SimplerEnv task's scripted reset.
+
+    ``BaseTaskEnv.reset(states=...)`` means "put the selected envs in these states instead of the
+    task's initial ones"; the IL/VLA eval runners replay demo initial states that way. A SimplerEnv
+    reset scripts its own layout (per-episode RNG, fall-and-settle), so external states are applied
+    once that layout is in place and before the controller / success checker latch onto it — the
+    caller's states win, exactly as in the base contract.
+
+    Args:
+        task: The SimplerEnv task (any ``BaseTaskEnv``; used for its handler).
+        states: External states, or None to keep the task's scripted initial states.
+        env_ids: The environment ids the states apply to.
+
+    Returns:
+        True if states were applied, False if ``states`` was None. Callers use this to refresh any
+        cached quantity they derived from the scripted layout (e.g. post-settle object heights).
+    """
+    if states is None:
+        return False
+    task.handler.set_states(states=states, env_ids=env_ids)
+    task.handler.refresh_render()
+    return True
+
+
 class SimplerMetaSimTask(BaseTaskEnv):
     """Base task: handler loads the scenario; SimplerEnv control/overlay/checker layer on top."""
 

--- a/roboverse_pack/tasks/simpler_env/_metasim/coke_task.py
+++ b/roboverse_pack/tasks/simpler_env/_metasim/coke_task.py
@@ -47,6 +47,7 @@ from .._native.scene import (
     SCENE_POSE_Q,
     SIM_FREQ,
 )
+from .base import apply_external_states
 
 SUBSTEPS = SIM_FREQ // CONTROL_FREQ
 SCENE_TABLE_HEIGHT = 0.87
@@ -180,7 +181,9 @@ class SimplerCokeTask(BaseTaskEnv):
         self.obj_height_after_settle = None
 
     # ---- reset (RNG repro + fall/settle, on the handler objects) -------------
-    def reset(self, env_ids=None, options=None, seed=0):
+    def reset(self, states=None, env_ids=None, seed=0, options=None):
+        """Reset the task. ``states``/``env_ids``/``seed`` are the ``BaseTaskEnv.reset`` contract;
+        ``options`` is the SimplerEnv episode spec (obj/robot init options) from the gym adapter."""
         options = options or {}
         oio = options.get("obj_init_options") or {}
         if oio.get("init_rot_quat") is None:
@@ -217,6 +220,9 @@ class SimplerCokeTask(BaseTaskEnv):
         self.robot.set_root_pose(sapien.Pose([rxy[0], rxy[1], ROBOT_INIT_HEIGHT], [0, 0, 0, 1]))
         self.robot.set_qpos(INIT_QPOS)
         self.robot.set_qvel(np.zeros(self.robot.dof))
+        if apply_external_states(self, states, env_ids):
+            # the success checker keys off the settled height, so re-read it from the applied states
+            self.obj_height_after_settle = float(self.obj.pose.p[2])
         self.controller.reset()
         self.evaluator.reset(self.obj_height_after_settle)
         self._elapsed = 0

--- a/roboverse_pack/tasks/simpler_env/_metasim/drawer_task.py
+++ b/roboverse_pack/tasks/simpler_env/_metasim/drawer_task.py
@@ -32,7 +32,7 @@ from .._native.robot_config import (
     google_robot_deployed_controller_configs,
 )
 from .._native.scene import INIT_QPOS, ROBOT_INIT_HEIGHT, SCENE_OFFSET
-from .base import SimplerMetaSimTask
+from .base import SimplerMetaSimTask, apply_external_states
 
 ROBOT_NAME, CAB_NAME, CAM_NAME = "google_robot", "cabinet", "overhead_camera"
 CABINET_POSE_P = (-0.295, 0.0, 0.017)
@@ -157,7 +157,10 @@ class SimplerDrawerTask(SimplerMetaSimTask):
             j.set_drive_property(stiffness=0, damping=1)
         self.joint_names = [j.name for j in self.cabinet.get_active_joints()]
 
-    def reset(self, env_ids=None, options=None, seed=0):
+    def reset(self, states=None, env_ids=None, seed=0, options=None):
+        """Reset the task. ``states``/``env_ids``/``seed`` are the ``BaseTaskEnv.reset`` contract;
+        ``options`` is the SimplerEnv episode spec (robot init options / station) from the gym
+        adapter."""
         options = options or {}
         rng = np.random.RandomState(seed)
         self.drawer_id = str(rng.choice(list(self.drawer_ids)))
@@ -178,6 +181,7 @@ class SimplerDrawerTask(SimplerMetaSimTask):
             qpos[self.joint_idx] = CLOSE_INIT_QPOS
         self.cabinet.set_qpos(qpos)
         self.cabinet.set_qvel(np.zeros(self.cabinet.dof))
+        apply_external_states(self, states, env_ids)
         self.controller.reset()
         self._elapsed = 0
         return self.get_obs(), {"drawer_id": self.drawer_id}

--- a/roboverse_pack/tasks/simpler_env/_metasim/grasp_objects_task.py
+++ b/roboverse_pack/tasks/simpler_env/_metasim/grasp_objects_task.py
@@ -27,7 +27,7 @@ from .._native.move_near import MOVE_NEAR_CONFIG, _instruction_obj_name, _xy_con
 from .._native.overlay import load_overlay_image
 from .._native.robot_config import google_robot_deployed_controller_configs
 from .._native.scene import INIT_QPOS, ROBOT_INIT_HEIGHT, SCENE_OFFSET, SCENE_POSE_Q
-from .base import HIDDEN_POS, SimplerMetaSimTask, candidate_mesh_objects, set_actor_collision
+from .base import HIDDEN_POS, SimplerMetaSimTask, apply_external_states, candidate_mesh_objects, set_actor_collision
 from .drawer_task import _google_robot_cfg, _overhead_camera_cfg, _sim_params
 
 ROBOT_NAME, ARENA_NAME, CAM_NAME = "google_robot", "arena", "overhead_camera"
@@ -129,7 +129,9 @@ class SimplerPickObjectTask(_GoogleArenaTask):
     def _foreground_ids(self):
         return [link.get_id() for link in self.robot.get_links()] + [self.obj.get_id()]
 
-    def reset(self, env_ids=None, options=None, seed=0):
+    def reset(self, states=None, env_ids=None, seed=0, options=None):
+        """Reset the task. ``states``/``env_ids``/``seed`` are the ``BaseTaskEnv.reset`` contract;
+        ``options`` is the SimplerEnv episode spec from the gym adapter."""
         orientation = np.random.RandomState(seed).choice(list(_ORIENT.keys()))
         self.model_id = PICK_OBJECT_IDS[np.random.RandomState(seed).randint(len(PICK_OBJECT_IDS))]
         self._park(PICK_OBJECT_IDS)
@@ -155,6 +157,9 @@ class SimplerPickObjectTask(_GoogleArenaTask):
         self.robot.set_root_pose(sapien.Pose([ix, iy, ROBOT_INIT_HEIGHT], [0, 0, 0, 1]))
         self.robot.set_qpos(INIT_QPOS)
         self.robot.set_qvel(np.zeros(self.robot.dof))
+        if apply_external_states(self, states, env_ids):
+            # the success checker keys off the settled height, so re-read it from the applied states
+            self.obj_height_after_settle = float(self.obj.pose.p[2])
         self.controller.reset()
         self.evaluator.reset(self.obj_height_after_settle)
         self._elapsed = 0
@@ -210,7 +215,9 @@ class SimplerMoveNearTask(_GoogleArenaTask):
     def _foreground_ids(self):
         return [link.get_id() for link in self.robot.get_links()] + [o.get_id() for o in self.objs]
 
-    def reset(self, env_ids=None, options=None, seed=0):
+    def reset(self, states=None, env_ids=None, seed=0, options=None):
+        """Reset the task. ``states``/``env_ids``/``seed`` are the ``BaseTaskEnv.reset`` contract;
+        ``options`` is the SimplerEnv episode spec from the gym adapter."""
         n = 5 * len(_SRC_IDS) * 2
         episode_id = np.random.RandomState(seed).randint(n)
         triplet = list(self.cfg["triplets"][episode_id // (len(_SRC_IDS) * 2)])
@@ -252,6 +259,11 @@ class SimplerMoveNearTask(_GoogleArenaTask):
         self.robot.set_root_pose(sapien.Pose([rx, ry, ROBOT_INIT_HEIGHT], [0, 0, 0, 1]))
         self.robot.set_qpos(INIT_QPOS)
         self.robot.set_qvel(np.zeros(self.robot.dof))
+        if apply_external_states(self, states, env_ids):
+            # success is measured against the post-reset object poses, so re-derive them
+            self.xyz_after_settle = [o.pose.p.copy() for o in self.objs]
+            self.src_bbox_world = quat2mat(self.objs[self.src_id].pose.q) @ self.bbox[self.src_id]
+            self.tgt_bbox_world = quat2mat(self.objs[self.tgt_id].pose.q) @ self.bbox[self.tgt_id]
         self.controller.reset()
         self._elapsed = 0
         return self.get_obs(), {"episode_id": int(episode_id), "model_ids": triplet}

--- a/roboverse_pack/tasks/simpler_env/_metasim/place_task.py
+++ b/roboverse_pack/tasks/simpler_env/_metasim/place_task.py
@@ -26,7 +26,7 @@ from .._native.grasp import compute_total_impulse, get_pairwise_contacts
 from .._native.overlay import load_overlay_image
 from .._native.robot_config import google_robot_deployed_controller_configs
 from .._native.scene import INIT_QPOS, ROBOT_INIT_HEIGHT
-from .base import HIDDEN_POS, SimplerMetaSimTask, candidate_mesh_objects, set_actor_collision
+from .base import HIDDEN_POS, SimplerMetaSimTask, apply_external_states, candidate_mesh_objects, set_actor_collision
 from .drawer_task import CABINET_POSE_P, _google_robot_cfg, _overhead_camera_cfg, dummy_drawer_floor_cfg
 
 CAB_NAME = "cabinet"
@@ -123,7 +123,9 @@ class SimplerPlaceTask(SimplerMetaSimTask):
             o.lock_motion(1, 1, 1, 1, 1, 1)
             set_actor_collision(o, False)
 
-    def reset(self, env_ids=None, options=None, seed=0):
+    def reset(self, states=None, env_ids=None, seed=0, options=None):
+        """Reset the task. ``states``/``env_ids``/``seed`` are the ``BaseTaskEnv.reset`` contract;
+        ``options`` is the SimplerEnv episode spec (obj/robot init options) from the gym adapter."""
         options = options or {}
         if self.fixed_model_id is not None:
             self.model_id = self.fixed_model_id
@@ -169,6 +171,9 @@ class SimplerPlaceTask(SimplerMetaSimTask):
         self.robot.set_root_pose(sapien.Pose([rxy[0], rxy[1], ROBOT_INIT_HEIGHT], rquat))
         self.robot.set_qpos(INIT_QPOS)
         self.robot.set_qvel(np.zeros(self.robot.dof))
+        if apply_external_states(self, states, env_ids):
+            # the success checker keys off the settled height, so re-read it from the applied states
+            self.obj_height_after_settle = float(self.obj.pose.p[2])
         self.controller.reset()
         self.drawer_link = next(x for x in self.cabinet.get_links() if x.get_name() == f"{self.drawer_id}_drawer")
         self.drawer_collision = self.drawer_link.get_collision_shapes()[2]

--- a/roboverse_pack/tasks/simpler_env/_metasim/put_on_task.py
+++ b/roboverse_pack/tasks/simpler_env/_metasim/put_on_task.py
@@ -48,7 +48,7 @@ from .._native.widowx_config import (
     apply_widowx_urdf_materials,
     widowx_deployed_controller_configs,
 )
-from .base import SimplerMetaSimTask
+from .base import SimplerMetaSimTask, apply_external_states
 
 ROBOT_NAME, ARENA_NAME, CAM_NAME = "widowx", "arena", "3rd_view_camera"
 OBJ_FRICTION = 0.5
@@ -187,7 +187,10 @@ class SimplerPutOnTask(SimplerMetaSimTask):
     def _foreground_ids(self):
         return [link.get_id() for link in self.robot.get_links()] + [o.get_id() for o in self.objs]
 
-    def reset(self, env_ids=None, options=None, seed=0):
+    def reset(self, states=None, env_ids=None, seed=0, options=None):
+        """Reset the task. ``states``/``env_ids``/``seed`` are the ``BaseTaskEnv.reset`` contract;
+        ``options`` is the SimplerEnv episode spec (episode id, robot init options) from the gym
+        adapter."""
         cfg = self.cfg
         n = len(cfg["xy"]) * len(cfg["quat"])
         episode_id = (options or {}).get("episode_id")
@@ -232,6 +235,11 @@ class SimplerPutOnTask(SimplerMetaSimTask):
         self.robot.set_root_pose(sapien.Pose([rxy[0], rxy[1], rh], [0, 0, 0, 1]))
         self.robot.set_qpos(self.qpos)
         self.robot.set_qvel(np.zeros(self.robot.dof))
+        if apply_external_states(self, states, env_ids):
+            # success is measured against the post-reset object poses, so re-derive them
+            self.xyz_after_settle = [o.pose.p.copy() for o in self.objs]
+            self.src_bbox_world = quat2mat(self.objs[0].pose.q) @ self.bbox[0]
+            self.tgt_bbox_world = quat2mat(self.objs[1].pose.q) @ self.bbox[1]
         self.controller.reset()
         self.consecutive_grasp = 0
         self._elapsed = 0

--- a/tests/test_task_reset_seed_contract.py
+++ b/tests/test_task_reset_seed_contract.py
@@ -1,9 +1,21 @@
-"""Backend-free conformance guardrail: every Tier-1 task ``reset`` accepts ``seed``.
+"""Backend-free conformance guardrail: every Tier-1 task ``reset`` is substitutable for the base.
 
-The gym bridge (``metasim.task.gym_registration``) forwards ``env.reset(seed=)``
-to a task only when the task's ``reset`` signature accepts it — tasks that
-override ``reset`` without a ``seed`` parameter silently drop the seed, so
-rollouts are not reproducible on the simulator side.
+The base contract is ``BaseTaskEnv.reset(states=None, env_ids=None, seed=None)``, and callers rely
+on the *whole* signature, not just one parameter:
+
+* ``states`` — the IL/VLA eval runners replay demo initial states with
+  ``env.reset(states=...)`` (``roboverse_learn/il/runners/default_runner.py``,
+  ``roboverse_learn/vla/{OpenVLA,SmolVLA,pi0}/*_eval.py``). An override that drops ``states``
+  makes those runners die with ``TypeError: reset() got an unexpected keyword argument 'states'``.
+* ``env_ids`` — partial resets.
+* ``seed`` — the gym bridge (``metasim.task.gym_registration``) forwards ``env.reset(seed=)`` to a
+  task only when its signature accepts it, so an override without ``seed`` silently drops it and
+  rollouts are not reproducible on the simulator side.
+
+This guardrail originally checked ``seed`` alone; eight Tier-1 overrides passed it while dropping
+``states`` (six SimplerEnv tasks took ``options`` in its place). It now checks full
+substitutability — accepted parameters, their positional order, and that no override adds a
+*required* parameter of its own — so that class of drift cannot recur.
 
 This test statically (no sim backend, no instantiation) scans every task file
 and asserts the contract on **Tier-1 tasks only**:
@@ -20,15 +32,18 @@ and asserts the contract on **Tier-1 tasks only**:
 
 Assertions (ratchets — each allowlist may only SHRINK, and may not go stale):
 
-* ``reset`` — no *new* Tier-1 override drops ``seed`` (allowlist now empty →
+* ``reset`` — no *new* Tier-1 override breaks substitutability (allowlist now empty →
   zero-tolerance); the unified family base classes honor the contract.
 * ``step`` — no *new* Tier-1 override (action transforms belong in a pre-physics
   action hook / ``pre_physics_step_callback``); current overrides are tracked
   in ``KNOWN_STEP_OVERRIDES`` as P1-cleanup targets.
 * ``close`` — no *new* Tier-1 override (teardown belongs in ``close_callback``).
 
-When you fix a file (accept ``seed`` / drop the ``step``/``close`` override),
+When you fix a file (honor the reset contract / drop the ``step``/``close`` override),
 delete it from the corresponding allowlist below.
+
+A task may still take *extra* parameters (e.g. SimplerEnv's ``options`` episode spec) as long as
+they come after the contract's three and have defaults, so a plain ``reset(states=...)`` call works.
 """
 
 from __future__ import annotations
@@ -45,7 +60,11 @@ _TASKS = pathlib.Path(__file__).resolve().parents[1] / "roboverse_pack" / "tasks
 # roboverse_learn — they are not defined under tasks/, so they anchor the graph.
 _CONTRACT_ROOTS = {"BaseTaskEnv", "RLTaskEnv", "ManagerBasedRVEnv"}
 
-# Family base classes fixed in the reset(seed) unification — must stay conformant.
+# The base signature: BaseTaskEnv.reset(states=None, env_ids=None, seed=None). Order matters —
+# callers may pass these positionally.
+_CONTRACT_PARAMS = ("states", "env_ids", "seed")
+
+# Family base classes / tasks fixed in the reset-contract unification — must stay conformant.
 _FIXED_BASES = {
     "libero/libero_base.py",
     "libero_90/libero_90_base.py",
@@ -55,13 +74,22 @@ _FIXED_BASES = {
     "calvin/base_table.py",
     "pick_place/base.py",
     "humanoid/base/base_legged_robot.py",
+    "beyondmimic/metasim/envs/base_legged_robot.py",
+    # SimplerEnv: took `options` in place of `states`, so VLA eval on SimplerEnv — the canonical
+    # pairing for that benchmark — was a hard TypeError. They keep `options` after the contract's
+    # three parameters.
+    "simpler_env/_metasim/coke_task.py",
+    "simpler_env/_metasim/drawer_task.py",
+    "simpler_env/_metasim/grasp_objects_task.py",
+    "simpler_env/_metasim/place_task.py",
+    "simpler_env/_metasim/put_on_task.py",
 }
 
-# P1 cleanup targets: Tier-1 task files whose ``reset`` override still drops
-# ``seed``. The contract is now COMPLETE — every Tier-1 task accepts ``seed`` —
-# so this is empty and the guardrail is zero-tolerance. It may only ever be
-# extended with a NEW genuine violator pending its fix; prefer fixing instead.
-KNOWN_NO_SEED_RESET = frozenset()
+# P1 cleanup targets: Tier-1 task files whose ``reset`` override is not substitutable for the base
+# signature. The contract is now COMPLETE — every Tier-1 task accepts states/env_ids/seed — so this
+# is empty and the guardrail is zero-tolerance. It may only ever be extended with a NEW genuine
+# violator pending its fix; prefer fixing instead.
+KNOWN_NONCONFORMANT_RESET = frozenset()
 
 # The BaseTaskEnv contract says tasks should NOT override step()/close() — action
 # transforms belong in a pre-physics action hook, teardown in close_callback. These
@@ -144,15 +172,49 @@ def _is_tier3(rel_path: str, class_name: str) -> bool:
     return "/_native/" in p or "_passthrough" in rel_path
 
 
-def _reset_lacks_seed(fn: ast.FunctionDef) -> bool:
+def _reset_violations(fn: ast.FunctionDef) -> list[str]:
+    """Reasons ``fn`` is not substitutable for ``reset(states=None, env_ids=None, seed=None)``.
+
+    Three ways an override breaks a caller of the base signature:
+
+    1. it does not accept a contract parameter at all (``reset(states=...)`` → TypeError);
+    2. it accepts them positionally in a different order (a positional caller silently binds the
+       wrong value — worse than a TypeError, because it corrupts instead of failing);
+    3. it adds a parameter of its own with no default (``reset(states=...)`` → TypeError for the
+       missing argument).
+    """
     a = fn.args
-    names = {p.arg for p in (*a.posonlyargs, *a.args, *a.kwonlyargs)}
-    return "seed" not in names and a.kwarg is None  # no seed= and no **kwargs
+    positional = [p.arg for p in (*a.posonlyargs, *a.args)][1:]  # drop self
+    kwonly = [p.arg for p in a.kwonlyargs]
+    names = [*positional, *kwonly]
+    bad: list[str] = []
+
+    # (1) accepted at all? **kwargs absorbs anything, so it satisfies the contract.
+    if a.kwarg is None:
+        missing = [p for p in _CONTRACT_PARAMS if p not in names]
+        if missing:
+            bad.append(f"does not accept {', '.join(missing)}")
+
+    # (2) contract params that are positional must keep the base's relative order.
+    ordered = [p for p in positional if p in _CONTRACT_PARAMS]
+    if ordered != [p for p in _CONTRACT_PARAMS if p in ordered]:
+        bad.append(f"positional order is {tuple(ordered)}, must follow {_CONTRACT_PARAMS}")
+
+    # (3) any extra parameter must have a default (positional defaults bind to the tail).
+    n_pos_defaults = len(a.defaults)
+    required_positional = positional[: len(positional) - n_pos_defaults]
+    required_kwonly = [p.arg for p, d in zip(a.kwonlyargs, a.kw_defaults) if d is None]
+    extra_required = [p for p in (*required_positional, *required_kwonly) if p not in _CONTRACT_PARAMS]
+    if extra_required:
+        bad.append(f"adds required parameter(s) {', '.join(extra_required)} (give them defaults)")
+
+    return bad
 
 
-def _all_violators() -> set[str]:
+def _all_violators() -> dict[str, list[str]]:
+    """Tier-1 task files whose ``reset`` override is not substitutable → why."""
     graph = _build_class_graph()
-    out: set[str] = set()
+    out: dict[str, list[str]] = {}
     for path in _TASKS.rglob("*.py"):
         rel = path.relative_to(_TASKS).as_posix()
         try:
@@ -163,12 +225,10 @@ def _all_violators() -> set[str]:
             if _is_tier3(rel, cls.name) or not _in_contract(cls.name, graph):
                 continue
             for fn in cls.body:
-                if (
-                    isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
-                    and fn.name == "reset"
-                    and _reset_lacks_seed(fn)
-                ):
-                    out.add(rel)
+                if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)) and fn.name == "reset":
+                    bad = _reset_violations(fn)
+                    if bad:
+                        out.setdefault(rel, []).extend(f"{cls.name}.reset {b}" for b in bad)
     return out
 
 
@@ -191,40 +251,65 @@ def _files_overriding(method: str) -> set[str]:
 
 
 @pytest.mark.general
-def test_no_new_reset_without_seed():
-    """No Tier-1 task may add a ``reset`` override that drops ``seed`` (ratchet)."""
-    new = sorted(_all_violators() - KNOWN_NO_SEED_RESET)
+def test_no_new_nonconformant_reset():
+    """No Tier-1 task may add a ``reset`` override that is not substitutable for the base (ratchet).
+
+    Covers all three contract parameters. ``states`` is the one that bit us: the IL and VLA eval
+    runners call ``env.reset(states=...)`` unconditionally, so an override that drops it turns
+    every evaluation on that task into a TypeError.
+    """
+    violators = _all_violators()
+    new = sorted(set(violators) - KNOWN_NONCONFORMANT_RESET)
+    detail = "\n  ".join(f"{rel}: {'; '.join(violators[rel])}" for rel in new)
     assert not new, (
-        "These Tier-1 task files override reset() without a seed parameter, breaking "
-        "the env.reset(seed=) contract. Add seed=None and forward it to super().reset:\n  " + "\n  ".join(new)
+        "These Tier-1 task files override reset() incompatibly with the base contract "
+        "reset(states=None, env_ids=None, seed=None). Accept all three (extra params go last, with "
+        "defaults) and forward them to super().reset:\n  " + detail
     )
 
 
 @pytest.mark.general
-def test_reset_seed_allowlist_has_no_stale_entries():
+def test_reset_allowlist_has_no_stale_entries():
     """Allowlisted files must still be violators — forces the list to shrink."""
-    stale = sorted(KNOWN_NO_SEED_RESET - _all_violators())
+    stale = sorted(KNOWN_NONCONFORMANT_RESET - set(_all_violators()))
     assert not stale, (
-        "These files no longer violate the reset(seed) contract — remove them from "
-        "KNOWN_NO_SEED_RESET:\n  " + "\n  ".join(stale)
+        "These files no longer violate the reset() contract — remove them from "
+        "KNOWN_NONCONFORMANT_RESET:\n  " + "\n  ".join(stale)
     )
 
 
 @pytest.mark.general
-def test_unified_bases_accept_seed():
-    """The fixed family base classes must keep accepting seed (regression guard)."""
+def test_unified_bases_honor_reset_contract():
+    """The fixed family bases/tasks must keep the full reset signature (regression guard)."""
     regressed = []
     for rel in sorted(_FIXED_BASES):
         tree = ast.parse((_TASKS / rel).read_text(encoding="utf-8"))
         for cls in (n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)):
             for fn in cls.body:
-                if (
-                    isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
-                    and fn.name == "reset"
-                    and _reset_lacks_seed(fn)
-                ):
-                    regressed.append(rel)
-    assert not regressed, f"Base classes regressed to reset() without seed: {sorted(set(regressed))}"
+                if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)) and fn.name == "reset":
+                    regressed += [f"{rel}: {cls.name}.reset {b}" for b in _reset_violations(fn)]
+    assert not regressed, "Base classes regressed off the reset contract:\n  " + "\n  ".join(sorted(regressed))
+
+
+@pytest.mark.general
+@pytest.mark.parametrize(
+    ("sig", "conformant"),
+    [
+        ("def reset(self, states=None, env_ids=None, seed=None): ...", True),
+        # SimplerEnv: extra episode-spec param, after the contract's three, with a default.
+        ("def reset(self, states=None, env_ids=None, seed=0, options=None): ...", True),
+        ("def reset(self, states=None, env_ids=None, **kwargs): ...", True),  # **kwargs absorbs seed
+        ("def reset(self, env_ids=None, seed=None): ...", False),  # legged-robot bases, pre-fix
+        ("def reset(self, env_ids=None, options=None, seed=0): ...", False),  # SimplerEnv, pre-fix
+        ("def reset(self, env_ids=None, states=None, seed=None): ...", False),  # swapped positionals
+        # extra param with no default: reset(states=...) would TypeError on the missing argument
+        ("def reset(self, states=None, env_ids=None, seed=None, *, options): ...", False),
+    ],
+)
+def test_reset_violation_checker(sig, conformant):
+    """The checker itself — it must reject exactly the signatures the seed-only guardrail let pass."""
+    fn = ast.parse(sig).body[0]
+    assert (not _reset_violations(fn)) is conformant
 
 
 @pytest.mark.general


### PR DESCRIPTION
BaseTaskEnv.reset(states=None, env_ids=None, seed=None) is the contract every task must be
substitutable for, but eight Tier-1 overrides dropped `states`: the two legged-robot bases
(humanoid, beyondmimic) reimplemented reset without it, and the six SimplerEnv tasks took
`options` in its place.

The IL and VLA evaluation runners pass `states` unconditionally — default_runner calls
env.reset(states=init_states[...]) to replay a demo's initial states, and the OpenVLA, SmolVLA
and pi0 eval loops do the same. Because `--task` is a free-form string, nothing stopped a user
from pairing a VLA with a SimplerEnv task — the canonical pairing for that benchmark — and doing
so died immediately with `TypeError: reset() got an unexpected keyword argument 'states'`. The
same TypeError hit any IL evaluation on the humanoid or beyondmimic bases.

All eight now accept states/env_ids/seed in the base's order. The legged-robot bases apply
caller-supplied states in place of their scripted initial states. The SimplerEnv tasks keep
`options` — it carries the episode spec (object/robot init options, episode id) that the gym
adapter feeds them, so dropping it would have silently discarded per-episode setup — but it
moves after the contract's three parameters and keeps its default. External states are applied
on top of the scripted layout, and the settle-derived quantities the success checkers key off
(object height, object poses, bbox extents) are re-derived from the applied states rather than
left describing a layout that was overwritten.

The guardrail that should have caught this (tests/test_task_reset_seed_contract.py) only looked
for a `seed` parameter, so all eight sailed through it — that is why they rotted. It now checks
full substitutability: every contract parameter is accepted, positional order matches the base
(a swapped positional binds the wrong value, which corrupts rather than raises), and an override
may not add a required parameter of its own. Extra parameters like SimplerEnv's `options` remain
allowed after the contract's three, with defaults. The ratchet is zero-tolerance, so this class
of drift cannot recur.

Review: independently reviewed against current main (verdict MERGE AS-IS); rebased, re-verified: 14 passed in 6.72s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw