### PR TITLE
fix(core): content packs win over the example pack, gym wrappers stop mutating class scenarios, get_states honours env_ids

### DIFF
--- a/packages/metasim/CHANGELOG.md
+++ b/packages/metasim/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Content packs win over MetaSim's bundled example pack: `get_package_candidates` searches `defaults` last (a RoboVerse checkout used to resolve `get_robot("franka")` to the example `FrankaCfg`), and `_lookup_cfg` reports a config name defined in more than one package.
+- `gym.make`-style wrappers no longer mutate the task class's shared `scenario` (they update a copy); `ScenarioCfg.replace(**kw)` returns an updated copy for new code.
+- `get_states(env_ids=...)` returns exactly those envs: the base class slices the full batch when a backend ignores `env_ids` (six did, silently) and raises when a backend returns a batch that is neither the subset nor the full set.
+- The task-index cache defaults to a per-user directory (`$METASIM_CACHE_DIR`, else `$XDG_CACHE_HOME/metasim`, else `~/.cache/metasim`) instead of the shared temp dir.
 - `RLTaskEnv.step` publishes the *terminal* observation in `info["observations"]["raw"]["obs"]` instead of the episode's first one (off-policy truncation bootstraps in clean_rl SAC/TD3 and FastTD3 read it).
 - IsaacGym and PyBullet reported `joint_pos_target` in native DoF order while `joint_pos` is in sorted-name order; both now use `get_joint_names(sort=True)` (completes #12).
 - `ParallelSimWrapper`: a worker that died during handler construction or `launch` surfaced as a bare `EOFError`/`ConnectionResetError` from the handshake and left the other workers running; the handshake now raises the worker's own traceback, `close()` tolerates dead workers, and a failed constructor tears the pool down.

--- a/packages/metasim/metasim/scenario/scenario.py
+++ b/packages/metasim/metasim/scenario/scenario.py
@@ -157,3 +157,13 @@ class ScenarioCfg:
                 setattr(self, key, value)
         self.__post_init__()
         return self
+
+    def replace(self, **kwargs):
+        """Return a copy with ``kwargs`` applied.
+
+        ``update`` mutates in place and the object is shared by every holder (class-level task
+        defaults included); prefer ``replace`` in new code.
+        """
+        import copy
+
+        return copy.deepcopy(self).update(**kwargs)

--- a/packages/metasim/metasim/sim/base.py
+++ b/packages/metasim/metasim/sim/base.py
@@ -13,7 +13,7 @@ from loguru import logger as log
 from metasim.queries.base import BaseQueryType
 from metasim.types import CompatActionInput, DictStateBatch, StateMode, StateOutput, TensorState
 from metasim.utils.gs_util import quaternion_multiply
-from metasim.utils.state import list_state_to_tensor, state_tensor_to_nested
+from metasim.utils.state import list_state_to_tensor, select_envs, state_tensor_to_nested
 
 try:
     from robo_splatter.models.basic import GSInstance, RenderConfig
@@ -23,6 +23,20 @@ try:
     ROBO_SPLATTER_AVAILABLE = True
 except ImportError:
     ROBO_SPLATTER_AVAILABLE = False
+
+
+def _state_env_count(result) -> int | None:
+    """Env rows in a ``get_states`` result, or None when it carries no per-env tensor to tell from."""
+    if isinstance(result, TensorState):
+        for group in (result.robots, result.objects):
+            for st in group.values():
+                rs = getattr(st, "root_state", None)
+                if isinstance(rs, torch.Tensor) and rs.ndim == 2:
+                    return int(rs.shape[0])
+        return None
+    if isinstance(result, list):
+        return len(result)
+    return None
 
 
 class BaseSimHandler(ABC):
@@ -306,6 +320,27 @@ class BaseSimHandler(ABC):
         finally:
             self._invalidate_state_caches()
 
+    def _enforce_env_subset(self, result, env_ids: list[int]):
+        """Make ``get_states(env_ids=...)`` return exactly those envs.
+
+        Six backends accept ``env_ids`` and ignore it, returning the full batch; callers that index
+        the result as a subset then read the wrong rows. Slice here (a subset of the full state is
+        the same data) and say so once, instead of trusting every backend's signature.
+        """
+        n_env = _state_env_count(result)
+        if n_env is None or n_env == len(env_ids):
+            return result
+        if n_env != self.num_envs:
+            raise RuntimeError(
+                f"{type(self).__name__}._get_states(env_ids={env_ids}) returned {n_env} envs (handler has {self.num_envs})"
+            )
+        if not getattr(self, "_env_ids_ignored_warned", False):
+            self._env_ids_ignored_warned = True
+            log.warning(f"{type(self).__name__} ignores env_ids in _get_states; the base class slices the full batch.")
+        if isinstance(result, TensorState):
+            return select_envs(result, env_ids)
+        return [result[i] for i in env_ids]
+
     def _normalise_set_states_input(self, states):
         """Coerce ``states`` to the shape declared by ``_set_states_input_type``."""
         wanted = type(self)._set_states_input_type
@@ -470,6 +505,7 @@ class BaseSimHandler(ABC):
             result = self._get_states(env_ids=env_ids)
             if result is None:
                 return None
+            result = self._enforce_env_subset(result, list(env_ids))
             if mode == "tensor":
                 return result if isinstance(result, TensorState) else list_state_to_tensor(self, result)
             return state_tensor_to_nested(self, result) if isinstance(result, TensorState) else result

--- a/packages/metasim/metasim/task/_static_index.py
+++ b/packages/metasim/metasim/task/_static_index.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import ast
 import json
 import os
-import tempfile
 from dataclasses import dataclass, field
 from importlib.util import find_spec
 
@@ -75,10 +74,16 @@ def _parse_registrations(path: str) -> tuple[list[str], bool]:
 
 
 def default_cache_path() -> str:
-    """Per-file index cache (JSON). ``$METASIM_CACHE_DIR`` overrides the temp-dir default."""
-    return os.path.join(
-        os.environ.get("METASIM_CACHE_DIR", os.path.join(tempfile.gettempdir(), "metasim_cache")), "task_index.json"
-    )
+    """Per-file index cache (JSON) in a per-user directory.
+
+    ``$METASIM_CACHE_DIR``, else ``$XDG_CACHE_HOME/metasim``, else ``~/.cache/metasim``; the shared
+    temp dir used before mixed users' caches.
+    """
+    base = os.environ.get("METASIM_CACHE_DIR")
+    if not base:
+        xdg = os.environ.get("XDG_CACHE_HOME") or os.path.join(os.path.expanduser("~"), ".cache")
+        base = os.path.join(xdg, "metasim")
+    return os.path.join(base, "task_index.json")
 
 
 def _load_cache(path: str) -> dict:

--- a/packages/metasim/metasim/task/gym_registration.py
+++ b/packages/metasim/metasim/task/gym_registration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import inspect
 import warnings
 from typing import Any, Callable
@@ -75,7 +76,9 @@ class GymEnvWrapper(gym.Env):
         scenario_kwargs["num_envs"] = 1
         self.device = device
         self.task_cls = get_task_class(task_name)
-        updated_scenario_cfg = self.task_cls.scenario.update(**scenario_kwargs)
+        # ``update`` mutates in place; the class attribute is shared by every instance of the task,
+        # so work on a copy or ``gym.make`` would rewrite the task's defaults for the whole process.
+        updated_scenario_cfg = copy.deepcopy(self.task_cls.scenario).update(**scenario_kwargs)
         self.scenario = updated_scenario_cfg
         self.task_env = self.task_cls(updated_scenario_cfg, device)
         self.action_space = self.task_env.action_space
@@ -139,7 +142,9 @@ class GymVectorEnvAdapter(VectorEnv):
         **scenario_kwargs: Any,
     ) -> None:
         self.task_cls = get_task_class(task_name)
-        updated_scenario_cfg = self.task_cls.scenario.update(**scenario_kwargs)
+        updated_scenario_cfg = copy.deepcopy(self.task_cls.scenario).update(
+            **scenario_kwargs
+        )  # never the shared class cfg
         self.task_env = self.task_cls(updated_scenario_cfg, device)
         self.scenario = updated_scenario_cfg
         self.device = self.task_env.device

--- a/packages/metasim/metasim/test/test_core_contracts_general.py
+++ b/packages/metasim/metasim/test/test_core_contracts_general.py
@@ -1,0 +1,118 @@
+"""Contracts that used to hold only by accident (architecture review, 2026-09-03).
+
+* Content packs win over MetaSim's bundled example pack when both define a config name, and a
+  shadowed name is reported.
+* ``gym.make``-style construction never mutates the task class's shared ``scenario``.
+* ``get_states(env_ids=...)`` returns exactly those envs even when the backend ignores ``env_ids``.
+* The task-index cache lives in a per-user directory, not the shared temp dir.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import textwrap
+
+import pytest
+import torch
+
+from metasim.task import _static_index
+from metasim.utils import package_discovery, setup_util
+
+
+@pytest.mark.general
+def test_defaults_are_searched_last(monkeypatch):
+    monkeypatch.setattr(package_discovery, "_entry_point_packages", lambda role: ("content_pack.robots",))
+    cands = package_discovery.get_package_candidates("robots", defaults=["metasim.example.example_pack.robots"])
+    assert cands.index("content_pack.robots") < cands.index("metasim.example.example_pack.robots")
+
+
+@pytest.mark.general
+def test_shadowed_config_name_is_reported_and_first_wins(tmp_path, monkeypatch):
+    for pkg in ("packa", "packb"):
+        d = tmp_path / pkg
+        d.mkdir()
+        (d / "__init__.py").write_text(
+            textwrap.dedent(f'''
+            class DemoCfg:
+                origin = "{pkg}"
+            '''),
+            encoding="utf-8",
+        )
+    monkeypatch.syspath_prepend(str(tmp_path))
+    setup_util._SHADOW_WARNED.clear()
+    from loguru import logger
+
+    messages: list[str] = []
+    sink_id = logger.add(lambda m: messages.append(str(m)), level="WARNING")
+    try:
+        cfg = setup_util._lookup_cfg("DemoCfg", ["packa", "packb"], "Robot")
+    finally:
+        logger.remove(sink_id)
+    assert cfg.origin == "packa"
+    assert any("defined in several packages" in m and "packa" in m for m in messages)
+
+
+@pytest.mark.general
+def test_scenario_replace_leaves_original_untouched():
+    from metasim.scenario.scenario import ScenarioCfg
+
+    base = ScenarioCfg(num_envs=1)
+    other = base.replace(num_envs=8)
+    assert base.num_envs == 1 and other.num_envs == 8 and other is not base
+
+
+@pytest.mark.general
+def test_gym_wrapper_does_not_mutate_class_scenario(monkeypatch):
+    from metasim.scenario.scenario import ScenarioCfg
+    from metasim.task import gym_registration
+
+    class _Env:
+        scenario = ScenarioCfg(num_envs=4)
+
+        def __init__(self, scenario, device=None):
+            self.scenario = scenario
+            self.device = "cpu"
+            self.action_space = self.observation_space = None
+            self.num_envs = scenario.num_envs
+
+    monkeypatch.setattr(gym_registration, "get_task_class", lambda name: _Env)
+    wrapper = gym_registration.GymEnvWrapper.__new__(gym_registration.GymEnvWrapper)
+    gym_registration.GymEnvWrapper.__init__(wrapper, "demo")
+    assert wrapper.scenario.num_envs == 1
+    assert _Env.scenario.num_envs == 4, "gym.make rewrote the task's class-level scenario"
+
+
+@pytest.mark.general
+def test_get_states_slices_when_backend_ignores_env_ids():
+    from metasim.sim.base import BaseSimHandler
+    from metasim.types import ObjectState, TensorState
+
+    full = TensorState(
+        objects={"cube": ObjectState(root_state=torch.arange(4 * 13, dtype=torch.float32).view(4, 13))},
+        robots={},
+        cameras={},
+    )
+
+    class _Handler:
+        num_envs = 4
+        _get_states = staticmethod(lambda env_ids=None: full)  # ignores env_ids, like six real backends
+
+    sub = BaseSimHandler._enforce_env_subset(_Handler(), full, [1, 3])
+    assert sub.objects["cube"].root_state.shape[0] == 2
+    assert torch.equal(sub.objects["cube"].root_state, full.objects["cube"].root_state[[1, 3]])
+
+    # A batch that is neither the requested subset nor the full env set is a backend bug, not a slice.
+    class _Broken(_Handler):
+        num_envs = 5
+
+    with pytest.raises(RuntimeError):
+        BaseSimHandler._enforce_env_subset(_Broken(), full, [0, 1])
+
+
+@pytest.mark.general
+def test_index_cache_defaults_to_user_cache_dir(monkeypatch, tmp_path):
+    monkeypatch.delenv("METASIM_CACHE_DIR", raising=False)
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
+    assert _static_index.default_cache_path() == os.path.join(str(tmp_path), "metasim", "task_index.json")
+    assert "tmp" not in _static_index.default_cache_path().split(os.sep)[:2] or sys.platform == "win32"

--- a/packages/metasim/metasim/test/test_core_contracts_general.py
+++ b/packages/metasim/metasim/test/test_core_contracts_general.py
@@ -10,7 +10,6 @@
 from __future__ import annotations
 
 import os
-import sys
 import textwrap
 
 import pytest
@@ -115,4 +114,5 @@ def test_index_cache_defaults_to_user_cache_dir(monkeypatch, tmp_path):
     monkeypatch.delenv("METASIM_CACHE_DIR", raising=False)
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path))
     assert _static_index.default_cache_path() == os.path.join(str(tmp_path), "metasim", "task_index.json")
-    assert "tmp" not in _static_index.default_cache_path().split(os.sep)[:2] or sys.platform == "win32"
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    assert _static_index.default_cache_path().startswith(os.path.join(os.path.expanduser("~"), ".cache", "metasim"))

--- a/packages/metasim/metasim/test/test_package_discovery_general.py
+++ b/packages/metasim/metasim/test/test_package_discovery_general.py
@@ -127,7 +127,6 @@ def test_package_candidates_merge_sources_in_order(tmp_path, monkeypatch):
     )
 
     assert packages == [
-        "builtin_robot",
         "entry_root.robots",
         "entry_robot",
         "toml_root.robots",
@@ -139,6 +138,7 @@ def test_package_candidates_merge_sources_in_order(tmp_path, monkeypatch):
         "env_root.robots",
         "env_robot",
         "local_robot",
+        "builtin_robot",  # MetaSim's bundled defaults come last: content packs must win
     ]
 
 

--- a/packages/metasim/metasim/utils/package_discovery.py
+++ b/packages/metasim/metasim/utils/package_discovery.py
@@ -58,17 +58,24 @@ def get_package_candidates(
     local_modules: Sequence[str] = (),
     cwd: Path | None = None,
 ) -> list[str]:
-    """Return package candidates for a MetaSim content role without importing them."""
+    """Return package candidates for a MetaSim content role without importing them.
+
+    Order is precedence: installed content packs (entry points), then project-local configuration
+    (``metasim.toml`` / ``pyproject.toml`` walking up from ``cwd``, ``METASIM_CONFIG``,
+    ``METASIM_*_PACKAGES``), then modules in ``cwd``, and only then ``defaults`` — MetaSim's bundled
+    example pack. The defaults used to come first, so ``get_robot("franka")`` in a checkout that ships
+    its own ``FrankaCfg`` silently returned the example one.
+    """
     _validate_role(role)
     base_dir = Path.cwd() if cwd is None else Path(cwd)
     candidates = []
-    candidates.extend(defaults)
     candidates.extend(_entry_point_packages(role))
     candidates.extend(_nearest_config_packages(base_dir, "metasim.toml", role))
     candidates.extend(_nearest_config_packages(base_dir, "pyproject.toml", role))
     candidates.extend(_explicit_config_packages(role))
     candidates.extend(_env_packages(role))
     candidates.extend(local_modules)
+    candidates.extend(defaults)
     return _dedupe(candidates)
 
 

--- a/packages/metasim/metasim/utils/setup_util.py
+++ b/packages/metasim/metasim/utils/setup_util.py
@@ -149,25 +149,42 @@ def _local_python_modules(cwd: str) -> list[str]:
     ]
 
 
+_SHADOW_WARNED: set[tuple[str, str]] = set()
+
+
 def _lookup_cfg(attr_name: str, candidate_packages: list[str], cfg_kind: str):
+    """Instantiate ``attr_name`` from the first candidate package that defines it.
+
+    Every candidate is inspected so a name defined in more than one package is reported once (the
+    first, highest-precedence package wins; see ``get_package_candidates`` for the order). A silent
+    first-match used to hide that MetaSim's example pack was shadowing a content pack's config.
+    """
     errors: list[str] = []
+    found: list[tuple[str, type]] = []
     for pkg_name in candidate_packages:
         try:
             pkg = importlib.import_module(pkg_name)
         except Exception as e:
             errors.append(f"{pkg_name}: import failed ({e})")
             continue
+        cfg_cls = getattr(pkg, attr_name, None)
+        if cfg_cls is not None:
+            found.append((pkg_name, cfg_cls))
 
-        try:
-            cfg_cls = getattr(pkg, attr_name)
-            return cfg_cls()
-        except AttributeError:
-            continue
-        except Exception as e:
-            errors.append(f"{pkg_name}: lookup failed ({e})")
-
-    searched_in = ", ".join(candidate_packages)
-    raise ValueError(f"{cfg_kind} config class '{attr_name}' not found in [{searched_in}]. Errors: {errors}")
+    if not found:
+        searched_in = ", ".join(candidate_packages)
+        raise ValueError(f"{cfg_kind} config class '{attr_name}' not found in [{searched_in}]. Errors: {errors}")
+    if len(found) > 1 and (attr_name, found[0][0]) not in _SHADOW_WARNED:
+        _SHADOW_WARNED.add((attr_name, found[0][0]))
+        others = ", ".join(p for p, _ in found[1:])
+        log.warning(
+            f"{cfg_kind} config '{attr_name}' is defined in several packages; using {found[0][0]} (also in: {others})."
+        )
+    pkg_name, cfg_cls = found[0]
+    try:
+        return cfg_cls()
+    except Exception as e:
+        raise ValueError(f"{cfg_kind} config class '{attr_name}' from {pkg_name} could not be instantiated: {e}") from e
 
 
 def get_robot(robot_name: str) -> RobotCfg:

--- a/packages/metasim/metasim/utils/state.py
+++ b/packages/metasim/metasim/utils/state.py
@@ -287,6 +287,30 @@ def _body_tensor_to_dict(body_tensor: torch.Tensor, body_names: list[str]) -> di
     }
 
 
+def select_envs(state: TensorState, env_ids: list[int]) -> TensorState:
+    """Rows ``env_ids`` of every per-env tensor in ``state`` (a new ``TensorState``; names are shared)."""
+    import dataclasses
+
+    idx = torch.as_tensor(list(env_ids), dtype=torch.long)
+
+    def take(value):
+        if isinstance(value, torch.Tensor) and value.ndim >= 1 and value.shape[0] > int(idx.max()):
+            return value[idx.to(value.device)]
+        return value
+
+    def sub(obj):
+        if obj is None or not dataclasses.is_dataclass(obj):
+            return obj
+        return dataclasses.replace(obj, **{f.name: take(getattr(obj, f.name)) for f in dataclasses.fields(obj)})
+
+    return TensorState(
+        objects={k: sub(v) for k, v in state.objects.items()},
+        robots={k: sub(v) for k, v in state.robots.items()},
+        cameras={k: sub(v) for k, v in state.cameras.items()},
+        extras={k: take(v) for k, v in (state.extras or {}).items()},
+    )
+
+
 def state_tensor_to_nested(handler: BaseSimHandler, tensor_state: TensorState) -> list[DictEnvState]:
     """Convert a tensor state to a list of env states. All the tensors will be converted to cpu for compatibility."""
     num_envs = next(iter(chain(tensor_state.objects.values(), tensor_state.robots.values()))).root_state.shape[0]


### PR DESCRIPTION
Stacked on #820; retarget to main once that merges.

Four "stop the bleeding" items from the architecture review, each with a contract test in `metasim/test/test_core_contracts_general.py`:

1. **Package order** — `get_package_candidates` searches MetaSim's bundled `defaults` (the example pack) **last**. Verified before the change: in a RoboVerse checkout `get_robot("franka")` returned `metasim.example.example_pack.robots.franka_cfg.FrankaCfg` (different `mjx_mjcf_path`) — 200 `robots=["..."]` call sites were silently using example configs. `_lookup_cfg` now also warns once when a name is defined in several packages.
2. **Shared class scenario** — `GymEnvWrapper` / `GymVectorEnvAdapter` called `task_cls.scenario.update(...)` on the class attribute (in-place, returns self), so `gym.make` permanently rewrote the task's default (and forced `num_envs=1`) for the whole process. They now update a deepcopy; `ScenarioCfg.replace(**kw)` is the copying variant for new code. `update()` itself is unchanged (54 call sites rely on in-place).
3. **`env_ids` contract** — six backends accept `env_ids` in `_get_states` and ignore it. `BaseSimHandler.get_states(env_ids=...)` now slices the full batch (new `select_envs`), warns once, and raises if a backend returns a batch that is neither the subset nor the full set.
4. **Index cache location** — `~/.cache/metasim` (XDG) instead of the shared temp dir.

Tests: MetaSim general suite 517 passed (`test_package_candidates_merge_sources_in_order` updated for the new order).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw