### PR TITLE
fix(rl): make FastTD3 configs inherit from base.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ release.
 
 - `g1_feet` robot cfg crashed at import (wrong `BaseActuatorCfg` keywords) and `unitree_dex3_1` had a degenerate thumb joint limit; a config validation test now guards both.
 - Eight Tier-1 task `reset` overrides (humanoid, beyondmimic, six SimplerEnv tasks) dropped `states=`, so `env.reset(states=...)` from the IL/VLA eval runners raised `TypeError`; the contract test now checks full signature substitutability.
+- FastTD3: the nine stub configs that say `# Inherits from base.yaml` now actually inherit (`load_config` deep-merges over `configs/base.yaml`; previously `float(None)` at startup); `mjx_walk.yaml` `headless: flase` typo.
 - Native LIBERO `Open`/`Close`/`TurnOn`/`TurnOff` predicates always evaluated False on
   mujoco >= 3.x (`numpy.int32 in (mjtJoint...)` membership).
 - `get_started/multiple_cameras.py` passed a removed `ScenarioCfg` kwarg.

--- a/roboverse_learn/rl/fast_td3/configs/mjx_walk.yaml
+++ b/roboverse_learn/rl/fast_td3/configs/mjx_walk.yaml
@@ -9,7 +9,7 @@ robots: ["h1"]
 task: "walk"
 decimation: 10
 train_or_eval: "train"
-headless: flase
+headless: false
 
 # -------------------------------------------------------------------------------
 # Seeds & Device

--- a/roboverse_learn/rl/fast_td3/train.py
+++ b/roboverse_learn/rl/fast_td3/train.py
@@ -1,35 +1,64 @@
 from __future__ import annotations
 
+import argparse
 import os
 import random
 import sys
 import time
 from typing import Any
+
 import yaml
-import argparse
+
+
+def _deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``override`` onto ``base``; ``override`` wins on key conflicts."""
+    merged = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
 
 def load_config(config_path: str) -> dict[str, Any]:
-    """Load configuration from YAML file."""
-    with open(config_path, 'r') as f:
-        config = yaml.safe_load(f)
+    """Load a FastTD3 YAML config, layered on top of ``configs/base.yaml``.
+
+    Every task config inherits from ``base.yaml`` (task keys override the base defaults), so a
+    per-task file only needs to declare what differs. ``base.yaml`` itself loads unchanged.
+    """
+    with open(config_path) as f:
+        config = yaml.safe_load(f) or {}
+
+    base_path = os.path.join(os.path.dirname(os.path.abspath(config_path)), "base.yaml")
+    if os.path.abspath(config_path) != base_path and os.path.exists(base_path):
+        with open(base_path) as f:
+            base_config = yaml.safe_load(f) or {}
+        config = _deep_merge(base_config, config)
     return config
+
 
 def get_config():
     """Get configuration with command line argument support."""
-    parser = argparse.ArgumentParser(description='FastTD3 Training')
-    parser.add_argument('--config', type=str, default='track.yaml',
-                       help='YAML configuration file name (will be loaded from configs/ directory)')
+    parser = argparse.ArgumentParser(description="FastTD3 Training")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="track.yaml",
+        help="YAML configuration file name (will be loaded from configs/ directory)",
+    )
     args = parser.parse_args()
 
     # Get the directory of the current script
     script_dir = os.path.dirname(os.path.abspath(__file__))
-    configs_dir = os.path.join(script_dir, 'configs')
+    configs_dir = os.path.join(script_dir, "configs")
     config_path = os.path.join(configs_dir, args.config)
 
     if not os.path.exists(config_path):
         raise FileNotFoundError(f"Configuration file not found: {config_path}")
 
     return load_config(config_path)
+
 
 # Load configuration
 CONFIG = get_config()
@@ -59,6 +88,7 @@ import torch
 torch.set_float32_matmul_precision("high")
 
 import inspect
+
 import numpy as np
 import torch
 import torch.nn.functional as F
@@ -68,10 +98,10 @@ from tensordict import TensorDict
 from torch import optim
 from torch.amp import GradScaler, autocast
 
-from roboverse_learn.rl.fast_td3.fttd3_module import Actor, Critic, EmpiricalNormalization, SimpleReplayBuffer
 from metasim.scenario.cameras import PinholeCameraCfg
 from metasim.task.registry import get_task_class
 from roboverse_learn.rl.episode_tracker import EpisodeTracker
+from roboverse_learn.rl.fast_td3.fttd3_module import Actor, Critic, EmpiricalNormalization, SimpleReplayBuffer
 
 
 def cpu_state(state_dict):
@@ -103,14 +133,10 @@ def save_params(
         "qnet_state_dict": cpu_state(get_ddp_state_dict(qnet)),
         "qnet_target_state_dict": cpu_state(get_ddp_state_dict(qnet_target)),
         "obs_normalizer_state": (
-            cpu_state(obs_normalizer.state_dict())
-            if hasattr(obs_normalizer, "state_dict")
-            else None
+            cpu_state(obs_normalizer.state_dict()) if hasattr(obs_normalizer, "state_dict") else None
         ),
         "critic_obs_normalizer_state": (
-            cpu_state(critic_obs_normalizer.state_dict())
-            if hasattr(critic_obs_normalizer, "state_dict")
-            else None
+            cpu_state(critic_obs_normalizer.state_dict()) if hasattr(critic_obs_normalizer, "state_dict") else None
         ),
         "config": config,  # Save configuration
         "global_step": global_step,
@@ -140,6 +166,7 @@ def main() -> None:
     # Import wandb if enabled
     if cfg("use_wandb"):
         import wandb
+
         if cfg("train_or_eval") == "train":
             wandb.init(
                 project=cfg("wandb_project", "fttd3_training"),
@@ -183,6 +210,7 @@ def main() -> None:
     if not cfg("headless"):
         try:
             from metasim.utils.viser.viser_env_wrapper import TaskViserWrapper
+
             envs = TaskViserWrapper(envs)
         except ImportError:
             log.warning("Viser not available, skipping visualization wrapper")

--- a/tests/test_fast_td3_config_inheritance.py
+++ b/tests/test_fast_td3_config_inheritance.py
@@ -1,0 +1,98 @@
+"""Regression tests for FastTD3 config loading and ``base.yaml`` inheritance.
+
+Nine task configs (``isaacgym_*`` and half the ``mjx_*``) ship as 3-4 key stubs that
+declare ``# Inherits from base.yaml`` but relied on an inheritance mechanism that did not
+exist, so every such run died at startup on ``float(cfg("gamma"))`` -> ``float(None)``.
+``configs/mjx_walk.yaml`` also had ``headless: flase``, which YAML parses as the truthy
+string ``"flase"`` rather than a bool. These tests load every shipped config through the
+*real* loader in ``train.py`` and assert each yields all keys ``train.py`` reads without a
+default, with correctly-typed values.
+
+``train.py`` cannot be imported wholesale (its module body imports torch/isaacgym, parses
+CLI args, and sets env vars at import time), so we extract just ``load_config`` and its
+helper from the source via AST and exec them in isolation -- this exercises the shipped
+loader code, not a reimplementation.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+yaml = pytest.importorskip("yaml")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TRAIN_PY = REPO_ROOT / "roboverse_learn" / "rl" / "fast_td3" / "train.py"
+CONFIG_DIR = REPO_ROOT / "roboverse_learn" / "rl" / "fast_td3" / "configs"
+
+
+def _train_source_tree() -> ast.Module:
+    if not TRAIN_PY.exists():
+        pytest.skip(f"train.py not found at {TRAIN_PY}")
+    return ast.parse(TRAIN_PY.read_text())
+
+
+def _load_real_loader():
+    """Return the actual ``load_config`` from train.py without importing the module body."""
+    tree = _train_source_tree()
+    wanted = {"_deep_merge", "load_config"}
+    funcs = [n for n in tree.body if isinstance(n, ast.FunctionDef) and n.name in wanted]
+    missing = wanted - {n.name for n in funcs}
+    if missing:
+        pytest.fail(f"train.py is missing expected loader function(s): {sorted(missing)}")
+    ns = {"os": os, "yaml": yaml, "Any": Any}
+    exec(compile(ast.Module(body=funcs, type_ignores=[]), str(TRAIN_PY), "exec"), ns)
+    return ns["load_config"]
+
+
+def _required_keys() -> set[str]:
+    """Keys train.py reads via ``cfg("key")`` with no default -> None would crash it."""
+    tree = _train_source_tree()
+    with_default: set[str] = set()
+    all_keys: set[str] = set()
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "cfg"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            key = node.args[0].value
+            all_keys.add(key)
+            if len(node.args) > 1:
+                with_default.add(key)
+    required = all_keys - with_default
+    assert "gamma" in required, "expected gamma to be a required (no-default) config key"
+    return required
+
+
+ALL_CONFIGS = sorted(CONFIG_DIR.glob("*.yaml")) if CONFIG_DIR.exists() else []
+
+
+def test_configs_present():
+    assert ALL_CONFIGS, f"no FastTD3 configs found under {CONFIG_DIR}"
+
+
+@pytest.mark.parametrize("config_path", ALL_CONFIGS, ids=lambda p: p.name)
+def test_config_has_all_required_keys(config_path: Path):
+    load_config = _load_real_loader()
+    required = _required_keys()
+
+    cfg = load_config(str(config_path))
+
+    missing = sorted(required - set(cfg))
+    assert not missing, f"{config_path.name} is missing required keys after loading: {missing}"
+
+    # gamma feeds float(cfg("gamma")); a stub without it (or a non-numeric) crashes training.
+    assert isinstance(cfg["gamma"], float), f"{config_path.name}: gamma should be float, got {cfg['gamma']!r}"
+
+    # headless must be a real bool -- the 'flase' typo made it the truthy string "flase".
+    assert isinstance(cfg["headless"], bool), (
+        f"{config_path.name}: headless should be bool, got {type(cfg['headless']).__name__} {cfg['headless']!r}"
+    )


### PR DESCRIPTION
Nine FastTD3 task configs (configs/isaacgym_run|stand|walk.yaml and
configs/mjx_run|stand|crawl|sit|slide|stair.yaml) shipped as 3-4 key stubs whose only
guidance was a "# Inherits from base.yaml" comment. No inheritance mechanism existed:
load_config did a bare yaml.safe_load, so those files were dead on arrival. Every such
run crashed at startup on GAMMA = float(cfg("gamma")) because gamma was absent and
cfg("gamma") returned None, giving float(None) -> TypeError before any training began.

Implement the advertised inheritance in the loader: load configs/base.yaml first, then
deep-merge the selected task file on top (task keys win). base.yaml and configs that
already carry the full key set load identically, since the merge only backfills keys they
do not override. This is the minimal change that makes every shipped config load and keeps
base.yaml the single source of truth for defaults.

Also fix configs/mjx_walk.yaml, which had "headless: flase" -- a typo YAML parses as the
truthy string "flase", silently forcing headless on regardless of intent -- to a real
boolean.

Add tests/test_fast_td3_config_inheritance.py, which loads every shipped config through the
real loader (extracted from train.py via AST, since the module body has import-time side
effects) and asserts each yields all keys train.py reads without a default, with gamma a
float and headless a bool.

Review: independently reviewed against current main (verdict MERGE AS-IS); rebased, re-verified: 28 passed, 1 skipped in 0.38s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw