### PR TITLE
fix(managers): return (obs, info) from ManagerBasedRVEnv.reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ release.
 - Eight Tier-1 task `reset` overrides (humanoid, beyondmimic, six SimplerEnv tasks) dropped `states=`, so `env.reset(states=...)` from the IL/VLA eval runners raised `TypeError`; the contract test now checks full signature substitutability.
 - FastTD3: the nine stub configs that say `# Inherits from base.yaml` now actually inherit (`load_config` deep-merges over `configs/base.yaml`; previously `float(None)` at startup); `mjx_walk.yaml` `headless: flase` typo.
 - IL `DefaultRunner`: validation loss is computed on the deployed policy (EMA model in `eval()` mode) instead of the train-mode raw model.
+- `ManagerBasedRVEnv.reset` returned `None` (Gym wrappers expect `(obs, info)`), had no `num_obs`/`observation_space`, and mjlab cartpole reset noise ignored `set_seed`; all three fixed with a gym-reset regression test.
 - Native LIBERO `Open`/`Close`/`TurnOn`/`TurnOff` predicates always evaluated False on
   mujoco >= 3.x (`numpy.int32 in (mjtJoint...)` membership).
 - `get_started/multiple_cameras.py` passed a removed `ScenarioCfg` kwarg.

--- a/roboverse_learn/managers/manager_based_rv_env.py
+++ b/roboverse_learn/managers/manager_based_rv_env.py
@@ -32,10 +32,13 @@ from __future__ import annotations
 
 import math
 from copy import deepcopy
-from dataclasses import asdict, fields, is_dataclass
+from dataclasses import fields, is_dataclass
 from typing import Any, Sequence
 
+import numpy as np
 import torch
+from gymnasium import spaces
+from loguru import logger
 
 from metasim.scenario.scenario import ScenarioCfg
 from metasim.task.base import BaseTaskEnv
@@ -162,9 +165,7 @@ class ManagerBasedRVEnv(RLTaskEnv):
 
         # Initial states are computed by the subclass (which knows the
         # robot's default joint pose etc.); cache as tensor state.
-        self._initial_states = list_state_to_tensor(
-            self.handler, self._get_initial_states(), self.device
-        )
+        self._initial_states = list_state_to_tensor(self.handler, self._get_initial_states(), self.device)
 
         # First reset must happen after managers are wired so we get a
         # valid observation tensor for the wrapper's lazy obs_buf path.
@@ -336,18 +337,41 @@ class ManagerBasedRVEnv(RLTaskEnv):
     # env api
     # ------------------------------------------------------------------
 
-    def reset(self, env_ids: Sequence[int] | None = None, seed: int | None = None):
-        """Reset selected envs (or all).
+    def reset(
+        self, env_ids: Sequence[int] | None = None, seed: int | None = None
+    ) -> tuple[dict[str, torch.Tensor], Info]:
+        """Reset selected envs (or all) and return the post-reset ``(obs, info)``.
 
         ``seed`` is forwarded to the handler when supported, honoring the
         ``env.reset(seed=)`` contract (this base reimplements ``reset`` and does
         not call ``super().reset``). Without this, ``gym.make(...).reset(seed=)``
-        raised ``TypeError`` for every manager-based (mjlab v2) task.
+        raised ``TypeError`` for every manager-based (mjlab v2) task. A handler
+        without ``set_seed`` warns once instead of dropping the seed silently
+        (same warn-if-unsupported semantics as ``RLTaskEnv.reset``).
+
+        Returns:
+            obs: The per-group observation dict — the exact structure ``step``
+                returns as its first element, so a gym caller sees the same
+                observation type from ``reset`` and ``step``. (``RLTaskEnv``
+                returns a flat tensor because its ``step`` does too; this env's
+                obs is grouped, so its ``observation_space`` is a ``spaces.Dict``.)
+            info: ``self.extras`` — again the same object ``step`` returns as info.
+                The privileged observation the base surfaces under
+                ``info["privileged_observation"]`` is the ``critic`` entry of the
+                obs dict here (also exposed via the ``priv_obs_buf`` property).
         """
         if seed is not None:
             set_seed = getattr(self.handler, "set_seed", None)
             if callable(set_seed):
                 set_seed(seed)
+            elif not getattr(self, "_seed_unsupported_warned", False):
+                # Warn once per env, not per reset — RL training resets constantly.
+                logger.warning(
+                    f"{type(self).__name__}: handler {type(self.handler).__name__} does not "
+                    f"implement set_seed; reset(seed={seed}) is a no-op on the simulator side "
+                    f"and rollouts will not be reproducible."
+                )
+                self._seed_unsupported_warned = True
         if env_ids is None:
             env_ids = torch.arange(self.num_envs, dtype=torch.int64, device=self.device)
         elif not isinstance(env_ids, torch.Tensor):
@@ -363,6 +387,7 @@ class ManagerBasedRVEnv(RLTaskEnv):
         self._obs_buf = self._observation(self.handler.get_states(mode="tensor"))
         # Lazy: extras['observations'] keeps last obs around for rsl-rl
         self.extras["observations"] = self._obs_buf
+        return self._obs_buf, self.extras
 
     def _reset_idx(self, env_ids: torch.Tensor) -> None:
         """Per-env reset (set initial state, run reset events, zero buffers)."""
@@ -401,16 +426,12 @@ class ManagerBasedRVEnv(RLTaskEnv):
         # Log + zero per-term episode reward sums.
         max_ep_s = max(self.cfg.max_episode_length_s, 1e-6)
         for key, buf in self.episode_rewards.items():
-            self.extras["episode"][f"Episode_Reward/{key}"] = (
-                torch.mean(buf[env_ids]) / max_ep_s
-            )
+            self.extras["episode"][f"Episode_Reward/{key}"] = torch.mean(buf[env_ids]) / max_ep_s
             buf[env_ids] = 0.0
 
         # Log + leave term-dones — they get overwritten next step.
         for key, buf in self._term_dones.items():
-            self.extras["episode"][f"Episode_Termination/{key}"] = (
-                torch.count_nonzero(buf[env_ids]).item()
-            )
+            self.extras["episode"][f"Episode_Termination/{key}"] = torch.count_nonzero(buf[env_ids]).item()
 
         # Curriculum: each term receives env_ids and returns a scalar/dict.
         for name, (func, params) in self.curriculum_terms.items():
@@ -549,8 +570,7 @@ class ManagerBasedRVEnv(RLTaskEnv):
             if group_name == "critic":
                 return self._observation_group("policy", env_states)
             raise AttributeError(
-                f"cfg.observations has no group '{group_name}' "
-                f"(expected one of {self.cfg.observation_group_names})"
+                f"cfg.observations has no group '{group_name}' (expected one of {self.cfg.observation_group_names})"
             )
         parts = []
         for name in self._term_names(group):
@@ -597,6 +617,34 @@ class ManagerBasedRVEnv(RLTaskEnv):
                 return self._obs_buf["critic"]
             return self.obs_buf
         return self._obs_buf
+
+    @property
+    def num_obs(self) -> int:
+        """Width of the actor/policy observation group.
+
+        ``RLTaskEnv`` sets this in its ``__init__``, which this class bypasses
+        (managers must exist before the first ``_observation``), so it is derived
+        from the obs buffer instead. ``RLTaskEnv.observation_space`` reads it.
+        """
+        return int(self.obs_buf.shape[-1])
+
+    @property
+    def observation_space(self) -> spaces.Space:
+        """Dict space with one ``Box`` per configured observation group.
+
+        ``RLTaskEnv.observation_space`` is a single ``Box(num_obs,)`` because its
+        obs is one flat tensor. This env emits ``{group: tensor}`` from both
+        ``reset`` and ``step``, so the space that actually describes it is a
+        ``spaces.Dict``. Without this override the inherited property raised
+        ``AttributeError: 'num_obs'`` inside ``GymEnvWrapper.__init__``, i.e.
+        ``gym.make`` failed before a task was ever reset.
+        """
+        if self._observation_space is None:
+            self._observation_space = spaces.Dict({
+                name: spaces.Box(low=-np.inf, high=np.inf, shape=(int(tensor.shape[-1]),), dtype=np.float32)
+                for name, tensor in self._obs_buf.items()
+            })
+        return self._observation_space
 
     @property
     def max_episode_steps(self) -> int:

--- a/roboverse_pack/tasks/mjlab/cartpole_v2.py
+++ b/roboverse_pack/tasks/mjlab/cartpole_v2.py
@@ -84,7 +84,12 @@ def reset_cartpole(
     # MuJoCo path (single-env scene-MJCF): write to physics.data.qpos.
     if hasattr(env.handler, "physics"):
         physics = env.handler.physics
-        rng = np.random.default_rng()
+        # Draw from the *global* NumPy RNG. ``reset(seed=N)`` forwards to
+        # ``handler.set_seed``, which seeds ``np.random`` (plus ``random`` and
+        # torch) — a fresh ``np.random.default_rng()`` would ignore that seed, so
+        # the reset-noise here stayed unreproducible and ``reset(seed=N)`` was a
+        # silent no-op for this task despite the plumbing being in place.
+        rng = np.random
         with physics.reset_context():
             physics.data.qpos[0] = 0.0 + rng.uniform(*slider_pos_range)
             physics.data.qpos[1] = hinge_init + rng.uniform(*hinge_pos_range)

--- a/tests/test_manager_env_gym_reset.py
+++ b/tests/test_manager_env_gym_reset.py
@@ -1,0 +1,87 @@
+"""Regression: ``ManagerBasedRVEnv`` is reachable through the gym API.
+
+Two defects made every manager-based (mjlab v2) task unusable via ``gym.make``:
+
+* ``ManagerBasedRVEnv.reset`` set ``self._obs_buf`` and fell off the end, returning
+  ``None``. ``metasim.task.gym_registration`` does ``obs, info = task_env.reset(seed=seed)``,
+  which raised ``TypeError: cannot unpack non-iterable NoneType object``. The base
+  ``RLTaskEnv.reset`` returns ``(obs, info)``; the manager base must too.
+* ``ManagerBasedRVEnv`` bypasses ``RLTaskEnv.__init__`` (managers must be wired before the
+  first ``_observation``), so ``num_obs`` was never set and the inherited
+  ``observation_space`` raised ``AttributeError: 'num_obs'`` inside ``GymEnvWrapper.__init__``
+  — ``gym.make`` failed before a task was ever reset.
+
+Also guards the ``reset(seed=)`` contract end-to-end: the seed must reach the reset noise,
+not merely be forwarded into a handler whose RNG nobody draws from.
+
+Uses the cartpole scene-MJCF task on the MuJoCo backend (lightest manager-based task);
+skips without ``mujoco``.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+pytest.importorskip("mujoco")
+
+TASK = "mjlab.cartpole_balance_v2"
+
+
+@pytest.fixture(scope="module")
+def gym_env():
+    import gymnasium as gym
+
+    import roboverse_pack.tasks.mjlab  # noqa: F401  (registers the mjlab tasks)
+    from metasim.task.gym_registration import register_task_with_gym
+
+    env = gym.make(register_task_with_gym(TASK), simulator="mujoco", headless=True)
+    yield env
+    env.close()
+
+
+def test_gym_reset_returns_obs_and_info(gym_env):
+    """``gym.make(...).reset(seed=)`` unpacks — the TypeError regression."""
+    obs, info = gym_env.reset(seed=0)
+
+    assert isinstance(obs, dict) and obs, "reset must return the per-group observation dict"
+    for group in ("actor", "critic"):
+        assert isinstance(obs[group], torch.Tensor), f"obs['{group}'] must be a tensor"
+        assert obs[group].shape[0] == gym_env.unwrapped.task_env.num_envs
+    assert isinstance(info, dict)
+    assert "observations" in info, "info must carry the rsl-rl observation entry"
+
+
+def test_reset_obs_has_same_structure_as_step_obs(gym_env):
+    """A gym caller must see the same observation type from reset and step."""
+    reset_obs, _ = gym_env.reset(seed=0)
+    num_actions = gym_env.unwrapped.task_env.num_actions
+    step_obs, _, _, _, _ = gym_env.step(torch.zeros(1, num_actions))
+
+    assert sorted(reset_obs) == sorted(step_obs)
+    for group, tensor in reset_obs.items():
+        assert tensor.shape == step_obs[group].shape
+
+
+def test_observation_space_describes_the_returned_obs(gym_env):
+    """``observation_space`` must exist (gym.make reads it) and match the obs groups."""
+    from gymnasium import spaces
+
+    space = gym_env.observation_space
+    assert isinstance(space, spaces.Dict)
+
+    obs, _ = gym_env.reset(seed=0)
+    assert sorted(space.spaces) == sorted(obs)
+    for group, tensor in obs.items():
+        assert space[group].shape == (tensor.shape[-1],)
+
+
+def test_reset_seed_is_reproducible(gym_env):
+    """Equal seeds → identical reset state; different seeds → different reset state."""
+    first, _ = gym_env.reset(seed=7)
+    a = first["actor"].clone()
+    second, _ = gym_env.reset(seed=7)
+    assert torch.allclose(a, second["actor"]), "reset(seed=N) must reproduce the same initial state"
+
+    other, _ = gym_env.reset(seed=8)
+    assert not torch.allclose(a, other["actor"]), "a different seed must give a different reset state"


### PR DESCRIPTION
ManagerBasedRVEnv.reset() computed the post-reset observation, stored it in self._obs_buf,
and then fell off the end of the function — returning None. The base RLTaskEnv.reset returns
a 2-tuple (obs, info), and the gym bridge relies on that: metasim.task.gym_registration does
`obs, info = self.task_env.reset(seed=seed)` in both GymEnvWrapper.reset and
GymVectorEnvAdapter.reset. Every manager-based task therefore died with
"TypeError: cannot unpack non-iterable NoneType object" the moment it was reset through the
gym API, which made all of the mjlab-v2 tasks (cartpole balance/swingup, velocity go1/g1,
lift_cube_yam) unreachable that way — they inherit this reset and define no override. The
in-repo RSL-RL trainer never noticed, because RslRlEnvWrapper reads the obs_buf property
instead of the value reset() hands back.

reset() now returns (self._obs_buf, self.extras) — deliberately the same two objects step()
already returns as its observation and info, so a gym caller sees one consistent observation
type across reset and step. That observation is a per-group dict ({"actor": ..., "critic": ...}),
not the flat tensor RLTaskEnv returns, because this env's step() emits groups; the base's
info["privileged_observation"] is the "critic" entry here (also reachable via priv_obs_buf).

Reaching reset() through gym.make exposed a second break in the same contract. This class
bypasses RLTaskEnv.__init__ (managers have to be wired before the first _observation), so
num_obs was never assigned and the inherited observation_space property raised
"AttributeError: num_obs" inside GymEnvWrapper.__init__ — gym.make failed before a task was
ever reset, hiding the reset defect behind it. num_obs is now derived from the actor obs
buffer, and observation_space is a spaces.Dict of per-group Boxes, which is what these envs
actually return.

Finally, the seed added to reset() in 69046495 was still a no-op for cartpole: reset(seed=N)
forwards to handler.set_seed, which seeds the global numpy/random/torch RNGs, but the
cartpole reset event drew its joint noise from a fresh np.random.default_rng() that ignores
that seed — so consecutive reset(seed=7) calls produced different initial states. It now
draws from the global numpy RNG, and a handler without set_seed warns once instead of
dropping the seed silently, matching RLTaskEnv.reset.

tests/test_manager_env_gym_reset.py covers the whole path on the MuJoCo backend: gym.make,
reset unpacking, reset/step observation agreement, the observation space, and seed
reproducibility.

Review: independently reviewed against current main (verdict MERGE AS-IS); rebased, re-verified: 11 passed in 14.12s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw