### PR TITLE
fix(tasks): give the 2,648 robotless ManiSkill tasks their Franka arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ release.
 - FastTD3: the nine stub configs that say `# Inherits from base.yaml` now actually inherit (`load_config` deep-merges over `configs/base.yaml`; previously `float(None)` at startup); `mjx_walk.yaml` `headless: flase` typo.
 - IL `DefaultRunner`: validation loss is computed on the deployed policy (EMA model in `eval()` mode) instead of the train-mode raw model.
 - `ManagerBasedRVEnv.reset` returned `None` (Gym wrappers expect `(obs, info)`), had no `num_obs`/`observation_space`, and mjlab cartpole reset noise ignored `set_seed`; all three fixed with a gym-reset regression test.
+- ManiSkill task leaves declared `ScenarioCfg(objects=[...])` with no robot, so 2,648 registered tasks crashed with `IndexError` on reset; the family now defaults to `franka` (leaf-declared robots win) and raises a clear `ValueError` when no robot resolves.
 - Native LIBERO `Open`/`Close`/`TurnOn`/`TurnOff` predicates always evaluated False on
   mujoco >= 3.x (`numpy.int32 in (mjtJoint...)` membership).
 - `get_started/multiple_cameras.py` passed a removed `ScenarioCfg` kwarg.

--- a/roboverse_pack/tasks/maniskill/_dense_rl.py
+++ b/roboverse_pack/tasks/maniskill/_dense_rl.py
@@ -34,8 +34,12 @@ class DenseRLResetMixin:
     traj_filepath = None
 
     # Skip ManiskillBaseTask's demo-trajectory download — call BaseTaskEnv
-    # directly so the dense task doesn't depend on replay data.
-    def __init__(self, scenario, device=None) -> None:
+    # directly so the dense task doesn't depend on replay data. Still apply the
+    # family's default robot: bypassing ManiskillBaseTask.__init__ must not also
+    # bypass the robot fill-in, or _get_initial_states below would index robots[0]
+    # on an empty list.
+    def __init__(self, scenario=None, device=None) -> None:
+        scenario = self._apply_default_robots(scenario)
         BaseTaskEnv.__init__(self, scenario, device)
 
     def _get_initial_states(self) -> list[dict]:

--- a/roboverse_pack/tasks/maniskill/maniskill_base.py
+++ b/roboverse_pack/tasks/maniskill/maniskill_base.py
@@ -21,10 +21,37 @@ class ManiskillBaseTask(BaseTaskEnv):
     # so the seed-aware base reset() is inherited unchanged.
     skip_checker_reset = False
 
-    def __init__(self, scenario: ScenarioCfg, device: str | torch.device | None = None) -> None:
-        check_and_download_single(self.traj_filepath)
+    default_robots: list[str] = ["franka"]
+    """Robot(s) to use when a leaf's ``scenario`` does not name one.
+
+    Leaves declare ``scenario = ScenarioCfg(objects=[...])``, which *replaces* this class's
+    scenario wholesale; ``ScenarioCfg.robots`` then falls back to its ``[]`` default. Every
+    ManiSkill task ported into this pack is a Franka/Panda tabletop task replaying a
+    franka-keyed demo (``roboverse_data/trajs/maniskill/**/trajectory-franka-*``), so the arm
+    is a property of the *family*, not of each of the ~2.6k object variants. Keep it here as
+    the single source of truth; a leaf that needs a different arm names it explicitly in its
+    own ``scenario.robots`` (which always wins) or overrides ``default_robots``.
+    """
+
+    def __init__(
+        self,
+        scenario: ScenarioCfg | None = None,
+        device: str | torch.device | None = None,
+    ) -> None:
         # update objects and robots defined by task, must before super().__init__ because handler init
+        scenario = self._apply_default_robots(scenario)
+        check_and_download_single(self.traj_filepath)
         super().__init__(scenario, device)
+
+    @classmethod
+    def _apply_default_robots(cls, scenario: ScenarioCfg | None = None) -> ScenarioCfg | None:
+        """Fill in ``default_robots`` when the scenario names no robot, and return it."""
+        if scenario is None:
+            scenario = cls.scenario
+        if isinstance(scenario, ScenarioCfg) and not scenario.robots and cls.default_robots:
+            # update() re-runs __post_init__, which resolves the names into RobotCfg instances.
+            scenario.update(robots=list(cls.default_robots))
+        return scenario
 
     def _terminated(self, states: TensorState) -> torch.Tensor:
         """Task success when the cube has been lifted sufficiently along z from its reset height."""
@@ -44,6 +71,15 @@ class ManiskillBaseTask(BaseTaskEnv):
         """Give the inital states from traj file."""
         # Keep it simple and leave robot states to defaults; just seed cube pose.
         # If the handler handles None gracefully, this can be set to None.
+        if not self.scenario.robots:
+            # Previously an IndexError from `robots[0]` two lines down, which said nothing
+            # about which task was misconfigured or why a robot is required.
+            raise ValueError(
+                f"{type(self).__name__} has no robot in its scenario, but ManiSkill tasks replay a"
+                f" robot-keyed demo trajectory ({self.traj_filepath}) and cannot be manipulated"
+                f" without an arm. Set robots=[...] on the task's ScenarioCfg, or leave"
+                f" {type(self).__name__}.default_robots at its default."
+            )
         initial_states, _, _ = get_traj(self.traj_filepath, self.scenario.robots[0], self.handler)
         # Duplicate / trim list so that its length matches num_envs
         if len(initial_states) < self.num_envs:

--- a/roboverse_pack/tasks/maniskill/peg_insertion_side.py
+++ b/roboverse_pack/tasks/maniskill/peg_insertion_side.py
@@ -20018,20 +20018,21 @@ class PegInsertionSide533Task(PegInsertionSideBaseTask):
 
 @register_task("maniskill.peg_insertion_side_81", "peg_insertion_side_81")
 class PegInsertionSide81Task(PegInsertionSideBaseTask):
-    scenario = ScenarioCfg
-    objects = [
-        RigidObjCfg(
-            name="box",
-            usd_path="roboverse_data/assets/maniskill/peg/base_81.usd",
-            physics=PhysicStateType.GEOM,
-            fix_base_link=True,
-        ),
-        RigidObjCfg(
-            name="stick",
-            usd_path="roboverse_data/assets/maniskill/peg/stick_81.usd",
-            physics=PhysicStateType.RIGIDBODY,
-        ),
-    ]
+    scenario = ScenarioCfg(
+        objects=[
+            RigidObjCfg(
+                name="box",
+                usd_path="roboverse_data/assets/maniskill/peg/base_81.usd",
+                physics=PhysicStateType.GEOM,
+                fix_base_link=True,
+            ),
+            RigidObjCfg(
+                name="stick",
+                usd_path="roboverse_data/assets/maniskill/peg/stick_81.usd",
+                physics=PhysicStateType.RIGIDBODY,
+            ),
+        ]
+    )
     traj_filepath = "roboverse_data/trajs/maniskill/peg_insertion_side/trajectory-franka-81_v2.pkl"
 
 

--- a/tests/test_maniskill_task_robots.py
+++ b/tests/test_maniskill_task_robots.py
@@ -1,0 +1,115 @@
+"""Every registered ManiSkill task must run with a robot arm.
+
+Each config-port leaf declares ``scenario = ScenarioCfg(objects=[...])``, which *replaces* the
+base class's scenario wholesale — and ``ScenarioCfg.robots`` defaults to ``[]``. Only a handful
+of leaves (pick_cube, the ``*_dense`` variants, ...) passed ``robots=["franka"]``, so ~2.6k task
+classes (every pick_single_egad / peg_insertion_side / pick_single_ycb object variant, plus
+plug_charger, stack_pyramid, pull_cube_tool, place_sphere, poke_cube) shipped with an empty robot
+list. Constructing one died in ``ManiskillBaseTask._get_initial_states`` with a bare
+``IndexError: list index out of range`` from ``self.scenario.robots[0]``.
+
+``ManiskillBaseTask.default_robots`` now supplies the family's arm when a leaf's scenario names
+none. These tests pin both halves of that contract:
+
+- every registered ManiSkill task names a robot, directly or via the family default;
+- constructing a leaf from each affected family actually reaches ``get_traj`` with a franka
+  RobotCfg, instead of raising IndexError.
+
+Backend-free: the handler and the trajectory loader are stubbed, so nothing touches a simulator
+or the HuggingFace asset store.
+"""
+
+from __future__ import annotations
+
+import copy
+from unittest.mock import MagicMock
+
+import pytest
+
+from metasim.scenario.scenario import ScenarioCfg
+from metasim.task.base import BaseTaskEnv
+from metasim.task.registry import TASK_REGISTRY, get_task_class
+from roboverse_pack.tasks.maniskill.maniskill_base import ManiskillBaseTask
+
+# One leaf per family that shipped an empty robot list, plus pick_cube as the control
+# (it always declared robots=["franka"]). peg_insertion_side_81 is included because it
+# additionally had `scenario = ScenarioCfg` (the class, not an instance) with a stray
+# top-level `objects = [...]`, so it could not construct at all.
+_AFFECTED_FAMILIES = [
+    "maniskill.peg_insertion_side_363",
+    "maniskill.peg_insertion_side_81",
+    "maniskill.pick_single_egad_a100",
+    "maniskill.pick_single_ycb_lego_duplo",
+    "maniskill.place_sphere",
+    "maniskill.plug_charger",
+    "maniskill.poke_cube",
+    "maniskill.pull_cube_tool",
+    "maniskill.stack_pyramid",
+]
+_CONTROL = "maniskill.pick_cube"
+
+
+def _maniskill_task_classes() -> dict[str, type[ManiskillBaseTask]]:
+    """Registered ManiSkill config-port tasks, de-duplicated across aliases."""
+    get_task_class(_CONTROL)  # force task discovery to populate the registry
+    return {
+        cls.__name__: cls
+        for cls in TASK_REGISTRY.values()
+        if isinstance(cls, type) and issubclass(cls, ManiskillBaseTask) and cls is not ManiskillBaseTask
+    }
+
+
+@pytest.mark.general
+def test_every_registered_maniskill_task_names_a_robot():
+    classes = _maniskill_task_classes()
+    assert len(classes) > 2000, f"expected the full ManiSkill registry, only saw {len(classes)} classes"
+
+    robotless = [
+        name
+        for name, cls in classes.items()
+        if not getattr(cls.scenario, "robots", None) and not getattr(cls, "default_robots", None)
+    ]
+    assert not robotless, (
+        f"{len(robotless)} ManiSkill task(s) name no robot and have no family default, so"
+        f" _get_initial_states() will IndexError on scenario.robots[0]:"
+        f" {sorted(robotless)[:5]}{' ...' if len(robotless) > 5 else ''}"
+    )
+
+
+@pytest.mark.general
+def test_every_maniskill_scenario_is_a_scenariocfg_instance():
+    """``scenario = ScenarioCfg`` (the class) is not a scenario — the task can never construct."""
+    bad = {
+        name: cls.scenario
+        for name, cls in _maniskill_task_classes().items()
+        if cls.scenario is not None and not isinstance(cls.scenario, ScenarioCfg)
+    }
+    assert not bad, f"task scenario must be a ScenarioCfg instance, not a class/other: {bad}"
+
+
+@pytest.mark.general
+@pytest.mark.parametrize("task_id", [*_AFFECTED_FAMILIES, _CONTROL])
+def test_maniskill_task_constructs_with_a_franka(task_id, monkeypatch):
+    """The real __init__ path must reach get_traj with a franka RobotCfg (was: IndexError)."""
+    seen: dict[str, object] = {}
+
+    def fake_get_traj(traj_filepath, robot, handler):
+        seen["robot"] = robot
+        return [{"objects": {}, "robots": {}}], None, None
+
+    def fake_instantiate_env(self, scenario):
+        self.handler = MagicMock()
+        self.handler.device = "cpu"
+
+    monkeypatch.setattr("roboverse_pack.tasks.maniskill.maniskill_base.get_traj", fake_get_traj)
+    monkeypatch.setattr("roboverse_pack.tasks.maniskill.maniskill_base.check_and_download_single", lambda *a: None)
+    monkeypatch.setattr("metasim.task.base.check_and_download_single", lambda *a: None)
+    monkeypatch.setattr(BaseTaskEnv, "_instantiate_env", fake_instantiate_env)
+
+    cls = get_task_class(task_id)
+    # deepcopy: the class-level ScenarioCfg is shared, don't let one test mutate it for the next.
+    task = cls(copy.deepcopy(cls.scenario))
+
+    assert task.scenario.robots, f"{task_id} constructed with no robot"
+    assert task.scenario.robots[0].name == "franka"
+    assert seen["robot"] is task.scenario.robots[0], f"{task_id} did not load its demo traj for the robot"


### PR DESCRIPTION
Every ManiSkill config-port leaf declares `scenario = ScenarioCfg(objects=[...])`, which
*replaces* the base class's scenario wholesale rather than extending it, and
`ScenarioCfg.robots` defaults to `[]`. Only ~14 leaves (pick_cube, the `*_dense` variants,
draw_svg, ...) also passed `robots=["franka"]`. The other 2,648 shipped with an empty robot
list, so constructing any of them died in `ManiskillBaseTask._get_initial_states` on
`self.scenario.robots[0]` with a bare `IndexError: list index out of range` — no task name,
no hint. That is every object variant of pick_single_egad (1,588), peg_insertion_side (999)
and pick_single_ycb (52), plus plug_charger, stack_pyramid, pull_cube_tool, place_sphere and
poke_cube: the great majority of the ManiSkill registry could not be instantiated at all, on
any backend. Same defect class as 249103f5 (libero_pick), which fixed 9 tasks and left these
behind.

The arm is a property of the *family*, not of each variant: all eight affected families are
Franka/Panda tabletop tasks, every one replays a franka-keyed demo
(`trajs/maniskill/**/trajectory-franka-*`), pull_cube_tool's checker even measures distance to
a marker object named `franka_base`, and the sibling `*_dense` leaves in the very same files
declare `robots=["franka"]` and read `env_states.robots["franka"]`. So rather than paste an
identical `robots=["franka"]` line into 2,648 class bodies — duplicating a family constant
2,648 times and leaving the next generated leaf free to omit it again — the default now lives
in one place: `ManiskillBaseTask.default_robots`, applied in `__init__` when (and only when) a
leaf's scenario names no robot. A leaf that needs a different arm still wins by naming it in
its own `scenario.robots`. Resolution is done at construction, not at class-definition time,
because `get_robot()` costs ~7 ms and eagerly resolving 2,648 classes would add ~19 s to task
discovery, which imports every task module.

`_get_initial_states` additionally now fails with a message naming the task and saying why a
robot is required, instead of an anonymous IndexError, for the case where a task deliberately
empties `default_robots`. `DenseRLResetMixin.__init__` bypasses `ManiskillBaseTask.__init__`
to skip the demo download, so it applies the same fill-in — otherwise it would reintroduce the
identical `robots[0]` crash for dense tasks.

Also fixes `peg_insertion_side_81`, found while sweeping the registry: it had
`scenario = ScenarioCfg` — the class, not an instance — with a stray top-level
`objects = [...]`, so it could never construct regardless of robots. Now matches its 998
siblings.

Verified against the live registry (not by reading the source): enumerating `TASK_REGISTRY`
found 2,648 `ManiskillBaseTask` subclasses with an empty robot list (5,296 registered ids,
counting aliases); after the fix all 2,662 concrete ManiSkill task classes resolve to
`franka`. The 3 abstract `*_base` intermediates keep `scenario = None` and are untouched —
they already fail with BaseTaskEnv's explicit "requires a scenario" error. mjlab's genuinely
robotless scene-MJCF tasks were checked and deliberately left alone.

tests/test_maniskill_task_robots.py pins all of this: the whole registry names a robot, every
task scenario is a ScenarioCfg instance, and one leaf from each affected family constructs
through the real `__init__` and reaches `get_traj` with a franka RobotCfg (backend-free —
handler and trajectory loader stubbed). Before the fix it reports "2648 ManiSkill task(s) name
no robot" and raises the original IndexError; after, 12 pass. `pytest tests/ -m general` shows
an identical failure set before and after (9 pre-existing failures on main, all unrelated).

Review: independently reviewed against current main (verdict MERGE AS-IS); rebased, re-verified: 12 passed, 3 skipped in 5.87s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw