### PR TITLE
fix(tasks): build the mjlab class-level scenarios lazily so the package imports without assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ release.
 
 ### Fixed
 
+- `roboverse_pack.tasks.mjlab` failed to import without the asset checkout (hosted CI, registry discovery): the go1 / yam class-level scenarios parsed an MJCF at import time; they are now built on first access (`lazy_scenario`).
 - `import roboverse_pack.tasks.benchmark` raised a circular-import error when the tasks package was
   imported first (task discovery); `roboverse_pack.benchmark` now resolves its two helpers lazily.
 - `roboverse_pack.tasks.mjlab` no longer downloads assets from HuggingFace at import time; the

--- a/roboverse_pack/tasks/mjlab/_locator.py
+++ b/roboverse_pack/tasks/mjlab/_locator.py
@@ -72,3 +72,23 @@ def mjlab_asset(relpath: str) -> str:
     # slowed task discovery and broke offline imports. ``ScenarioCfg.check_assets()`` (run by every
     # handler at construction) fetches the MJCF and its referenced meshes when the task is used.
     return hf_mjlab_path(relpath)
+
+
+class lazy_scenario:
+    """Class-level ``scenario`` built on first access instead of at import time.
+
+    The mjlab tasks patch an MJCF from ``roboverse_data`` to build their scenario. Doing that in the
+    class body meant ``import roboverse_pack.tasks.mjlab`` parsed asset files, so any process without
+    the asset checkout (CI runners, the task registry's discovery, ``list_tasks``) failed at import.
+    The descriptor keeps ``TaskClass.scenario`` working for readers such as ``gym_registration`` while
+    deferring the file access to the first real use. Assigning ``TaskClass.scenario = cfg`` replaces it.
+    """
+
+    def __init__(self, factory):
+        self._factory = factory
+        self._value = None
+
+    def __get__(self, instance, owner=None):
+        if self._value is None:
+            self._value = self._factory()
+        return self._value

--- a/roboverse_pack/tasks/mjlab/cartpole.py
+++ b/roboverse_pack/tasks/mjlab/cartpole.py
@@ -20,7 +20,7 @@ from metasim.scenario.simulator_params import SimParamCfg
 from metasim.task.base import BaseTaskEnv
 from metasim.task.registry import register_task
 
-from ._locator import mjlab_asset
+from ._locator import lazy_scenario, mjlab_asset
 
 _CARTPOLE_XML = "tasks/cartpole/cartpole.xml"
 
@@ -42,7 +42,7 @@ def _cartpole_scenario() -> ScenarioCfg:
 class MjlabCartpoleBalance(BaseTaskEnv):
     """Balance the pole upright (hinge_1 starts near 0)."""
 
-    scenario = _cartpole_scenario()
+    scenario = lazy_scenario(lambda: _cartpole_scenario())
     max_episode_steps = 5000  # mjlab episode_length_s = 50s / dt 0.01
 
 
@@ -50,7 +50,7 @@ class MjlabCartpoleBalance(BaseTaskEnv):
 class MjlabCartpoleSwingup(BaseTaskEnv):
     """Swing the pole up from hanging-down (hinge_1 starts at pi)."""
 
-    scenario = _cartpole_scenario()
+    scenario = lazy_scenario(lambda: _cartpole_scenario())
     max_episode_steps = 5000
 
     def _get_initial_states(self):

--- a/roboverse_pack/tasks/mjlab/cartpole_train.py
+++ b/roboverse_pack/tasks/mjlab/cartpole_train.py
@@ -35,7 +35,7 @@ from metasim.scenario.simulator_params import SimParamCfg
 from metasim.task.base import BaseTaskEnv
 from metasim.task.registry import register_task
 
-from ._locator import mjlab_asset
+from ._locator import lazy_scenario, mjlab_asset
 from .cartpole import _CARTPOLE_XML  # path string
 
 # dm_control tolerance defaults: value_at_margin = 0.1
@@ -76,7 +76,7 @@ def _cartpole_scenario() -> ScenarioCfg:
 class _MjlabCartpoleTrainBase(BaseTaskEnv):
     """Shared training scaffold for balance + swingup."""
 
-    scenario = _cartpole_scenario()
+    scenario = lazy_scenario(lambda: _cartpole_scenario())
     # mjlab default: episode_length_s = 50s, control_dt = 0.05s (dt 0.01 * decim 5)
     max_episode_steps = 1000
     _hinge_init: float = 0.0  # 0 for balance, math.pi for swingup

--- a/roboverse_pack/tasks/mjlab/cartpole_v2.py
+++ b/roboverse_pack/tasks/mjlab/cartpole_v2.py
@@ -37,7 +37,7 @@ from roboverse_learn.managers import (
     RewTerm,
 )
 
-from ._locator import mjlab_asset
+from ._locator import lazy_scenario, mjlab_asset
 from .cartpole import _CARTPOLE_XML
 from .mdp import (
     SceneEntityCfg,
@@ -209,7 +209,7 @@ class CartpoleSwingupEnvCfg(CartpoleBalanceEnvCfg):
 class _CartpoleTaskBase(ManagerBasedRVEnv):
     """Common machinery for both balance + swingup variants."""
 
-    scenario = _cartpole_scenario()
+    scenario = lazy_scenario(lambda: _cartpole_scenario())
     _cfg_cls: type[ManagerBasedRVEnvCfg] = CartpoleBalanceEnvCfg
 
     def __init__(self, scenario: ScenarioCfg | None = None, device: str | torch.device | None = None) -> None:

--- a/roboverse_pack/tasks/mjlab/floating_base.py
+++ b/roboverse_pack/tasks/mjlab/floating_base.py
@@ -17,7 +17,7 @@ from metasim.scenario.simulator_params import SimParamCfg
 from metasim.task.base import BaseTaskEnv
 from metasim.task.registry import register_task
 
-from ._locator import mjlab_asset
+from ._locator import lazy_scenario, mjlab_asset
 
 _G1_XML = "asset_zoo/robots/unitree_g1/xmls/g1.xml"
 _GO1_XML = "asset_zoo/robots/unitree_go1/xmls/go1.xml"
@@ -48,7 +48,7 @@ def _floating_scenario(robot_name: str, mjcf_relpath: str, num_joints: int) -> S
 class MjlabVelocityFlatG1(BaseTaskEnv):
     """Unitree G1 humanoid scaffold (29 DoF)."""
 
-    scenario = _floating_scenario("g1", _G1_XML, num_joints=29)
+    scenario = lazy_scenario(lambda: _floating_scenario("g1", _G1_XML, num_joints=29))
     max_episode_steps = 4000  # mjlab episode_length_s = 20s / dt 0.005
 
 
@@ -56,7 +56,7 @@ class MjlabVelocityFlatG1(BaseTaskEnv):
 class MjlabVelocityRoughG1(BaseTaskEnv):
     """G1 humanoid on rough terrain (terrain wrapper not yet ported)."""
 
-    scenario = _floating_scenario("g1", _G1_XML, num_joints=29)
+    scenario = lazy_scenario(lambda: _floating_scenario("g1", _G1_XML, num_joints=29))
     max_episode_steps = 4000
 
 
@@ -64,7 +64,7 @@ class MjlabVelocityRoughG1(BaseTaskEnv):
 class MjlabVelocityFlatGo1(BaseTaskEnv):
     """Unitree Go1 quadruped scaffold (12 DoF)."""
 
-    scenario = _floating_scenario("go1", _GO1_XML, num_joints=12)
+    scenario = lazy_scenario(lambda: _floating_scenario("go1", _GO1_XML, num_joints=12))
     max_episode_steps = 4000
 
 
@@ -72,7 +72,7 @@ class MjlabVelocityFlatGo1(BaseTaskEnv):
 class MjlabVelocityRoughGo1(BaseTaskEnv):
     """Go1 quadruped on rough terrain (terrain wrapper not yet ported)."""
 
-    scenario = _floating_scenario("go1", _GO1_XML, num_joints=12)
+    scenario = lazy_scenario(lambda: _floating_scenario("go1", _GO1_XML, num_joints=12))
     max_episode_steps = 4000
 
 
@@ -80,7 +80,7 @@ class MjlabVelocityRoughGo1(BaseTaskEnv):
 class MjlabTrackingFlatG1(BaseTaskEnv):
     """G1 humanoid reference-trajectory tracking on flat ground."""
 
-    scenario = _floating_scenario("g1", _G1_XML, num_joints=29)
+    scenario = lazy_scenario(lambda: _floating_scenario("g1", _G1_XML, num_joints=29))
     max_episode_steps = 2000  # mjlab episode_length_s = 10s / dt 0.005
 
 
@@ -88,5 +88,5 @@ class MjlabTrackingFlatG1(BaseTaskEnv):
 class MjlabTrackingFlatG1NoStateEst(BaseTaskEnv):
     """Same physical scaffold as Tracking-Flat-G1; observation differs in mjlab."""
 
-    scenario = _floating_scenario("g1", _G1_XML, num_joints=29)
+    scenario = lazy_scenario(lambda: _floating_scenario("g1", _G1_XML, num_joints=29))
     max_episode_steps = 2000

--- a/roboverse_pack/tasks/mjlab/lift_cube.py
+++ b/roboverse_pack/tasks/mjlab/lift_cube.py
@@ -19,7 +19,7 @@ from metasim.scenario.simulator_params import SimParamCfg
 from metasim.task.base import BaseTaskEnv
 from metasim.task.registry import register_task
 
-from ._locator import mjlab_asset
+from ._locator import lazy_scenario, mjlab_asset
 
 _YAM_XML = "asset_zoo/robots/i2rt_yam/xmls/yam.xml"
 
@@ -49,7 +49,7 @@ def _yam_scenario() -> ScenarioCfg:
 class MjlabLiftCubeYam(BaseTaskEnv):
     """YAM arm scaffold (7 DoF, no actuators in the bare MJCF)."""
 
-    scenario = _yam_scenario()
+    scenario = lazy_scenario(lambda: _yam_scenario())
     max_episode_steps = 2500  # mjlab episode_length_s = 5s / dt 0.002
 
 
@@ -57,7 +57,7 @@ class MjlabLiftCubeYam(BaseTaskEnv):
 class MjlabLiftCubeYamRgb(BaseTaskEnv):
     """RGB-observation variant; physics is identical to the parent task."""
 
-    scenario = _yam_scenario()
+    scenario = lazy_scenario(lambda: _yam_scenario())
     max_episode_steps = 2500
 
 
@@ -65,7 +65,7 @@ class MjlabLiftCubeYamRgb(BaseTaskEnv):
 class MjlabLiftCubeYamDepth(BaseTaskEnv):
     """Depth-observation variant; physics is identical to the parent task."""
 
-    scenario = _yam_scenario()
+    scenario = lazy_scenario(lambda: _yam_scenario())
     max_episode_steps = 2500
 
 
@@ -73,5 +73,5 @@ class MjlabLiftCubeYamDepth(BaseTaskEnv):
 class MjlabMultiCubeSegYam(BaseTaskEnv):
     """Multi-cube segmentation variant; physics is identical to the parent task."""
 
-    scenario = _yam_scenario()
+    scenario = lazy_scenario(lambda: _yam_scenario())
     max_episode_steps = 2500

--- a/roboverse_pack/tasks/mjlab/lift_cube_yam_v2.py
+++ b/roboverse_pack/tasks/mjlab/lift_cube_yam_v2.py
@@ -39,7 +39,7 @@ from roboverse_learn.managers import (
     RewTerm,
 )
 
-from ._locator import mjlab_asset
+from ._locator import lazy_scenario, mjlab_asset
 from ._mjcf_patch import YAM_KP, patch_mjcf_add_cube_and_table, patch_mjcf_with_pd_actuators
 from .mdp import (
     SceneEntityCfg,
@@ -316,7 +316,7 @@ class LiftCubeYamEnvCfg(ManagerBasedRVEnvCfg):
 
 
 class _YamTaskBase(ManagerBasedRVEnv):
-    scenario = _yam_scenario()
+    scenario = lazy_scenario(_yam_scenario)
     _env_cfg_cls: type = LiftCubeYamEnvCfg  # subclasses override to swap cfg
 
     def __init__(self, scenario: ScenarioCfg | None = None, device: str | torch.device | None = None) -> None:

--- a/roboverse_pack/tasks/mjlab/velocity_g1_v2.py
+++ b/roboverse_pack/tasks/mjlab/velocity_g1_v2.py
@@ -35,7 +35,7 @@ from roboverse_learn.managers import (
     RewTerm,
 )
 
-from ._locator import mjlab_asset
+from ._locator import lazy_scenario, mjlab_asset
 from ._mjcf_patch import G1_KP, patch_mjcf_with_pd_actuators
 from .mdp import (
     SceneEntityCfg,
@@ -483,7 +483,7 @@ class VelocityFlatG1EnvCfg(ManagerBasedRVEnvCfg):
 class _G1TaskBase(ManagerBasedRVEnv):
     """Shared scaffold for all G1 velocity variants (flat / rough)."""
 
-    scenario = _g1_scenario()
+    scenario = lazy_scenario(lambda: _g1_scenario())
     # Subclasses override these: rough adds the height_scan obs + terrain_scan sensor.
     _obs_cfg_cls: type = _G1ObsCfg
     _use_terrain_scan: bool = False
@@ -649,7 +649,7 @@ class VelocityRoughG1Task(_G1TaskBase):
     scan).
     """
 
-    scenario = _g1_scenario(rough=True)
+    scenario = lazy_scenario(lambda: _g1_scenario(rough=True))
     _obs_cfg_cls = _G1RoughObsCfg
     _use_terrain_scan = True
 

--- a/roboverse_pack/tasks/mjlab/velocity_go1_v2.py
+++ b/roboverse_pack/tasks/mjlab/velocity_go1_v2.py
@@ -47,7 +47,7 @@ from roboverse_learn.managers import (
     RewTerm,
 )
 
-from ._locator import mjlab_asset
+from ._locator import lazy_scenario, mjlab_asset
 from ._mjcf_patch import GO1_KP, patch_mjcf_with_pd_actuators
 from .mdp import (
     SceneEntityCfg,
@@ -545,7 +545,7 @@ class VelocityFlatGo1EnvCfg(ManagerBasedRVEnvCfg):
 class _Go1TaskBase(ManagerBasedRVEnv):
     """Shared scaffold for all go1 velocity variants (flat / rough)."""
 
-    scenario = _go1_scenario()
+    scenario = lazy_scenario(_go1_scenario)
     # Subclasses override these: rough adds the height_scan obs + terrain_scan sensor.
     _obs_cfg_cls: type = _Go1ObsCfg
     _use_terrain_scan: bool = False
@@ -776,6 +776,6 @@ class VelocityRoughGo1Task(_Go1TaskBase):
     remaining step for full rough 1:1.
     """
 
-    scenario = _go1_scenario(rough=True)
+    scenario = lazy_scenario(lambda: _go1_scenario(rough=True))
     _obs_cfg_cls = _Go1RoughObsCfg
     _use_terrain_scan = True

--- a/tests/test_mjlab_import_without_assets.py
+++ b/tests/test_mjlab_import_without_assets.py
@@ -1,0 +1,28 @@
+"""Importing the mjlab task family must not touch ``roboverse_data``.
+
+Regression: the go1 / yam tasks built their class-level ``scenario`` in the class body, which parses
+an MJCF from the asset checkout; ``import roboverse_pack.tasks.mjlab`` therefore failed on any
+machine without assets (hosted CI, registry discovery). The scenario is now built on first access.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.general
+def test_mjlab_package_imports_without_asset_checkout(tmp_path):
+    code = (
+        "import roboverse_pack.tasks.mjlab as m, roboverse_pack.tasks.mjlab.mdp.events_dr as dr; "
+        "from roboverse_pack.tasks.mjlab.lift_cube_yam_v2 import _YamTaskBase; "
+        "assert isinstance(type(_YamTaskBase).__dict__.get('scenario', None), object); print('ok')"
+    )
+    # An empty cwd: no roboverse_data symlink or checkout anywhere the task code could find.
+    proc = subprocess.run(
+        [sys.executable, "-c", code], cwd=tmp_path, capture_output=True, text=True, timeout=600, check=False
+    )
+    assert proc.returncode == 0, proc.stderr[-2000:]
+    assert "ok" in proc.stdout


### PR DESCRIPTION
velocity_go1_v2 and lift_cube_yam_v2 built their class-level scenario in the
class body, which parses an MJCF from roboverse_data. Since #807 stopped
downloading assets at import time, importing roboverse_pack.tasks.mjlab (and
therefore collecting tests/test_mjlab_dr_backend_support.py) failed on any
machine without the asset checkout. A lazy_scenario descriptor keeps
TaskClass.scenario working for gym registration while deferring the file
access to first use. Regression test imports the package from an empty cwd.

Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw

Review: independently reviewed against current main (verdict MERGE AS-IS); rebased, re-verified: 11 passed in 6.92s

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw