### PR TITLE
chore(deps): bump hydra-core to 1.3.4 in the IL policy requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,9 @@ release.
   passthrough registration, hard-coded personal paths in scripts/tests, untruthful
   `requires-python >= 3.8` (now 3.10), wheels missing LIBERO json/npz bundles, stale ruff ignores.
 
+### Security
+
+- `hydra-core` pinned to 1.3.4 in the dp / vita / fm IL policy requirements (Dependabot: `hydra.utils.instantiate` code execution with untrusted configs in <=1.3.3).
 
 ## [1.0.0-beta] - 2026-05-31
 

--- a/roboverse_learn/il/policies/dp/requirements.txt
+++ b/roboverse_learn/il/policies/dp/requirements.txt
@@ -2,7 +2,7 @@ zarr==2.12.0
 ipdb
 gpustat
 omegaconf
-hydra-core==1.2.0
+hydra-core==1.3.4
 dill==0.3.5.1
 einops==0.4.1
 diffusers

--- a/roboverse_learn/il/policies/fm/requirements.txt
+++ b/roboverse_learn/il/policies/fm/requirements.txt
@@ -2,7 +2,7 @@ zarr==2.12.0
 ipdb
 gpustat
 omegaconf
-hydra-core==1.2.0
+hydra-core==1.3.4
 dill==0.3.5.1
 einops==0.4.1
 diffusers

--- a/roboverse_learn/il/policies/vita/requirements.txt
+++ b/roboverse_learn/il/policies/vita/requirements.txt
@@ -2,7 +2,7 @@ zarr==2.12.0
 ipdb
 gpustat
 omegaconf
-hydra-core==1.2.0
+hydra-core==1.3.4
 dill==0.3.5.1
 einops==0.4.1
 diffusers


### PR DESCRIPTION
Dependabot flags hydra-core<=1.3.3 (GHSA: hydra.utils.instantiate with an
untrusted config can execute code). The dp / vita / fm policy requirement
files pinned 1.2.0; 1.3.4 is the first patched release.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw

Review: independently reviewed against current main (verdict MERGE AS-IS); rebased, re-verified: 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw