### PR TITLE
fix(il): validate the deployed policy in eval() mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ release.
 - `g1_feet` robot cfg crashed at import (wrong `BaseActuatorCfg` keywords) and `unitree_dex3_1` had a degenerate thumb joint limit; a config validation test now guards both.
 - Eight Tier-1 task `reset` overrides (humanoid, beyondmimic, six SimplerEnv tasks) dropped `states=`, so `env.reset(states=...)` from the IL/VLA eval runners raised `TypeError`; the contract test now checks full signature substitutability.
 - FastTD3: the nine stub configs that say `# Inherits from base.yaml` now actually inherit (`load_config` deep-merges over `configs/base.yaml`; previously `float(None)` at startup); `mjx_walk.yaml` `headless: flase` typo.
+- IL `DefaultRunner`: validation loss is computed on the deployed policy (EMA model in `eval()` mode) instead of the train-mode raw model.
 - Native LIBERO `Open`/`Close`/`TurnOn`/`TurnOff` predicates always evaluated False on
   mujoco >= 3.x (`numpy.int32 in (mjtJoint...)` membership).
 - `get_started/multiple_cameras.py` passed a removed `ScenarioCfg` kwarg.

--- a/roboverse_learn/il/runners/default_runner.py
+++ b/roboverse_learn/il/runners/default_runner.py
@@ -4,8 +4,6 @@ import os
 import pathlib
 import random
 import time
-from omegaconf import OmegaConf
-from torch.utils.data import DataLoader
 
 import hydra
 import imageio.v2 as iio
@@ -14,14 +12,16 @@ import torch
 import tqdm
 import wandb
 from loguru import logger as log
+from omegaconf import OmegaConf
+from torch.utils.data import DataLoader
 
+from metasim.randomization import DomainRandomizationManager, DRConfig
 from metasim.scenario.cameras import PinholeCameraCfg
+from metasim.task.registry import get_task_class
 from metasim.utils.demo_util import get_traj
 from metasim.utils.setup_util import get_robot
-from metasim.task.registry import get_task_class
-from metasim.randomization import DomainRandomizationManager, DRConfig
-from roboverse_learn.il.utils.ema_model import EMAModel
 from roboverse_learn.il.runners.base_runner import BaseRunner
+from roboverse_learn.il.utils.ema_model import EMAModel
 from roboverse_learn.il.utils.json_logger import JsonLogger
 from roboverse_learn.il.utils.lr_scheduler import get_scheduler
 from roboverse_learn.il.utils.pytorch_util import optimizer_to
@@ -133,9 +133,7 @@ class DefaultRunner(BaseRunner):
             self.ema_model = copy.deepcopy(self.model)
 
         # configure training state
-        self.optimizer = hydra.utils.instantiate(
-            cfg.train_config.optimizer, params=self.model.parameters()
-        )
+        self.optimizer = hydra.utils.instantiate(cfg.train_config.optimizer, params=self.model.parameters())
 
         # configure training state
         self.global_step = 0
@@ -160,9 +158,7 @@ class DefaultRunner(BaseRunner):
 
         # configure validation dataset
         val_dataset = dataset.get_validation_dataset()
-        val_dataloader = create_dataloader(
-            val_dataset, **cfg.train_config.val_dataloader
-        )
+        val_dataloader = create_dataloader(val_dataset, **cfg.train_config.val_dataloader)
 
         self.model.set_normalizer(normalizer)
         if cfg.train_config.training_params.use_ema:
@@ -173,9 +169,7 @@ class DefaultRunner(BaseRunner):
             cfg.train_config.training_params.lr_scheduler,
             optimizer=self.optimizer,
             num_warmup_steps=cfg.train_config.training_params.lr_warmup_steps,
-            num_training_steps=(
-                len(train_dataloader) * cfg.train_config.training_params.num_epochs
-            )
+            num_training_steps=(len(train_dataloader) * cfg.train_config.training_params.num_epochs)
             // cfg.train_config.training_params.gradient_accumulate_every,
             # pytorch assumes stepping LRScheduler every epoch
             # however huggingface diffusers steps it every batch
@@ -196,11 +190,9 @@ class DefaultRunner(BaseRunner):
                 config=OmegaConf.to_container(cfg, resolve=True),
                 **cfg.logging,
             )
-            wandb.config.update(
-                {
-                    "output_dir": self.output_dir,
-                }
-            )
+            wandb.config.update({
+                "output_dir": self.output_dir,
+            })
 
         # device transfer
         device = torch.device(cfg.train_config.training_params.device)
@@ -244,18 +236,11 @@ class DefaultRunner(BaseRunner):
                             train_sampling_batch = batch
 
                         raw_loss = self.model.compute_loss(batch)
-                        loss = (
-                            raw_loss
-                            / cfg.train_config.training_params.gradient_accumulate_every
-                        )
+                        loss = raw_loss / cfg.train_config.training_params.gradient_accumulate_every
                         loss.backward()
 
                         # step optimizer
-                        if (
-                            self.global_step
-                            % cfg.train_config.training_params.gradient_accumulate_every
-                            == 0
-                        ):
+                        if self.global_step % cfg.train_config.training_params.gradient_accumulate_every == 0:
                             self.optimizer.step()
                             self.optimizer.zero_grad()
                             lr_scheduler.step()
@@ -283,9 +268,7 @@ class DefaultRunner(BaseRunner):
                             json_logger.log(step_log)
                             self.global_step += 1
 
-                        if (
-                            cfg.train_config.training_params.max_train_steps is not None
-                        ) and batch_idx >= (
+                        if (cfg.train_config.training_params.max_train_steps is not None) and batch_idx >= (
                             cfg.train_config.training_params.max_train_steps - 1
                         ):
                             break
@@ -319,12 +302,14 @@ class DefaultRunner(BaseRunner):
                         ) as tepoch:
                             for batch_idx, batch in enumerate(tepoch):
                                 batch = dataset.postprocess(batch, device)
-                                loss = self.model.compute_loss(batch)
+                                # Validate the model that is actually deployed at eval time
+                                # (``policy`` == ``self.ema_model`` when ``use_ema`` else
+                                # ``self.model``) and in the eval() mode set above, so val_loss
+                                # tracks the deployed policy and is epoch-comparable. Using
+                                # ``self.model`` here would score a train-mode, non-EMA model.
+                                loss = policy.compute_loss(batch)
                                 val_losses.append(loss.item())
-                                if (
-                                    cfg.train_config.training_params.max_val_steps
-                                    is not None
-                                ) and batch_idx >= (
+                                if (cfg.train_config.training_params.max_val_steps is not None) and batch_idx >= (
                                     cfg.train_config.training_params.max_val_steps - 1
                                 ):
                                     break
@@ -361,10 +346,7 @@ class DefaultRunner(BaseRunner):
                 ) == 0 or self.epoch + 1 >= cfg.train_config.training_params.num_epochs:
                     # checkpointing
                     save_name = pathlib.Path(self.cfg.dataset_config.zarr_path).stem
-                    self.save_checkpoint(
-                        cfg.checkpoint.save_root_dir
-                        + f"/checkpoints/{self.epoch + 1}.ckpt"
-                    )  # TODO
+                    self.save_checkpoint(cfg.checkpoint.save_root_dir + f"/checkpoints/{self.epoch + 1}.ckpt")  # TODO
 
                 # ========= eval end for this epoch ==========
                 policy.train()
@@ -409,7 +391,7 @@ class DefaultRunner(BaseRunner):
         )
 
         # Lighting setup
-        render_mode = getattr(args, 'render_mode', 'raytracing')
+        render_mode = getattr(args, "render_mode", "raytracing")
         if render_mode == "pathtracing":
             ceiling_main = 18000.0
             ceiling_corners = 8000.0
@@ -418,6 +400,7 @@ class DefaultRunner(BaseRunner):
             ceiling_corners = 5000.0
 
         from metasim.scenario.lights import DiskLightCfg, SphereLightCfg
+
         lights = [
             DiskLightCfg(
                 name="ceiling_main",
@@ -447,7 +430,7 @@ class DefaultRunner(BaseRunner):
             num_envs=args.num_envs,
             headless=args.headless,
             lights=lights,
-            cameras=[camera]
+            cameras=[camera],
         )
         device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
         tic = time.time()
@@ -455,9 +438,9 @@ class DefaultRunner(BaseRunner):
         robot = get_robot(args.robot)
 
         # Domain Randomization configuration
-        dr_level = getattr(args, 'level', 0)
-        dr_scene_mode = getattr(args, 'scene_mode', 0)
-        dr_seed = getattr(args, 'randomization_seed', None)
+        dr_level = getattr(args, "level", 0)
+        dr_scene_mode = getattr(args, "scene_mode", 0)
+        dr_seed = getattr(args, "randomization_seed", None)
 
         if not RANDOMIZATION_AVAILABLE:
             if dr_level > 0:
@@ -479,7 +462,7 @@ class DefaultRunner(BaseRunner):
                 scenario=scenario,
                 handler=env.handler,
                 init_states=None,
-                render_cfg=SimpleRenderCfg(mode=render_mode)
+                render_cfg=SimpleRenderCfg(mode=render_mode),
             )
             if dr_level > 0:
                 log.info(f"Domain Randomization enabled: level={dr_level}, scene_mode={dr_scene_mode}, seed={dr_seed}")
@@ -493,9 +476,7 @@ class DefaultRunner(BaseRunner):
         checkpoint = self.get_checkpoint_path()
         checkpoint = ckpt_path if ckpt_path is not None else checkpoint
         if checkpoint is None:
-            raise ValueError(
-                "No checkpoint found, please provide a valid checkpoint path."
-            )
+            raise ValueError("No checkpoint found, please provide a valid checkpoint path.")
         args.checkpoint_path = pathlib.Path(checkpoint)
         ckpt_name = args.checkpoint_path.name + "_" + time_str
         ckpt_name = f"{args.task}/{self.policy_name}/{args.robot}/{ckpt_name}"
@@ -512,14 +493,10 @@ class DefaultRunner(BaseRunner):
             subset=args.subset,
         )
 
-        action_set_steps = (
-            2 if policyRunner.policy_cfg.action_config.action_type == "ee" else 1
-        )
+        action_set_steps = 2 if policyRunner.policy_cfg.action_config.action_type == "ee" else 1
         # Data
         tic = time.time()
-        assert os.path.exists(env.traj_filepath), (
-            f"Trajectory file: {env.traj_filepath} does not exist."
-        )
+        assert os.path.exists(env.traj_filepath), f"Trajectory file: {env.traj_filepath} does not exist."
         init_states, all_actions, all_states = get_traj(env.traj_filepath, robot, env.handler)
         num_demos = len(init_states)
         toc = time.time()
@@ -557,9 +534,7 @@ class DefaultRunner(BaseRunner):
             max_demos = args.max_demo
         max_demos = min(max_demos, num_demos)
 
-        for demo_start_idx in range(
-            args.task_id_range_low, args.task_id_range_low + max_demos, num_envs
-        ):
+        for demo_start_idx in range(args.task_id_range_low, args.task_id_range_low + max_demos, num_envs):
             demo_end_idx = min(demo_start_idx + num_envs, num_demos)
             current_demo_idxs = list(range(demo_start_idx, demo_end_idx))
 
@@ -568,7 +543,8 @@ class DefaultRunner(BaseRunner):
                 for env_id, demo_idx in enumerate(current_demo_idxs):
                     log.info(f"[DP Eval] Episode {demo_idx}: Applying DR")
                     randomization_manager.apply_randomization(
-                        demo_idx=demo_idx, is_initial=(demo_start_idx == args.task_id_range_low))
+                        demo_idx=demo_idx, is_initial=(demo_start_idx == args.task_id_range_low)
+                    )
                     randomization_manager.update_positions_to_table(demo_idx=demo_idx, env_id=env_id)
                     randomization_manager.update_camera_look_at(env_id=env_id)
                     randomization_manager.apply_camera_randomization()
@@ -637,9 +613,7 @@ class DefaultRunner(BaseRunner):
                     f.write(f"Domain Randomization Level: {dr_level}\n")
                     f.write(f"Domain Randomization Scene Mode: {dr_scene_mode}\n")
                     f.write(f"Domain Randomization Seed: {dr_seed}\n")
-                    f.write(
-                        f"Cumulative Average Success Rate: {total_success / total_completed:.4f}\n"
-                    )
+                    f.write(f"Cumulative Average Success Rate: {total_success / total_completed:.4f}\n")
             log.info("Demo Indices: ", range(demo_start_idx, demo_end_idx))
             log.info("Num Envs: ", num_envs)
             log.info(f"SuccessOnce: {SuccessOnce}")
@@ -714,9 +688,7 @@ def create_dataloader(
     seed: int = 0,
 ):
     # print("create_dataloader_batch_size", batch_size)
-    batch_sampler = BatchSampler(
-        len(dataset), batch_size, shuffle=shuffle, seed=seed, drop_last=True
-    )
+    batch_sampler = BatchSampler(len(dataset), batch_size, shuffle=shuffle, seed=seed, drop_last=True)
 
     def collate(x):
         assert len(x) == 1

--- a/tests/test_default_runner_val_loss.py
+++ b/tests/test_default_runner_val_loss.py
@@ -1,17 +1,34 @@
-"""Regression: the IL val-loss reduction must accumulate floats, not 0-d tensors.
+"""Regressions for the IL per-epoch validation step in ``DefaultRunner.train``.
 
-The validation loop did ``val_losses.append(loss)`` (0-d CUDA tensors) then
-``torch.mean(torch.tensor(val_losses))`` — ``torch.tensor`` over a list of
-existing tensors emits a copy-construct UserWarning and is fragile for
-CUDA/grad tensors. The train loop already uses ``.item()`` + ``np.mean``; the fix
-makes the val loop consistent. The runner isn't importable/runnable here (needs a
-model + dataloader), so the loop wiring is pinned at the source level and the
-reduction pattern's warning-freeness is demonstrated directly.
+Two independent things are pinned here:
+
+1. **Reduction pattern** (original test): the val loop must accumulate python
+   floats (``loss.item()``) and average with ``np.mean``, not build
+   ``torch.tensor(list_of_0d_tensors)`` (warns/copies, fragile for CUDA/grad).
+
+2. **Model & mode** (this fix): the validation loss must be computed on the
+   model that is *actually deployed* at eval time and in ``eval()`` mode.
+   ``default_eval_runner.py`` loads ``ema_model`` when ``use_ema`` (else
+   ``model``); the train loop selects the same object into ``policy`` and calls
+   ``policy.eval()``. Validation previously called ``self.model.compute_loss``
+   instead of ``policy.compute_loss`` — so with the shipped ``use_ema=True``
+   default it scored the raw, non-EMA model that is never put in ``eval()``
+   (dropout active). ``val_loss`` thus neither tracked the deployed EMA policy
+   nor was epoch-comparable — a misleading model-selection signal.
+
+The IL runner isn't importable here (it needs ``omegaconf``/``hydra``/``zarr``
+which are absent), so the behavioral test extracts the real "eval for this
+epoch" region from the source and executes it against tiny stub models that
+record their ``.training`` flag at ``compute_loss`` time. This keeps the test
+bound to the shipped code: it fails on the pre-fix source and passes on the
+fixed source.
 """
 
 from __future__ import annotations
 
 import pathlib
+import textwrap
+import types
 import warnings
 
 import numpy as np
@@ -21,6 +38,9 @@ import torch
 _RUNNER = pathlib.Path(__file__).resolve().parents[1] / "roboverse_learn" / "il" / "runners" / "default_runner.py"
 
 
+# --------------------------------------------------------------------------- #
+# Reduction pattern (unchanged behavior)
+# --------------------------------------------------------------------------- #
 @pytest.mark.general
 def test_val_loss_reduction_uses_item_and_npmean():
     src = _RUNNER.read_text()
@@ -41,3 +61,117 @@ def test_item_then_npmean_is_warning_free_and_correct():
         warnings.simplefilter("error")  # any warning becomes an error
         result = np.mean([loss.item() for loss in losses])
     assert result == 2.0
+
+
+# --------------------------------------------------------------------------- #
+# Model & mode (this fix): validate the deployed model in eval() mode.
+# --------------------------------------------------------------------------- #
+class _StubModel(torch.nn.Module):
+    """Records ``self.training`` every time ``compute_loss`` is called."""
+
+    def __init__(self):
+        super().__init__()
+        self.recorded_training_flags: list[bool] = []
+
+    def compute_loss(self, batch):
+        self.recorded_training_flags.append(self.training)
+        return torch.tensor(0.0)
+
+    def predict_action(self, obs_dict):
+        # Unused in tests: the sample_every branch is skipped.
+        return {"action_pred": torch.zeros(1), "action": torch.zeros(1)}
+
+
+def _extract_eval_region() -> str:
+    """Return the dedented ``# eval for this epoch ... policy.train()`` block from the runner."""
+    lines = _RUNNER.read_text().splitlines()
+    start = next(i for i, ln in enumerate(lines) if "# ========= eval for this epoch" in ln)
+    end = next(i for i, ln in enumerate(lines) if ln.strip() == "policy.train()")
+    return textwrap.dedent("\n".join(lines[start : end + 1]))
+
+
+def _run_eval_region(*, use_ema: bool, n_val_batches: int = 3, max_val_steps: int = 2):
+    """Exec the real eval/validation region with stub models; return the stub ``self``.
+
+    Epoch/period values are chosen so only the *validation* branch runs
+    (``sample_every`` and ``checkpoint`` branches are skipped), keeping the
+    stub surface minimal.
+    """
+    params = types.SimpleNamespace(
+        use_ema=use_ema,
+        val_every=1,  # epoch(2) % 1 == 0  -> run validation
+        sample_every=4,  # epoch(2) % 4 != 0  -> skip sampling
+        checkpoint_every=5,  # (epoch+1=3) % 5 != 0 -> skip checkpoint
+        num_epochs=100,  # epoch+1 < num_epochs -> skip checkpoint
+        max_val_steps=max_val_steps,
+        tqdm_interval_sec=0.0,
+    )
+    cfg = types.SimpleNamespace(train_config=types.SimpleNamespace(training_params=params))
+    stub_self = types.SimpleNamespace(
+        model=_StubModel(),
+        ema_model=_StubModel(),
+        epoch=2,
+        cfg=cfg,
+        output_dir=".",
+        save_checkpoint=lambda *a, **k: None,
+    )
+    dataset = types.SimpleNamespace(postprocess=lambda batch, device: batch)
+    val_dataloader = [object() for _ in range(n_val_batches)]
+
+    ns = {
+        "torch": torch,
+        "np": np,
+        "tqdm": __import__("tqdm"),
+        "self": stub_self,
+        "cfg": cfg,
+        "dataset": dataset,
+        "device": torch.device("cpu"),
+        "val_dataloader": val_dataloader,
+        "step_log": {},
+    }
+    # Runs the vetted eval/validation region extracted from the repo source.
+    exec(compile(_extract_eval_region(), "<eval_region>", "exec"), ns)
+    return stub_self, ns
+
+
+@pytest.mark.general
+def test_validation_runs_on_deployed_ema_model_in_eval_mode():
+    """use_ema=True (shipped default): val runs on ema_model, in eval(), restored to train().
+
+    Pre-fix this FAILS: validation called ``self.model.compute_loss`` (train mode,
+    non-deployed) so ``ema_model`` recorded nothing and ``self.model`` recorded
+    ``True`` flags.
+    """
+    stub_self, ns = _run_eval_region(use_ema=True, max_val_steps=2)
+
+    ema_flags = stub_self.ema_model.recorded_training_flags
+    model_flags = stub_self.model.recorded_training_flags
+
+    # (a) validation loss is computed on the DEPLOYED model (ema_model), not self.model
+    assert len(ema_flags) == 2, "validation must run on the deployed EMA model"
+    assert model_flags == [], "the raw non-EMA self.model must NOT be used for validation"
+
+    # (b) that model is in eval() mode during validation ...
+    assert ema_flags == [False, False], "deployed model must be in eval() mode during validation"
+    # ... and restored to train() afterward.
+    assert stub_self.ema_model.training is True, "deployed model must be back in train() after eval"
+
+    # a val_loss was actually produced
+    assert "val_loss" in ns["step_log"]
+
+
+@pytest.mark.general
+def test_validation_uses_eval_mode_when_no_ema():
+    """use_ema=False: policy is self.model; it must validate in eval() and restore train().
+
+    Guards against a fix that eval-then-leaves the training model in eval mode.
+    """
+    stub_self, ns = _run_eval_region(use_ema=False, max_val_steps=2)
+
+    model_flags = stub_self.model.recorded_training_flags
+    assert len(model_flags) == 2, "validation must run on self.model when use_ema=False"
+    assert model_flags == [False, False], "model must be in eval() mode during validation"
+    assert stub_self.model.training is True, "the training model must be restored to train() after eval"
+    # ema_model is unused in this branch
+    assert stub_self.ema_model.recorded_training_flags == []
+    assert "val_loss" in ns["step_log"]


### PR DESCRIPTION
DefaultRunner.train computed the per-epoch validation loss on the wrong model in
the wrong mode. It selected the deployed policy into `policy` (== ema_model when
use_ema, else model) and called `policy.eval()`, but the validation loop then
called `self.model.compute_loss(batch)`. Under the shipped use_ema=True default
this scored the raw, non-EMA model, which is never put in eval() — its
FlowTransformer dropout (0.1) stayed active. So val_loss neither tracked the EMA
policy that default_eval_runner.py actually loads and deploys, nor was it
epoch-comparable (dropout noise): a misleading model-selection signal. The
sample_every action-MSE block already used `policy` (EMA, eval mode), so the file
was internally inconsistent. Weights were not corrupted — the vision encoder uses
GroupNorm (use_group_norm: True everywhere), so there are no running stats to
pollute; the impact is purely the validation/selection metric.

Switch validation to `policy.compute_loss(batch)`. `policy.eval()` (set above) and
`policy.train()` (restored after) already toggle the correct object in both
branches: use_ema=True validates the eval-mode EMA model and leaves self.model in
train() untouched; use_ema=False keeps validating self.model, now consistently.

A prior review flagged this but only applied a cosmetic np.mean/.item() reduction
change, not the model/mode fix.

The IL runner isn't importable in CI (no omegaconf/hydra/zarr), so the regression
test extracts the real "eval for this epoch" source region and execs it against
stub models that record their .training flag at compute_loss time, asserting the
deployed model is used, in eval() during validation, and back in train() after.

Review: independently reviewed against current main (verdict MERGE AS-IS); rebased, re-verified: 4 passed in 1.02s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw