### PR TITLE
style(learn): bring roboverse_learn under ruff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ release.
 ## [Unreleased]
 
 ### Changed
+- `roboverse_learn` is linted and formatted by ruff like the rest of the tree (it was in `extend-exclude`, so CI never parsed its 26k lines): 97 auto-fixes applied (unused imports, import order, f-strings), `super(__class__, self)` / nested `max` / `stacklevel` / mutable-default findings fixed, an undefined `lighten` removed from `pymunk_override.__all__`; the remaining style families (`FA100`, `UP006`, `UP045`, `E731`, `B006`, `RUF013`, `F811`) are per-file-ignored for that directory as tracked debt.
 - MetaSim now lives in this repository under `packages/metasim` (imported with `git subtree`, history preserved) and is released in lockstep as `roboverse-metasim`; `roboverse-py` depends on `roboverse-metasim>=1.0.0b0,<1.1` instead of a git `@main` URL. Install with `pip install -e "packages/metasim[mujoco]" -e ".[mujoco]"` (MetaSim first). CI runs MetaSim's simulator-free suite on 3.10/3.11 alongside the RoboVerse suite; `changelog.yml` guards one CHANGELOG per package; `release.yml` builds and publishes both from one tag.
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,6 @@ lint.ignore = [
     "PLE0604", # allow __all__ to be nested but still all elements are strings
 ]
 extend-exclude = [
-    "roboverse_learn",
     "wandb",
     "third_party",
     "tmp",
@@ -185,6 +184,11 @@ roboverse_pack = [
 [tool.ruff.lint.per-file-ignores]
 ## For normal scripts, allow print statements, allow no docstrings
 "scripts/**.py" = ["T20", "D"]
+# roboverse_learn was excluded from ruff entirely until 2026-09; it now runs with the same F/E/I
+# rules as the rest of the tree. The style families below are tracked debt for this directory
+# (505 findings at inclusion time): remove a code from this list when its findings are fixed.
+"roboverse_learn/**.py" = ["D", "T20", "FA100", "UP006", "UP045", "E731", "B006", "RUF013", "F811"]
+"roboverse_learn/vla/pi0/train_config_snippet.py" = ["F821"]  # paste-in snippet for an openpi config, not a module
 "tools/**.py" = ["T20", "D"]  # research / diagnostic harnesses
 "roboverse_pack/tasks/maniskill/utils/**.py" = ["T20", "D"]
 ## For get_started scripts, allow no docstrings
@@ -200,7 +204,6 @@ roboverse_pack = [
 ## For tasks, allow no docstrings in public modules
 "roboverse_pack/tasks/**/*.py" = ["D100"]
 ## For roboverse_learn, allow no docstrings, allow print
-"roboverse_learn/**.py" = ["D", "T20"]
 ## Temporary disable linting for quick testing
 "roboverse_pack/robots/**.py" = ["D"]  # FIXME: whoever in charge of the robot add docstring and remove this
 "roboverse_pack/scenes/**.py" = ["D"]  # FIXME: Charlie add docstring and remove this

--- a/roboverse_learn/fusion/__init__.py
+++ b/roboverse_learn/fusion/__init__.py
@@ -25,8 +25,8 @@ from __future__ import annotations
 
 __all__ = [
     "collect_demos_from_policy",
-    "load_bc_into_actor_critic",
     "extract_actor_mlp_state_dict",
+    "load_bc_into_actor_critic",
 ]
 
 

--- a/roboverse_learn/fusion/bc_warmstart.py
+++ b/roboverse_learn/fusion/bc_warmstart.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 import torch
 
 
-def _ordered_linear_keys(state_dict: "OrderedDict[str, torch.Tensor]") -> list[str]:
+def _ordered_linear_keys(state_dict: OrderedDict[str, torch.Tensor]) -> list[str]:
     """Return ``*.weight`` keys of Linear layers, in declaration order.
 
     A key ``k.weight`` is treated as a Linear layer iff its tensor is 2-D and a
@@ -36,14 +36,14 @@ def _ordered_linear_keys(state_dict: "OrderedDict[str, torch.Tensor]") -> list[s
     return keys
 
 
-def _as_state_dict(obj) -> "OrderedDict[str, torch.Tensor]":
+def _as_state_dict(obj) -> OrderedDict[str, torch.Tensor]:
     sd = obj.state_dict() if hasattr(obj, "state_dict") else obj
     return OrderedDict(sd)
 
 
 def align_linear_layers(
-    src: "OrderedDict[str, torch.Tensor] | torch.nn.Module",
-    dst: "OrderedDict[str, torch.Tensor] | torch.nn.Module",
+    src: OrderedDict[str, torch.Tensor] | torch.nn.Module,
+    dst: OrderedDict[str, torch.Tensor] | torch.nn.Module,
 ) -> list[tuple[str, str]]:
     """Pair src->dst Linear layers in order, asserting matching shapes.
 
@@ -72,7 +72,7 @@ def align_linear_layers(
 
 def load_bc_into_actor_critic(
     actor_critic: torch.nn.Module,
-    bc_source: "OrderedDict[str, torch.Tensor] | torch.nn.Module",
+    bc_source: OrderedDict[str, torch.Tensor] | torch.nn.Module,
     *,
     actor_attr: str = "actor",
     strict: bool = True,
@@ -116,10 +116,10 @@ def load_bc_into_actor_critic(
 
 
 def extract_actor_mlp_state_dict(
-    actor_source: "OrderedDict[str, torch.Tensor] | torch.nn.Module",
+    actor_source: OrderedDict[str, torch.Tensor] | torch.nn.Module,
     *,
     actor_attr: str = "actor",
-) -> "OrderedDict[str, torch.Tensor]":
+) -> OrderedDict[str, torch.Tensor]:
     """Pull the actor's MLP Linear layers out as a standalone, BC-loadable dict.
 
     Keys are kept *relative to the actor and unchanged* (e.g. ``mlp.0.weight``,
@@ -131,7 +131,7 @@ def extract_actor_mlp_state_dict(
     """
     src = getattr(actor_source, actor_attr, actor_source) if hasattr(actor_source, actor_attr) else actor_source
     sd = _as_state_dict(src)
-    out: "OrderedDict[str, torch.Tensor]" = OrderedDict()
+    out: OrderedDict[str, torch.Tensor] = OrderedDict()
     for wk in _ordered_linear_keys(sd):
         bk = wk[: -len(".weight")] + ".bias"
         out[wk] = sd[wk].clone()

--- a/roboverse_learn/fusion/pipeline.py
+++ b/roboverse_learn/fusion/pipeline.py
@@ -78,28 +78,55 @@ def build_commands(args: Args) -> list[list[str]]:
     for stage in args.stages:
         if stage == "rl-train":
             cmds.append([
-                py, os.path.join(_REPO, "roboverse_learn", "rl", "rsl_rl", "ppo.py"),
-                "--task", args.task, "--robot", args.robot, "--sim", args.sim,
-                "--model_dir", model_dir, "--max_iterations", str(args.rl_iterations),
+                py,
+                os.path.join(_REPO, "roboverse_learn", "rl", "rsl_rl", "ppo.py"),
+                "--task",
+                args.task,
+                "--robot",
+                args.robot,
+                "--sim",
+                args.sim,
+                "--model_dir",
+                model_dir,
+                "--max_iterations",
+                str(args.rl_iterations),
             ])
         elif stage == "collect":
             cmd = [
-                py, "-m", "roboverse_learn.fusion.collect",
-                "--task", args.task, "--robot", args.robot, "--sim", args.sim,
-                "--checkpoint", checkpoint, "--out_dir", demo_dir, "--num_demos", str(args.num_demos),
+                py,
+                "-m",
+                "roboverse_learn.fusion.collect",
+                "--task",
+                args.task,
+                "--robot",
+                args.robot,
+                "--sim",
+                args.sim,
+                "--checkpoint",
+                checkpoint,
+                "--out_dir",
+                demo_dir,
+                "--num_demos",
+                str(args.num_demos),
             ]
             if args.keep_all:
                 cmd.append("--keep_all")
             cmds.append(cmd)
         elif stage == "to-zarr":
             cmds.append([
-                py, os.path.join(_REPO, "roboverse_learn", "il", "data2zarr_dp.py"),
-                "--task_name", args.name, "--metadata_dir", os.path.join(demo_dir, "success"),
-                "--expert_data_num", str(args.num_demos),
+                py,
+                os.path.join(_REPO, "roboverse_learn", "il", "data2zarr_dp.py"),
+                "--task_name",
+                args.name,
+                "--metadata_dir",
+                os.path.join(demo_dir, "success"),
+                "--expert_data_num",
+                str(args.num_demos),
             ])
         elif stage == "il-train":
             cmds.append([
-                py, os.path.join(_REPO, "roboverse_learn", "il", "train.py"),
+                py,
+                os.path.join(_REPO, "roboverse_learn", "il", "train.py"),
                 f"task.dataset.zarr_path=data_policy/{args.name}_{args.num_demos}.zarr",
             ])
     return cmds

--- a/roboverse_learn/fusion/rl_to_demo.py
+++ b/roboverse_learn/fusion/rl_to_demo.py
@@ -62,7 +62,6 @@ def _mlp_from_linear_state_dict(sd, device, activation=None):
     """
     import re
 
-    import torch
     import torch.nn as nn
 
     activation = activation or nn.ELU
@@ -120,7 +119,9 @@ def _load_inference_policy(env_wrapper, train_cfg, checkpoint: str, device):
     if actor_sd is not None:
         mlp = _mlp_from_linear_state_dict(actor_sd, device)
         if mlp is not None:
-            log.info(f"[rl_to_demo] loaded actor MLP ({sum(1 for k in actor_sd if k.endswith('.weight'))} layers) from {checkpoint}")
+            log.info(
+                f"[rl_to_demo] loaded actor MLP ({sum(1 for k in actor_sd if k.endswith('.weight'))} layers) from {checkpoint}"
+            )
             return lambda obs: mlp(obs if isinstance(obs, torch.Tensor) else obs["policy"])
 
     # 3) rsl-rl runner checkpoint.
@@ -156,7 +157,7 @@ def collect_demos_from_policy(
     device: str = "cuda:0",
     train_cfg=None,
     camera_cfg=None,
-    success_fn: Callable[..., "Sequence[bool]"] | None = None,
+    success_fn: Callable[..., Sequence[bool]] | None = None,
     task_desc: str = "",
     deterministic: bool = True,
 ) -> int:
@@ -198,7 +199,8 @@ def collect_demos_from_policy(
     policy = _load_inference_policy(env_wrapper, train_cfg, checkpoint, dev)
 
     if success_fn is None:
-        def success_fn(terminated, cache, info):  # noqa: ANN001 - default checker-based
+
+        def success_fn(terminated, cache, info):
             return bool(terminated)
 
     os.makedirs(os.path.join(out_dir, "success"), exist_ok=True)

--- a/roboverse_learn/il/data2zarr_dp.py
+++ b/roboverse_learn/il/data2zarr_dp.py
@@ -100,7 +100,9 @@ def main():
                     continue
 
         demo_indices.sort()
-        print(f"Found {len(demo_indices)} demos in success folder: {demo_indices[:10]}{'...' if len(demo_indices) > 10 else ''}")
+        print(
+            f"Found {len(demo_indices)} demos in success folder: {demo_indices[:10]}{'...' if len(demo_indices) > 10 else ''}"
+        )
 
         # Use actual number of demos if requested number is not enough
         if len(demo_indices) < num:
@@ -151,11 +153,11 @@ def main():
             print(f"Skipping episode {demo_idx} as directory {demo_dir} does not exist.")
             continue
 
-         # Check metadata.json
+        # Check metadata.json
         metadata_path = os.path.join(demo_dir, "metadata.json")
         if not os.path.isfile(metadata_path):
-          print(f"Skipping episode {demo_idx} as metadata.json does not exist.")
-          continue
+            print(f"Skipping episode {demo_idx} as metadata.json does not exist.")
+            continue
         else:
             with open(os.path.join(demo_dir, "metadata.json"), encoding="utf-8") as f:
                 # print("metadata load dir:", demo_dir)

--- a/roboverse_learn/il/datasets/robot_image_dataset.py
+++ b/roboverse_learn/il/datasets/robot_image_dataset.py
@@ -17,7 +17,10 @@ except Exception:  # ImportError, or numba's NumPy-version guard
     _HAS_NUMBA = False
     _prange = range
 import torch
+
+from roboverse_learn.il.datasets.base_dataset import BaseImageDataset
 from roboverse_learn.il.utils.normalize_util import get_image_range_normalizer
+from roboverse_learn.il.utils.normalizer import LinearNormalizer
 from roboverse_learn.il.utils.pytorch_util import dict_apply
 from roboverse_learn.il.utils.replay_buffer import ReplayBuffer
 from roboverse_learn.il.utils.sampler import (
@@ -25,8 +28,6 @@ from roboverse_learn.il.utils.sampler import (
     downsample_mask,
     get_val_mask,
 )
-from roboverse_learn.il.datasets.base_dataset import BaseImageDataset
-from roboverse_learn.il.utils.normalizer import LinearNormalizer
 
 
 class RobotImageDataset(BaseImageDataset):

--- a/roboverse_learn/il/policies/act/act_eval_runner.py
+++ b/roboverse_learn/il/policies/act/act_eval_runner.py
@@ -15,17 +15,16 @@ from rich.logging import RichHandler
 rootutils.setup_root(__file__, pythonpath=True)
 log.configure(handlers=[{"sink": RichHandler(), "format": "{message}"}])
 
-from metasim.utils.kinematics import get_curobo_models
 from metasim.task.registry import get_task_class
 
 # Try to import randomization components
 try:
     from metasim.randomization import DomainRandomizationManager, DRConfig
+
     RANDOMIZATION_AVAILABLE = True
 except ImportError as e:
     log.warning(f"Domain randomization not available: {e}")
     RANDOMIZATION_AVAILABLE = False
-
 
 
 def images_to_video(images, video_path, frame_size=(1920, 1080), fps=30):
@@ -180,20 +179,20 @@ def parse_args():
         type=int,
         default=0,
         choices=[0, 1, 2, 3],
-        help="Randomization level: 0=None, 1=Scene+Material, 2=+Light, 3=+Camera"
+        help="Randomization level: 0=None, 1=Scene+Material, 2=+Light, 3=+Camera",
     )
     parser.add_argument(
         "--scene_mode",
         type=int,
         default=0,
         choices=[0, 1, 2, 3],
-        help="Scene mode: 0=Manual, 1=USD Table, 2=USD Scene, 3=Full USD"
+        help="Scene mode: 0=Manual, 1=USD Table, 2=USD Scene, 3=Full USD",
     )
     parser.add_argument(
         "--randomization_seed",
         type=int,
         default=None,
-        help="Seed for reproducible randomization. If None, uses random seed"
+        help="Seed for reproducible randomization. If None, uses random seed",
     )
 
     args = parser.parse_args()
@@ -244,7 +243,7 @@ def main():
 
     # Lighting setup (same logic as collect_demo.py)
     # Determine intensity based on render mode (if available)
-    render_mode = getattr(args, 'render_mode', 'raytracing')
+    render_mode = getattr(args, "render_mode", "raytracing")
     if render_mode == "pathtracing":
         ceiling_main = 18000.0
         ceiling_corners = 8000.0
@@ -281,7 +280,7 @@ def main():
         num_envs=args.num_envs,
         headless=args.headless,
         lights=lights,
-        cameras=[camera]
+        cameras=[camera],
     )
 
     tic = time.time()
@@ -293,9 +292,7 @@ def main():
 
     ## Data
     tic = time.time()
-    assert os.path.exists(env.traj_filepath), (
-        f"Trajectory file: {env.traj_filepath} does not exist."
-    )
+    assert os.path.exists(env.traj_filepath), f"Trajectory file: {env.traj_filepath} does not exist."
     init_states, all_actions, all_states = get_traj(env.traj_filepath, robot, env.handler)
     toc = time.time()
     log.trace(f"Time to load data: {toc - tic:.2f}s")
@@ -306,10 +303,11 @@ def main():
         raise ImportError("Domain Randomization not available. Please check installation.")
 
     # Determine render mode from args
-    render_mode = getattr(args, 'render_mode', 'raytracing')
+    render_mode = getattr(args, "render_mode", "raytracing")
 
     # Create render config for DR
     from dataclasses import dataclass
+
     @dataclass
     class SimpleRenderCfg:
         mode: str = render_mode
@@ -323,7 +321,7 @@ def main():
         scenario=scenario,
         handler=env.handler,
         init_states=init_states,
-        render_cfg=SimpleRenderCfg(mode=render_mode)
+        render_cfg=SimpleRenderCfg(mode=render_mode),
     )
 
     if args.algo == "act":
@@ -372,9 +370,8 @@ def main():
             stats = pickle.load(f)
 
         def pre_process(s_qpos):
-           # return (s_qpos - stats["qpos_mean"]) / stats["qpos_std"]
+            # return (s_qpos - stats["qpos_mean"]) / stats["qpos_std"]
             return (s_qpos - stats["state_mean"]) / stats["state_std"]
-
 
         def post_process(a):
             return a * stats["action_std"] + stats["action_mean"]
@@ -440,15 +437,15 @@ def main():
                 # log.debug(f"Step {step}")
                 robot_joint_limits = scenario.robots[0].joint_limits
 
-                image_list.append(np.array(obs.cameras['camera'].rgb.cpu())[0])
+                image_list.append(np.array(obs.cameras["camera"].rgb.cpu())[0])
 
-                qpos_numpy = np.array(obs.robots['franka'].joint_pos.cpu())
+                qpos_numpy = np.array(obs.robots["franka"].joint_pos.cpu())
                 # qpos_numpy = np.array(obs["joint_qpos"])
                 qpos = pre_process(qpos_numpy)
                 # qpos = np.concatenate([qpos, np.zeros((qpos.shape[0], 14 - qpos.shape[1]))], axis=1)
                 qpos = torch.from_numpy(qpos).float().cuda()
                 qpos_history[:, step] = qpos
-                curr_image = np.array(obs.cameras['camera'].rgb.cpu()).transpose(0, 3, 1, 2)
+                curr_image = np.array(obs.cameras["camera"].rgb.cpu()).transpose(0, 3, 1, 2)
                 # cur_image = np.stack([curr_image, curr_image], axis=0)
                 curr_image = torch.from_numpy(curr_image / 255.0).float().cuda().unsqueeze(0)
                 # breakpoint()
@@ -481,7 +478,7 @@ def main():
                 inner_actions = {"dof_pos_target": dict(zip(scenario.robots[0].joint_limits.keys(), actions))}
                 # Format: actions[env_id][robot_name][action_type]
                 actions = [{"franka": inner_actions}]
-                #log.debug(f"Actions: {actions}")
+                # log.debug(f"Actions: {actions}")
                 # log.debug(f"Action: {actions}")
                 obs, reward, success, time_out, extras = env.step(actions)
                 env.handler.refresh_render()

--- a/roboverse_learn/il/policies/act/constants.py
+++ b/roboverse_learn/il/policies/act/constants.py
@@ -1,43 +1,40 @@
 import pathlib
 
 ### Task parameters
-DATA_DIR = 'sim_data'
+DATA_DIR = "sim_data"
 SIM_TASK_CONFIGS = {
-    'sim_transfer_cube_scripted':{
-        'dataset_dir': DATA_DIR + '/sim_transfer_cube_scripted',
-        'num_episodes': 5,
-        'episode_len': 400,
-        'camera_names': ['top']
+    "sim_transfer_cube_scripted": {
+        "dataset_dir": DATA_DIR + "/sim_transfer_cube_scripted",
+        "num_episodes": 5,
+        "episode_len": 400,
+        "camera_names": ["top"],
     },
-
-    'sim_transfer_cube_human':{
-        'dataset_dir': DATA_DIR + '/sim_transfer_cube_human',
-        'num_episodes': 50,
-        'episode_len': 400,
-        'camera_names': ['top']
+    "sim_transfer_cube_human": {
+        "dataset_dir": DATA_DIR + "/sim_transfer_cube_human",
+        "num_episodes": 50,
+        "episode_len": 400,
+        "camera_names": ["top"],
     },
-
-    'sim_insertion_scripted': {
-        'dataset_dir': DATA_DIR + '/sim_insertion_scripted',
-        'num_episodes': 50,
-        'episode_len': 400,
-        'camera_names': ['top']
+    "sim_insertion_scripted": {
+        "dataset_dir": DATA_DIR + "/sim_insertion_scripted",
+        "num_episodes": 50,
+        "episode_len": 400,
+        "camera_names": ["top"],
     },
-
-    'sim_insertion_human': {
-        'dataset_dir': DATA_DIR + '/sim_insertion_human',
-        'num_episodes': 50,
-        'episode_len': 500,
-        'camera_names': ['top']
+    "sim_insertion_human": {
+        "dataset_dir": DATA_DIR + "/sim_insertion_human",
+        "num_episodes": 50,
+        "episode_len": 500,
+        "camera_names": ["top"],
     },
 }
 
 ### Simulation envs fixed constants
 DT = 0.02
 JOINT_NAMES = ["waist", "shoulder", "elbow", "forearm_roll", "wrist_angle", "wrist_rotate"]
-START_ARM_POSE = [0, -0.96, 1.16, 0, -0.3, 0, 0.02239, -0.02239,  0, -0.96, 1.16, 0, -0.3, 0, 0.02239, -0.02239]
+START_ARM_POSE = [0, -0.96, 1.16, 0, -0.3, 0, 0.02239, -0.02239, 0, -0.96, 1.16, 0, -0.3, 0, 0.02239, -0.02239]
 
-XML_DIR = str(pathlib.Path(__file__).parent.resolve()) + '/assets/' # note: absolute path
+XML_DIR = str(pathlib.Path(__file__).parent.resolve()) + "/assets/"  # note: absolute path
 
 # Left finger position limits (qpos[7]), right_finger = -1 * left_finger
 MASTER_GRIPPER_POSITION_OPEN = 0.02417
@@ -53,24 +50,50 @@ PUPPET_GRIPPER_JOINT_CLOSE = -0.6213
 
 ############################ Helper functions ############################
 
-MASTER_GRIPPER_POSITION_NORMALIZE_FN = lambda x: (x - MASTER_GRIPPER_POSITION_CLOSE) / (MASTER_GRIPPER_POSITION_OPEN - MASTER_GRIPPER_POSITION_CLOSE)
-PUPPET_GRIPPER_POSITION_NORMALIZE_FN = lambda x: (x - PUPPET_GRIPPER_POSITION_CLOSE) / (PUPPET_GRIPPER_POSITION_OPEN - PUPPET_GRIPPER_POSITION_CLOSE)
-MASTER_GRIPPER_POSITION_UNNORMALIZE_FN = lambda x: x * (MASTER_GRIPPER_POSITION_OPEN - MASTER_GRIPPER_POSITION_CLOSE) + MASTER_GRIPPER_POSITION_CLOSE
-PUPPET_GRIPPER_POSITION_UNNORMALIZE_FN = lambda x: x * (PUPPET_GRIPPER_POSITION_OPEN - PUPPET_GRIPPER_POSITION_CLOSE) + PUPPET_GRIPPER_POSITION_CLOSE
+MASTER_GRIPPER_POSITION_NORMALIZE_FN = lambda x: (x - MASTER_GRIPPER_POSITION_CLOSE) / (
+    MASTER_GRIPPER_POSITION_OPEN - MASTER_GRIPPER_POSITION_CLOSE
+)
+PUPPET_GRIPPER_POSITION_NORMALIZE_FN = lambda x: (x - PUPPET_GRIPPER_POSITION_CLOSE) / (
+    PUPPET_GRIPPER_POSITION_OPEN - PUPPET_GRIPPER_POSITION_CLOSE
+)
+MASTER_GRIPPER_POSITION_UNNORMALIZE_FN = (
+    lambda x: x * (MASTER_GRIPPER_POSITION_OPEN - MASTER_GRIPPER_POSITION_CLOSE) + MASTER_GRIPPER_POSITION_CLOSE
+)
+PUPPET_GRIPPER_POSITION_UNNORMALIZE_FN = (
+    lambda x: x * (PUPPET_GRIPPER_POSITION_OPEN - PUPPET_GRIPPER_POSITION_CLOSE) + PUPPET_GRIPPER_POSITION_CLOSE
+)
 MASTER2PUPPET_POSITION_FN = lambda x: PUPPET_GRIPPER_POSITION_UNNORMALIZE_FN(MASTER_GRIPPER_POSITION_NORMALIZE_FN(x))
 
-MASTER_GRIPPER_JOINT_NORMALIZE_FN = lambda x: (x - MASTER_GRIPPER_JOINT_CLOSE) / (MASTER_GRIPPER_JOINT_OPEN - MASTER_GRIPPER_JOINT_CLOSE)
-PUPPET_GRIPPER_JOINT_NORMALIZE_FN = lambda x: (x - PUPPET_GRIPPER_JOINT_CLOSE) / (PUPPET_GRIPPER_JOINT_OPEN - PUPPET_GRIPPER_JOINT_CLOSE)
-MASTER_GRIPPER_JOINT_UNNORMALIZE_FN = lambda x: x * (MASTER_GRIPPER_JOINT_OPEN - MASTER_GRIPPER_JOINT_CLOSE) + MASTER_GRIPPER_JOINT_CLOSE
-PUPPET_GRIPPER_JOINT_UNNORMALIZE_FN = lambda x: x * (PUPPET_GRIPPER_JOINT_OPEN - PUPPET_GRIPPER_JOINT_CLOSE) + PUPPET_GRIPPER_JOINT_CLOSE
+MASTER_GRIPPER_JOINT_NORMALIZE_FN = lambda x: (x - MASTER_GRIPPER_JOINT_CLOSE) / (
+    MASTER_GRIPPER_JOINT_OPEN - MASTER_GRIPPER_JOINT_CLOSE
+)
+PUPPET_GRIPPER_JOINT_NORMALIZE_FN = lambda x: (x - PUPPET_GRIPPER_JOINT_CLOSE) / (
+    PUPPET_GRIPPER_JOINT_OPEN - PUPPET_GRIPPER_JOINT_CLOSE
+)
+MASTER_GRIPPER_JOINT_UNNORMALIZE_FN = (
+    lambda x: x * (MASTER_GRIPPER_JOINT_OPEN - MASTER_GRIPPER_JOINT_CLOSE) + MASTER_GRIPPER_JOINT_CLOSE
+)
+PUPPET_GRIPPER_JOINT_UNNORMALIZE_FN = (
+    lambda x: x * (PUPPET_GRIPPER_JOINT_OPEN - PUPPET_GRIPPER_JOINT_CLOSE) + PUPPET_GRIPPER_JOINT_CLOSE
+)
 MASTER2PUPPET_JOINT_FN = lambda x: PUPPET_GRIPPER_JOINT_UNNORMALIZE_FN(MASTER_GRIPPER_JOINT_NORMALIZE_FN(x))
 
 MASTER_GRIPPER_VELOCITY_NORMALIZE_FN = lambda x: x / (MASTER_GRIPPER_POSITION_OPEN - MASTER_GRIPPER_POSITION_CLOSE)
 PUPPET_GRIPPER_VELOCITY_NORMALIZE_FN = lambda x: x / (PUPPET_GRIPPER_POSITION_OPEN - PUPPET_GRIPPER_POSITION_CLOSE)
 
-MASTER_POS2JOINT = lambda x: MASTER_GRIPPER_POSITION_NORMALIZE_FN(x) * (MASTER_GRIPPER_JOINT_OPEN - MASTER_GRIPPER_JOINT_CLOSE) + MASTER_GRIPPER_JOINT_CLOSE
-MASTER_JOINT2POS = lambda x: MASTER_GRIPPER_POSITION_UNNORMALIZE_FN((x - MASTER_GRIPPER_JOINT_CLOSE) / (MASTER_GRIPPER_JOINT_OPEN - MASTER_GRIPPER_JOINT_CLOSE))
-PUPPET_POS2JOINT = lambda x: PUPPET_GRIPPER_POSITION_NORMALIZE_FN(x) * (PUPPET_GRIPPER_JOINT_OPEN - PUPPET_GRIPPER_JOINT_CLOSE) + PUPPET_GRIPPER_JOINT_CLOSE
-PUPPET_JOINT2POS = lambda x: PUPPET_GRIPPER_POSITION_UNNORMALIZE_FN((x - PUPPET_GRIPPER_JOINT_CLOSE) / (PUPPET_GRIPPER_JOINT_OPEN - PUPPET_GRIPPER_JOINT_CLOSE))
+MASTER_POS2JOINT = (
+    lambda x: MASTER_GRIPPER_POSITION_NORMALIZE_FN(x) * (MASTER_GRIPPER_JOINT_OPEN - MASTER_GRIPPER_JOINT_CLOSE)
+    + MASTER_GRIPPER_JOINT_CLOSE
+)
+MASTER_JOINT2POS = lambda x: MASTER_GRIPPER_POSITION_UNNORMALIZE_FN(
+    (x - MASTER_GRIPPER_JOINT_CLOSE) / (MASTER_GRIPPER_JOINT_OPEN - MASTER_GRIPPER_JOINT_CLOSE)
+)
+PUPPET_POS2JOINT = (
+    lambda x: PUPPET_GRIPPER_POSITION_NORMALIZE_FN(x) * (PUPPET_GRIPPER_JOINT_OPEN - PUPPET_GRIPPER_JOINT_CLOSE)
+    + PUPPET_GRIPPER_JOINT_CLOSE
+)
+PUPPET_JOINT2POS = lambda x: PUPPET_GRIPPER_POSITION_UNNORMALIZE_FN(
+    (x - PUPPET_GRIPPER_JOINT_CLOSE) / (PUPPET_GRIPPER_JOINT_OPEN - PUPPET_GRIPPER_JOINT_CLOSE)
+)
 
-MASTER_GRIPPER_JOINT_MID = (MASTER_GRIPPER_JOINT_OPEN + MASTER_GRIPPER_JOINT_CLOSE)/2
+MASTER_GRIPPER_JOINT_MID = (MASTER_GRIPPER_JOINT_OPEN + MASTER_GRIPPER_JOINT_CLOSE) / 2

--- a/roboverse_learn/il/policies/act/detr/main.py
+++ b/roboverse_learn/il/policies/act/detr/main.py
@@ -1,80 +1,121 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
 import argparse
-from pathlib import Path
-
-import numpy as np
-import torch
-from .models import build_ACT_model, build_CNNMLP_model
 
 import IPython
+import torch
+
+from .models import build_ACT_model, build_CNNMLP_model
+
 e = IPython.embed
 
-def get_args_parser():
-    parser = argparse.ArgumentParser('Set transformer detector', add_help=False)
-    parser.add_argument('--lr', default=1e-4, type=float) # will be overridden
-    parser.add_argument('--lr_backbone', default=1e-5, type=float) # will be overridden
-    parser.add_argument('--batch_size', default=2, type=int) # not used
-    parser.add_argument('--weight_decay', default=1e-4, type=float)
-    parser.add_argument('--epochs', default=300, type=int) # not used
-    parser.add_argument('--lr_drop', default=200, type=int) # not used
-    parser.add_argument('--clip_max_norm', default=0.1, type=float, # not used
-                        help='gradient clipping max norm')
-    parser.add_argument('--state_dim', default=9, type=int) # will be overridden
 
+def get_args_parser():
+    parser = argparse.ArgumentParser("Set transformer detector", add_help=False)
+    parser.add_argument("--lr", default=1e-4, type=float)  # will be overridden
+    parser.add_argument("--lr_backbone", default=1e-5, type=float)  # will be overridden
+    parser.add_argument("--batch_size", default=2, type=int)  # not used
+    parser.add_argument("--weight_decay", default=1e-4, type=float)
+    parser.add_argument("--epochs", default=300, type=int)  # not used
+    parser.add_argument("--lr_drop", default=200, type=int)  # not used
+    parser.add_argument(
+        "--clip_max_norm",
+        default=0.1,
+        type=float,  # not used
+        help="gradient clipping max norm",
+    )
+    parser.add_argument("--state_dim", default=9, type=int)  # will be overridden
 
     # Model parameters
     # * Backbone
-    parser.add_argument('--backbone', default='resnet18', type=str, # will be overridden
-                        help="Name of the convolutional backbone to use")
-    parser.add_argument('--dilation', action='store_true',
-                        help="If true, we replace stride with dilation in the last convolutional block (DC5)")
-    parser.add_argument('--position_embedding', default='sine', type=str, choices=('sine', 'learned'),
-                        help="Type of positional embedding to use on top of the image features")
-    parser.add_argument('--camera_names', default=[], type=list, # will be overridden
-                        help="A list of camera names")
+    parser.add_argument(
+        "--backbone",
+        default="resnet18",
+        type=str,  # will be overridden
+        help="Name of the convolutional backbone to use",
+    )
+    parser.add_argument(
+        "--dilation",
+        action="store_true",
+        help="If true, we replace stride with dilation in the last convolutional block (DC5)",
+    )
+    parser.add_argument(
+        "--position_embedding",
+        default="sine",
+        type=str,
+        choices=("sine", "learned"),
+        help="Type of positional embedding to use on top of the image features",
+    )
+    parser.add_argument(
+        "--camera_names",
+        default=[],
+        type=list,  # will be overridden
+        help="A list of camera names",
+    )
 
     # * Transformer
-    parser.add_argument('--enc_layers', default=4, type=int, # will be overridden
-                        help="Number of encoding layers in the transformer")
-    parser.add_argument('--dec_layers', default=6, type=int, # will be overridden
-                        help="Number of decoding layers in the transformer")
-    parser.add_argument('--dim_feedforward', default=2048, type=int, # will be overridden
-                        help="Intermediate size of the feedforward layers in the transformer blocks")
-    parser.add_argument('--hidden_dim', default=256, type=int, # will be overridden
-                        help="Size of the embeddings (dimension of the transformer)")
-    parser.add_argument('--dropout', default=0.1, type=float,
-                        help="Dropout applied in the transformer")
-    parser.add_argument('--nheads', default=8, type=int, # will be overridden
-                        help="Number of attention heads inside the transformer's attentions")
-    parser.add_argument('--num_queries', default=400, type=int, # will be overridden
-                        help="Number of query slots")
-    parser.add_argument('--pre_norm', action='store_true')
+    parser.add_argument(
+        "--enc_layers",
+        default=4,
+        type=int,  # will be overridden
+        help="Number of encoding layers in the transformer",
+    )
+    parser.add_argument(
+        "--dec_layers",
+        default=6,
+        type=int,  # will be overridden
+        help="Number of decoding layers in the transformer",
+    )
+    parser.add_argument(
+        "--dim_feedforward",
+        default=2048,
+        type=int,  # will be overridden
+        help="Intermediate size of the feedforward layers in the transformer blocks",
+    )
+    parser.add_argument(
+        "--hidden_dim",
+        default=256,
+        type=int,  # will be overridden
+        help="Size of the embeddings (dimension of the transformer)",
+    )
+    parser.add_argument("--dropout", default=0.1, type=float, help="Dropout applied in the transformer")
+    parser.add_argument(
+        "--nheads",
+        default=8,
+        type=int,  # will be overridden
+        help="Number of attention heads inside the transformer's attentions",
+    )
+    parser.add_argument(
+        "--num_queries",
+        default=400,
+        type=int,  # will be overridden
+        help="Number of query slots",
+    )
+    parser.add_argument("--pre_norm", action="store_true")
 
     # * Segmentation
-    parser.add_argument('--masks', action='store_true',
-                        help="Train segmentation head if the flag is provided")
+    parser.add_argument("--masks", action="store_true", help="Train segmentation head if the flag is provided")
 
     # repeat args in imitate_episodes just to avoid error. Will not be used
-    parser.add_argument('--num_episodes', action='store', type=int, help='num_episodes', required=False)
-    parser.add_argument('--dataset_dir', action='store', type=str, help='dataset_dir', required=False)
-    parser.add_argument('--eval', action='store_true')
-    parser.add_argument('--onscreen_render', action='store_true')
-    parser.add_argument('--ckpt_dir', action='store', type=str, help='ckpt_dir', default='act_tmp')
-    parser.add_argument('--policy_class', action='store', type=str, help='policy_class, capitalize', default='ACT')
-    parser.add_argument('--task_name', action='store', type=str, help='task_name', required=True)
-    parser.add_argument('--seed', action='store', type=int, help='seed', default=0)
-    parser.add_argument('--num_epochs', action='store', type=int, help='num_epochs', default=2000)
-    parser.add_argument('--kl_weight', action='store', type=int, help='KL Weight', required=False)
-    parser.add_argument('--chunk_size', action='store', type=int, help='chunk_size', required=False)
-    parser.add_argument('--temporal_agg', action='store_true')
-    parser.add_argument('--algo', type=str, default='act', help='algorithm to use')
-    parser.add_argument('--ckpt_path', type=str, default=None, help='path to checkpoint')
+    parser.add_argument("--num_episodes", action="store", type=int, help="num_episodes", required=False)
+    parser.add_argument("--dataset_dir", action="store", type=str, help="dataset_dir", required=False)
+    parser.add_argument("--eval", action="store_true")
+    parser.add_argument("--onscreen_render", action="store_true")
+    parser.add_argument("--ckpt_dir", action="store", type=str, help="ckpt_dir", default="act_tmp")
+    parser.add_argument("--policy_class", action="store", type=str, help="policy_class, capitalize", default="ACT")
+    parser.add_argument("--task_name", action="store", type=str, help="task_name", required=True)
+    parser.add_argument("--seed", action="store", type=int, help="seed", default=0)
+    parser.add_argument("--num_epochs", action="store", type=int, help="num_epochs", default=2000)
+    parser.add_argument("--kl_weight", action="store", type=int, help="KL Weight", required=False)
+    parser.add_argument("--chunk_size", action="store", type=int, help="chunk_size", required=False)
+    parser.add_argument("--temporal_agg", action="store_true")
+    parser.add_argument("--algo", type=str, default="act", help="algorithm to use")
+    parser.add_argument("--ckpt_path", type=str, default=None, help="path to checkpoint")
 
     return parser
 
 
 def build_ACT_model_and_optimizer(args_override):
-    parser = argparse.ArgumentParser('DETR training and evaluation script', parents=[get_args_parser()])
+    parser = argparse.ArgumentParser("DETR training and evaluation script", parents=[get_args_parser()])
     args, _ = parser.parse_known_args()
 
     for k, v in args_override.items():
@@ -90,14 +131,13 @@ def build_ACT_model_and_optimizer(args_override):
             "lr": args.lr_backbone,
         },
     ]
-    optimizer = torch.optim.AdamW(param_dicts, lr=args.lr,
-                                  weight_decay=args.weight_decay)
+    optimizer = torch.optim.AdamW(param_dicts, lr=args.lr, weight_decay=args.weight_decay)
 
     return model, optimizer
 
 
 def build_CNNMLP_model_and_optimizer(args_override):
-    parser = argparse.ArgumentParser('DETR training and evaluation script', parents=[get_args_parser()])
+    parser = argparse.ArgumentParser("DETR training and evaluation script", parents=[get_args_parser()])
     args, _ = parser.parse_known_args()
 
     for k, v in args_override.items():
@@ -113,7 +153,6 @@ def build_CNNMLP_model_and_optimizer(args_override):
             "lr": args.lr_backbone,
         },
     ]
-    optimizer = torch.optim.AdamW(param_dicts, lr=args.lr,
-                                  weight_decay=args.weight_decay)
+    optimizer = torch.optim.AdamW(param_dicts, lr=args.lr, weight_decay=args.weight_decay)
 
     return model, optimizer

--- a/roboverse_learn/il/policies/act/detr/models/__init__.py
+++ b/roboverse_learn/il/policies/act/detr/models/__init__.py
@@ -2,8 +2,10 @@
 from .detr_vae import build as build_vae
 from .detr_vae import build_cnnmlp as build_cnnmlp
 
+
 def build_ACT_model(args):
     return build_vae(args)
+
 
 def build_CNNMLP_model(args):
     return build_cnnmlp(args)

--- a/roboverse_learn/il/policies/act/detr/models/backbone.py
+++ b/roboverse_learn/il/policies/act/detr/models/backbone.py
@@ -2,20 +2,19 @@
 """
 Backbone modules.
 """
-from collections import OrderedDict
 
+from typing import List
+
+import IPython
 import torch
-import torch.nn.functional as F
 import torchvision
 from torch import nn
 from torchvision.models._utils import IntermediateLayerGetter
-from typing import Dict, List
 
 from roboverse_learn.il.policies.act.detr.util import NestedTensor, is_main_process
 
 from .position_encoding import build_position_encoding
 
-import IPython
 e = IPython.embed
 
 
@@ -29,21 +28,22 @@ class FrozenBatchNorm2d(torch.nn.Module):
     """
 
     def __init__(self, n):
-        super(FrozenBatchNorm2d, self).__init__()
+        super().__init__()
         self.register_buffer("weight", torch.ones(n))
         self.register_buffer("bias", torch.zeros(n))
         self.register_buffer("running_mean", torch.zeros(n))
         self.register_buffer("running_var", torch.ones(n))
 
-    def _load_from_state_dict(self, state_dict, prefix, local_metadata, strict,
-                              missing_keys, unexpected_keys, error_msgs):
-        num_batches_tracked_key = prefix + 'num_batches_tracked'
+    def _load_from_state_dict(
+        self, state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+    ):
+        num_batches_tracked_key = prefix + "num_batches_tracked"
         if num_batches_tracked_key in state_dict:
             del state_dict[num_batches_tracked_key]
 
-        super(FrozenBatchNorm2d, self)._load_from_state_dict(
-            state_dict, prefix, local_metadata, strict,
-            missing_keys, unexpected_keys, error_msgs)
+        super()._load_from_state_dict(
+            state_dict, prefix, local_metadata, strict, missing_keys, unexpected_keys, error_msgs
+        )
 
     def forward(self, x):
         # move reshapes to the beginning
@@ -59,7 +59,6 @@ class FrozenBatchNorm2d(torch.nn.Module):
 
 
 class BackboneBase(nn.Module):
-
     def __init__(self, backbone: nn.Module, train_backbone: bool, num_channels: int, return_interm_layers: bool):
         super().__init__()
         # for name, parameter in backbone.named_parameters(): # only train later layers # TODO do we want this?
@@ -68,7 +67,7 @@ class BackboneBase(nn.Module):
         if return_interm_layers:
             return_layers = {"layer1": "0", "layer2": "1", "layer3": "2", "layer4": "3"}
         else:
-            return_layers = {'layer4': "0"}
+            return_layers = {"layer4": "0"}
         self.body = IntermediateLayerGetter(backbone, return_layers=return_layers)
         self.num_channels = num_channels
 
@@ -80,14 +79,13 @@ class BackboneBase(nn.Module):
 class Backbone(BackboneBase):
     """ResNet backbone with frozen BatchNorm."""
 
-    def __init__(self, name: str,
-                 train_backbone: bool,
-                 return_interm_layers: bool,
-                 dilation: bool):
+    def __init__(self, name: str, train_backbone: bool, return_interm_layers: bool, dilation: bool):
         backbone = getattr(torchvision.models, name)(
             replace_stride_with_dilation=[False, False, dilation],
-            pretrained=is_main_process(), norm_layer=FrozenBatchNorm2d)  # pretrained # TODO do we want frozen batch_norm??
-        num_channels = 512 if name in ('resnet18', 'resnet34') else 2048
+            pretrained=is_main_process(),
+            norm_layer=FrozenBatchNorm2d,
+        )  # pretrained # TODO do we want frozen batch_norm??
+        num_channels = 512 if name in ("resnet18", "resnet34") else 2048
         super().__init__(backbone, train_backbone, num_channels, return_interm_layers)
 
 

--- a/roboverse_learn/il/policies/act/detr/models/detr_vae.py
+++ b/roboverse_learn/il/policies/act/detr/models/detr_vae.py
@@ -2,18 +2,16 @@
 """
 DETR model and criterion classes.
 """
+
+import IPython
+import numpy as np
 import torch
 from torch import nn
 from torch.autograd import Variable
+
 from .backbone import build_backbone
-from .transformer import build_transformer, TransformerEncoder, TransformerEncoderLayer
+from .transformer import TransformerEncoder, TransformerEncoderLayer, build_transformer
 
-import numpy as np
-
-from loguru import logger as log
-
-
-import IPython
 e = IPython.embed
 
 
@@ -35,9 +33,10 @@ def get_sinusoid_encoding_table(n_position, d_hid):
 
 
 class DETRVAE(nn.Module):
-    """ This is the DETR module that performs object detection """
+    """This is the DETR module that performs object detection"""
+
     def __init__(self, backbones, transformer, encoder, state_dim, num_queries, camera_names):
-        """ Initializes the model.
+        """Initializes the model.
         Parameters:
             backbones: torch module of the backbone to be used. See backbone.py
             transformer: torch module of the transformer architecture. See transformer.py
@@ -67,16 +66,18 @@ class DETRVAE(nn.Module):
             self.backbones = None
 
         # encoder extra parameters
-        self.latent_dim = 32 # final size of latent z # TODO tune
-        self.cls_embed = nn.Embedding(1, hidden_dim) # extra cls token embedding
-        self.encoder_action_proj = nn.Linear(state_dim, hidden_dim) # project action to embedding
+        self.latent_dim = 32  # final size of latent z # TODO tune
+        self.cls_embed = nn.Embedding(1, hidden_dim)  # extra cls token embedding
+        self.encoder_action_proj = nn.Linear(state_dim, hidden_dim)  # project action to embedding
         self.encoder_joint_proj = nn.Linear(state_dim, hidden_dim)  # project qpos to embedding
-        self.latent_proj = nn.Linear(hidden_dim, self.latent_dim*2) # project hidden state to latent std, var
-        self.register_buffer('pos_table', get_sinusoid_encoding_table(1+1+num_queries, hidden_dim)) # [CLS], qpos, a_seq
+        self.latent_proj = nn.Linear(hidden_dim, self.latent_dim * 2)  # project hidden state to latent std, var
+        self.register_buffer(
+            "pos_table", get_sinusoid_encoding_table(1 + 1 + num_queries, hidden_dim)
+        )  # [CLS], qpos, a_seq
 
         # decoder extra parameters
-        self.latent_out_proj = nn.Linear(self.latent_dim, hidden_dim) # project latent sample to embedding
-        self.additional_pos_embed = nn.Embedding(2, hidden_dim) # learned position embedding for proprio and latent
+        self.latent_out_proj = nn.Linear(self.latent_dim, hidden_dim)  # project latent sample to embedding
+        self.additional_pos_embed = nn.Embedding(2, hidden_dim)  # learned position embedding for proprio and latent
 
     def forward(self, qpos, image, env_state, actions=None, is_pad=None):
         """
@@ -85,30 +86,30 @@ class DETRVAE(nn.Module):
         env_state: None
         actions: batch, seq, action_dim
         """
-        is_training = actions is not None # train or val
+        is_training = actions is not None  # train or val
         bs, _ = qpos.shape
         ### Obtain latent z from action sequence
         if is_training:
             # project action sequence to embedding dim, and concat with a CLS token
-            action_embed = self.encoder_action_proj(actions) # (bs, seq, hidden_dim)
+            action_embed = self.encoder_action_proj(actions)  # (bs, seq, hidden_dim)
             qpos_embed = self.encoder_joint_proj(qpos)  # (bs, hidden_dim)
             qpos_embed = torch.unsqueeze(qpos_embed, axis=1)  # (bs, 1, hidden_dim)
-            cls_embed = self.cls_embed.weight # (1, hidden_dim)
-            cls_embed = torch.unsqueeze(cls_embed, axis=0).repeat(bs, 1, 1) # (bs, 1, hidden_dim)
-            encoder_input = torch.cat([cls_embed, qpos_embed, action_embed], axis=1) # (bs, seq+1, hidden_dim)
-            encoder_input = encoder_input.permute(1, 0, 2) # (seq+1, bs, hidden_dim)
+            cls_embed = self.cls_embed.weight  # (1, hidden_dim)
+            cls_embed = torch.unsqueeze(cls_embed, axis=0).repeat(bs, 1, 1)  # (bs, 1, hidden_dim)
+            encoder_input = torch.cat([cls_embed, qpos_embed, action_embed], axis=1)  # (bs, seq+1, hidden_dim)
+            encoder_input = encoder_input.permute(1, 0, 2)  # (seq+1, bs, hidden_dim)
             # do not mask cls token
-            cls_joint_is_pad = torch.full((bs, 2), False).to(qpos.device) # False: not a padding
+            cls_joint_is_pad = torch.full((bs, 2), False).to(qpos.device)  # False: not a padding
             is_pad = torch.cat([cls_joint_is_pad, is_pad], axis=1)  # (bs, seq+1)
             # obtain position embedding
             pos_embed = self.pos_table.clone().detach()
             pos_embed = pos_embed.permute(1, 0, 2)  # (seq+1, 1, hidden_dim)
             # query model
             encoder_output = self.encoder(encoder_input, pos=pos_embed, src_key_padding_mask=is_pad)
-            encoder_output = encoder_output[0] # take cls output only
+            encoder_output = encoder_output[0]  # take cls output only
             latent_info = self.latent_proj(encoder_output)
-            mu = latent_info[:, :self.latent_dim]
-            logvar = latent_info[:, self.latent_dim:]
+            mu = latent_info[:, : self.latent_dim]
+            logvar = latent_info[:, self.latent_dim :]
             latent_sample = reparametrize(mu, logvar)
             latent_input = self.latent_out_proj(latent_sample)
         else:
@@ -121,8 +122,8 @@ class DETRVAE(nn.Module):
             all_cam_features = []
             all_cam_pos = []
             for cam_id, cam_name in enumerate(self.camera_names):
-                features, pos = self.backbones[0](image[:, cam_id]) # HARDCODED
-                features = features[0] # take the last layer feature
+                features, pos = self.backbones[0](image[:, cam_id])  # HARDCODED
+                features = features[0]  # take the last layer feature
                 pos = pos[0]
                 all_cam_features.append(self.input_proj(features))
                 all_cam_pos.append(pos)
@@ -131,21 +132,22 @@ class DETRVAE(nn.Module):
             # fold camera dimension into width dimension
             src = torch.cat(all_cam_features, axis=3)
             pos = torch.cat(all_cam_pos, axis=3)
-            hs = self.transformer(src, None, self.query_embed.weight, pos, latent_input, proprio_input, self.additional_pos_embed.weight)[0]
+            hs = self.transformer(
+                src, None, self.query_embed.weight, pos, latent_input, proprio_input, self.additional_pos_embed.weight
+            )[0]
         else:
             qpos = self.input_proj_robot_state(qpos)
             env_state = self.input_proj_env_state(env_state)
-            transformer_input = torch.cat([qpos, env_state], axis=1) # seq length = 2
+            transformer_input = torch.cat([qpos, env_state], axis=1)  # seq length = 2
             hs = self.transformer(transformer_input, None, self.query_embed.weight, self.pos.weight)[0]
         a_hat = self.action_head(hs)
         is_pad_hat = self.is_pad_head(hs)
         return a_hat, is_pad_hat, [mu, logvar]
 
 
-
 class CNNMLP(nn.Module):
     def __init__(self, backbones, state_dim, camera_names):
-        """ Initializes the model.
+        """Initializes the model.
         Parameters:
             backbones: torch module of the backbone to be used. See backbone.py
             transformer: torch module of the transformer architecture. See transformer.py
@@ -156,7 +158,7 @@ class CNNMLP(nn.Module):
         """
         super().__init__()
         self.camera_names = camera_names
-        self.action_head = nn.Linear(1000, state_dim) # TODO add more
+        self.action_head = nn.Linear(1000, state_dim)  # TODO add more
         if backbones is not None:
             self.backbones = nn.ModuleList(backbones)
             backbone_down_projs = []
@@ -164,7 +166,7 @@ class CNNMLP(nn.Module):
                 down_proj = nn.Sequential(
                     nn.Conv2d(backbone.num_channels, 128, kernel_size=5),
                     nn.Conv2d(128, 64, kernel_size=5),
-                    nn.Conv2d(64, 32, kernel_size=5)
+                    nn.Conv2d(64, 32, kernel_size=5),
                 )
                 backbone_down_projs.append(down_proj)
             self.backbone_down_projs = nn.ModuleList(backbone_down_projs)
@@ -181,21 +183,21 @@ class CNNMLP(nn.Module):
         env_state: None
         actions: batch, seq, action_dim
         """
-        is_training = actions is not None # train or val
+        is_training = actions is not None  # train or val
         bs, _ = qpos.shape
         # Image observation features and position embeddings
         all_cam_features = []
         for cam_id, cam_name in enumerate(self.camera_names):
             features, pos = self.backbones[cam_id](image[:, cam_id])
-            features = features[0] # take the last layer feature
-            pos = pos[0] # not used
+            features = features[0]  # take the last layer feature
+            pos = pos[0]  # not used
             all_cam_features.append(self.backbone_down_projs[cam_id](features))
         # flatten everything
         flattened_features = []
         for cam_feature in all_cam_features:
             flattened_features.append(cam_feature.reshape([bs, -1]))
-        flattened_features = torch.cat(flattened_features, axis=1) # 768 each
-        features = torch.cat([flattened_features, qpos], axis=1) # qpos: 14
+        flattened_features = torch.cat(flattened_features, axis=1)  # 768 each
+        features = torch.cat([flattened_features, qpos], axis=1)  # qpos: 14
         a_hat = self.mlp(features)
         return a_hat
 
@@ -213,16 +215,15 @@ def mlp(input_dim, hidden_dim, output_dim, hidden_depth):
 
 
 def build_encoder(args):
-    d_model = args.hidden_dim # 256
-    dropout = args.dropout # 0.1
-    nhead = args.nheads # 8
-    dim_feedforward = args.dim_feedforward # 2048
-    num_encoder_layers = args.enc_layers # 4 # TODO shared with VAE decoder
-    normalize_before = args.pre_norm # False
+    d_model = args.hidden_dim  # 256
+    dropout = args.dropout  # 0.1
+    nhead = args.nheads  # 8
+    dim_feedforward = args.dim_feedforward  # 2048
+    num_encoder_layers = args.enc_layers  # 4 # TODO shared with VAE decoder
+    normalize_before = args.pre_norm  # False
     activation = "relu"
 
-    encoder_layer = TransformerEncoderLayer(d_model, nhead, dim_feedforward,
-                                            dropout, activation, normalize_before)
+    encoder_layer = TransformerEncoderLayer(d_model, nhead, dim_feedforward, dropout, activation, normalize_before)
     encoder_norm = nn.LayerNorm(d_model) if normalize_before else None
     encoder = TransformerEncoder(encoder_layer, num_encoder_layers, encoder_norm)
 
@@ -252,12 +253,13 @@ def build(args):
     )
 
     n_parameters = sum(p.numel() for p in model.parameters() if p.requires_grad)
-    print("number of parameters: %.2fM" % (n_parameters/1e6,))
+    print("number of parameters: %.2fM" % (n_parameters / 1e6,))
 
     return model
 
+
 def build_cnnmlp(args):
-    state_dim = 14 # TODO hardcode
+    state_dim = 14  # TODO hardcode
 
     # From state
     # backbone = None # from state for now, no need for conv nets
@@ -274,6 +276,6 @@ def build_cnnmlp(args):
     )
 
     n_parameters = sum(p.numel() for p in model.parameters() if p.requires_grad)
-    print("number of parameters: %.2fM" % (n_parameters/1e6,))
+    print("number of parameters: %.2fM" % (n_parameters / 1e6,))
 
     return model

--- a/roboverse_learn/il/policies/act/detr/models/position_encoding.py
+++ b/roboverse_learn/il/policies/act/detr/models/position_encoding.py
@@ -2,20 +2,23 @@
 """
 Various positional encodings for the transformer.
 """
-import math
-import torch
-from torch import nn
 
-from util.misc import NestedTensor
+import math
 
 import IPython
+import torch
+from torch import nn
+from util.misc import NestedTensor
+
 e = IPython.embed
+
 
 class PositionEmbeddingSine(nn.Module):
     """
     This is a more standard version of the position embedding, very similar to the one
     used by the Attention is all you need paper, generalized to work on images.
     """
+
     def __init__(self, num_pos_feats=64, temperature=10000, normalize=False, scale=None):
         super().__init__()
         self.num_pos_feats = num_pos_feats
@@ -56,6 +59,7 @@ class PositionEmbeddingLearned(nn.Module):
     """
     Absolute pos embedding, learned.
     """
+
     def __init__(self, num_pos_feats=256):
         super().__init__()
         self.row_embed = nn.Embedding(50, num_pos_feats)
@@ -73,19 +77,27 @@ class PositionEmbeddingLearned(nn.Module):
         j = torch.arange(h, device=x.device)
         x_emb = self.col_embed(i)
         y_emb = self.row_embed(j)
-        pos = torch.cat([
-            x_emb.unsqueeze(0).repeat(h, 1, 1),
-            y_emb.unsqueeze(1).repeat(1, w, 1),
-        ], dim=-1).permute(2, 0, 1).unsqueeze(0).repeat(x.shape[0], 1, 1, 1)
+        pos = (
+            torch.cat(
+                [
+                    x_emb.unsqueeze(0).repeat(h, 1, 1),
+                    y_emb.unsqueeze(1).repeat(1, w, 1),
+                ],
+                dim=-1,
+            )
+            .permute(2, 0, 1)
+            .unsqueeze(0)
+            .repeat(x.shape[0], 1, 1, 1)
+        )
         return pos
 
 
 def build_position_encoding(args):
     N_steps = args.hidden_dim // 2
-    if args.position_embedding in ('v2', 'sine'):
+    if args.position_embedding in ("v2", "sine"):
         # TODO find a better way of exposing other arguments
         position_embedding = PositionEmbeddingSine(N_steps, normalize=True)
-    elif args.position_embedding in ('v3', 'learned'):
+    elif args.position_embedding in ("v3", "learned"):
         position_embedding = PositionEmbeddingLearned(N_steps)
     else:
         raise ValueError(f"not supported {args.position_embedding}")

--- a/roboverse_learn/il/policies/act/detr/models/transformer.py
+++ b/roboverse_learn/il/policies/act/detr/models/transformer.py
@@ -7,34 +7,42 @@ Copy-paste from torch.nn.Transformer with modifications:
     * extra LN at the end of encoder is removed
     * decoder returns a stack of activations from all decoding layers
 """
-import copy
-from typing import Optional, List
 
-import torch
-import torch.nn.functional as F
-from torch import nn, Tensor
+import copy
+from typing import Optional
 
 import IPython
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+
 e = IPython.embed
 
-class Transformer(nn.Module):
 
-    def __init__(self, d_model=512, nhead=8, num_encoder_layers=6,
-                 num_decoder_layers=6, dim_feedforward=2048, dropout=0.1,
-                 activation="relu", normalize_before=False,
-                 return_intermediate_dec=False):
+class Transformer(nn.Module):
+    def __init__(
+        self,
+        d_model=512,
+        nhead=8,
+        num_encoder_layers=6,
+        num_decoder_layers=6,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation="relu",
+        normalize_before=False,
+        return_intermediate_dec=False,
+    ):
         super().__init__()
 
-        encoder_layer = TransformerEncoderLayer(d_model, nhead, dim_feedforward,
-                                                dropout, activation, normalize_before)
+        encoder_layer = TransformerEncoderLayer(d_model, nhead, dim_feedforward, dropout, activation, normalize_before)
         encoder_norm = nn.LayerNorm(d_model) if normalize_before else None
         self.encoder = TransformerEncoder(encoder_layer, num_encoder_layers, encoder_norm)
 
-        decoder_layer = TransformerDecoderLayer(d_model, nhead, dim_feedforward,
-                                                dropout, activation, normalize_before)
+        decoder_layer = TransformerDecoderLayer(d_model, nhead, dim_feedforward, dropout, activation, normalize_before)
         decoder_norm = nn.LayerNorm(d_model)
-        self.decoder = TransformerDecoder(decoder_layer, num_decoder_layers, decoder_norm,
-                                          return_intermediate=return_intermediate_dec)
+        self.decoder = TransformerDecoder(
+            decoder_layer, num_decoder_layers, decoder_norm, return_intermediate=return_intermediate_dec
+        )
 
         self._reset_parameters()
 
@@ -46,9 +54,11 @@ class Transformer(nn.Module):
             if p.dim() > 1:
                 nn.init.xavier_uniform_(p)
 
-    def forward(self, src, mask, query_embed, pos_embed, latent_input=None, proprio_input=None, additional_pos_embed=None):
+    def forward(
+        self, src, mask, query_embed, pos_embed, latent_input=None, proprio_input=None, additional_pos_embed=None
+    ):
         # TODO flatten only when input has H and W
-        if len(src.shape) == 4: # has H and W
+        if len(src.shape) == 4:  # has H and W
             # flatten NxCxHxW to HWxNxC
             bs, c, h, w = src.shape
             src = src.flatten(2).permute(2, 0, 1)
@@ -56,7 +66,7 @@ class Transformer(nn.Module):
             query_embed = query_embed.unsqueeze(1).repeat(1, bs, 1)
             # mask = mask.flatten(1)
 
-            additional_pos_embed = additional_pos_embed.unsqueeze(1).repeat(1, bs, 1) # seq, bs, dim
+            additional_pos_embed = additional_pos_embed.unsqueeze(1).repeat(1, bs, 1)  # seq, bs, dim
             pos_embed = torch.cat([additional_pos_embed, pos_embed], axis=0)
 
             addition_input = torch.stack([latent_input, proprio_input], axis=0)
@@ -71,28 +81,29 @@ class Transformer(nn.Module):
 
         tgt = torch.zeros_like(query_embed)
         memory = self.encoder(src, src_key_padding_mask=mask, pos=pos_embed)
-        hs = self.decoder(tgt, memory, memory_key_padding_mask=mask,
-                          pos=pos_embed, query_pos=query_embed)
+        hs = self.decoder(tgt, memory, memory_key_padding_mask=mask, pos=pos_embed, query_pos=query_embed)
         hs = hs.transpose(1, 2)
         return hs
 
-class TransformerEncoder(nn.Module):
 
+class TransformerEncoder(nn.Module):
     def __init__(self, encoder_layer, num_layers, norm=None):
         super().__init__()
         self.layers = _get_clones(encoder_layer, num_layers)
         self.num_layers = num_layers
         self.norm = norm
 
-    def forward(self, src,
-                mask: Optional[Tensor] = None,
-                src_key_padding_mask: Optional[Tensor] = None,
-                pos: Optional[Tensor] = None):
+    def forward(
+        self,
+        src,
+        mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
         output = src
 
         for layer in self.layers:
-            output = layer(output, src_mask=mask,
-                           src_key_padding_mask=src_key_padding_mask, pos=pos)
+            output = layer(output, src_mask=mask, src_key_padding_mask=src_key_padding_mask, pos=pos)
 
         if self.norm is not None:
             output = self.norm(output)
@@ -101,7 +112,6 @@ class TransformerEncoder(nn.Module):
 
 
 class TransformerDecoder(nn.Module):
-
     def __init__(self, decoder_layer, num_layers, norm=None, return_intermediate=False):
         super().__init__()
         self.layers = _get_clones(decoder_layer, num_layers)
@@ -109,23 +119,32 @@ class TransformerDecoder(nn.Module):
         self.norm = norm
         self.return_intermediate = return_intermediate
 
-    def forward(self, tgt, memory,
-                tgt_mask: Optional[Tensor] = None,
-                memory_mask: Optional[Tensor] = None,
-                tgt_key_padding_mask: Optional[Tensor] = None,
-                memory_key_padding_mask: Optional[Tensor] = None,
-                pos: Optional[Tensor] = None,
-                query_pos: Optional[Tensor] = None):
+    def forward(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
         output = tgt
 
         intermediate = []
 
         for layer in self.layers:
-            output = layer(output, memory, tgt_mask=tgt_mask,
-                           memory_mask=memory_mask,
-                           tgt_key_padding_mask=tgt_key_padding_mask,
-                           memory_key_padding_mask=memory_key_padding_mask,
-                           pos=pos, query_pos=query_pos)
+            output = layer(
+                output,
+                memory,
+                tgt_mask=tgt_mask,
+                memory_mask=memory_mask,
+                tgt_key_padding_mask=tgt_key_padding_mask,
+                memory_key_padding_mask=memory_key_padding_mask,
+                pos=pos,
+                query_pos=query_pos,
+            )
             if self.return_intermediate:
                 intermediate.append(self.norm(output))
 
@@ -142,9 +161,7 @@ class TransformerDecoder(nn.Module):
 
 
 class TransformerEncoderLayer(nn.Module):
-
-    def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1,
-                 activation="relu", normalize_before=False):
+    def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1, activation="relu", normalize_before=False):
         super().__init__()
         self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
         # Implementation of Feedforward model
@@ -163,14 +180,15 @@ class TransformerEncoderLayer(nn.Module):
     def with_pos_embed(self, tensor, pos: Optional[Tensor]):
         return tensor if pos is None else tensor + pos
 
-    def forward_post(self,
-                     src,
-                     src_mask: Optional[Tensor] = None,
-                     src_key_padding_mask: Optional[Tensor] = None,
-                     pos: Optional[Tensor] = None):
+    def forward_post(
+        self,
+        src,
+        src_mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
         q = k = self.with_pos_embed(src, pos)
-        src2 = self.self_attn(q, k, value=src, attn_mask=src_mask,
-                              key_padding_mask=src_key_padding_mask)[0]
+        src2 = self.self_attn(q, k, value=src, attn_mask=src_mask, key_padding_mask=src_key_padding_mask)[0]
         src = src + self.dropout1(src2)
         src = self.norm1(src)
         src2 = self.linear2(self.dropout(self.activation(self.linear1(src))))
@@ -178,33 +196,36 @@ class TransformerEncoderLayer(nn.Module):
         src = self.norm2(src)
         return src
 
-    def forward_pre(self, src,
-                    src_mask: Optional[Tensor] = None,
-                    src_key_padding_mask: Optional[Tensor] = None,
-                    pos: Optional[Tensor] = None):
+    def forward_pre(
+        self,
+        src,
+        src_mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
         src2 = self.norm1(src)
         q = k = self.with_pos_embed(src2, pos)
-        src2 = self.self_attn(q, k, value=src2, attn_mask=src_mask,
-                              key_padding_mask=src_key_padding_mask)[0]
+        src2 = self.self_attn(q, k, value=src2, attn_mask=src_mask, key_padding_mask=src_key_padding_mask)[0]
         src = src + self.dropout1(src2)
         src2 = self.norm2(src)
         src2 = self.linear2(self.dropout(self.activation(self.linear1(src2))))
         src = src + self.dropout2(src2)
         return src
 
-    def forward(self, src,
-                src_mask: Optional[Tensor] = None,
-                src_key_padding_mask: Optional[Tensor] = None,
-                pos: Optional[Tensor] = None):
+    def forward(
+        self,
+        src,
+        src_mask: Optional[Tensor] = None,
+        src_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+    ):
         if self.normalize_before:
             return self.forward_pre(src, src_mask, src_key_padding_mask, pos)
         return self.forward_post(src, src_mask, src_key_padding_mask, pos)
 
 
 class TransformerDecoderLayer(nn.Module):
-
-    def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1,
-                 activation="relu", normalize_before=False):
+    def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1, activation="relu", normalize_before=False):
         super().__init__()
         self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
         self.multihead_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
@@ -226,22 +247,28 @@ class TransformerDecoderLayer(nn.Module):
     def with_pos_embed(self, tensor, pos: Optional[Tensor]):
         return tensor if pos is None else tensor + pos
 
-    def forward_post(self, tgt, memory,
-                     tgt_mask: Optional[Tensor] = None,
-                     memory_mask: Optional[Tensor] = None,
-                     tgt_key_padding_mask: Optional[Tensor] = None,
-                     memory_key_padding_mask: Optional[Tensor] = None,
-                     pos: Optional[Tensor] = None,
-                     query_pos: Optional[Tensor] = None):
+    def forward_post(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
         q = k = self.with_pos_embed(tgt, query_pos)
-        tgt2 = self.self_attn(q, k, value=tgt, attn_mask=tgt_mask,
-                              key_padding_mask=tgt_key_padding_mask)[0]
+        tgt2 = self.self_attn(q, k, value=tgt, attn_mask=tgt_mask, key_padding_mask=tgt_key_padding_mask)[0]
         tgt = tgt + self.dropout1(tgt2)
         tgt = self.norm1(tgt)
-        tgt2 = self.multihead_attn(query=self.with_pos_embed(tgt, query_pos),
-                                   key=self.with_pos_embed(memory, pos),
-                                   value=memory, attn_mask=memory_mask,
-                                   key_padding_mask=memory_key_padding_mask)[0]
+        tgt2 = self.multihead_attn(
+            query=self.with_pos_embed(tgt, query_pos),
+            key=self.with_pos_embed(memory, pos),
+            value=memory,
+            attn_mask=memory_mask,
+            key_padding_mask=memory_key_padding_mask,
+        )[0]
         tgt = tgt + self.dropout2(tgt2)
         tgt = self.norm2(tgt)
         tgt2 = self.linear2(self.dropout(self.activation(self.linear1(tgt))))
@@ -249,41 +276,53 @@ class TransformerDecoderLayer(nn.Module):
         tgt = self.norm3(tgt)
         return tgt
 
-    def forward_pre(self, tgt, memory,
-                    tgt_mask: Optional[Tensor] = None,
-                    memory_mask: Optional[Tensor] = None,
-                    tgt_key_padding_mask: Optional[Tensor] = None,
-                    memory_key_padding_mask: Optional[Tensor] = None,
-                    pos: Optional[Tensor] = None,
-                    query_pos: Optional[Tensor] = None):
+    def forward_pre(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
         tgt2 = self.norm1(tgt)
         q = k = self.with_pos_embed(tgt2, query_pos)
-        tgt2 = self.self_attn(q, k, value=tgt2, attn_mask=tgt_mask,
-                              key_padding_mask=tgt_key_padding_mask)[0]
+        tgt2 = self.self_attn(q, k, value=tgt2, attn_mask=tgt_mask, key_padding_mask=tgt_key_padding_mask)[0]
         tgt = tgt + self.dropout1(tgt2)
         tgt2 = self.norm2(tgt)
-        tgt2 = self.multihead_attn(query=self.with_pos_embed(tgt2, query_pos),
-                                   key=self.with_pos_embed(memory, pos),
-                                   value=memory, attn_mask=memory_mask,
-                                   key_padding_mask=memory_key_padding_mask)[0]
+        tgt2 = self.multihead_attn(
+            query=self.with_pos_embed(tgt2, query_pos),
+            key=self.with_pos_embed(memory, pos),
+            value=memory,
+            attn_mask=memory_mask,
+            key_padding_mask=memory_key_padding_mask,
+        )[0]
         tgt = tgt + self.dropout2(tgt2)
         tgt2 = self.norm3(tgt)
         tgt2 = self.linear2(self.dropout(self.activation(self.linear1(tgt2))))
         tgt = tgt + self.dropout3(tgt2)
         return tgt
 
-    def forward(self, tgt, memory,
-                tgt_mask: Optional[Tensor] = None,
-                memory_mask: Optional[Tensor] = None,
-                tgt_key_padding_mask: Optional[Tensor] = None,
-                memory_key_padding_mask: Optional[Tensor] = None,
-                pos: Optional[Tensor] = None,
-                query_pos: Optional[Tensor] = None):
+    def forward(
+        self,
+        tgt,
+        memory,
+        tgt_mask: Optional[Tensor] = None,
+        memory_mask: Optional[Tensor] = None,
+        tgt_key_padding_mask: Optional[Tensor] = None,
+        memory_key_padding_mask: Optional[Tensor] = None,
+        pos: Optional[Tensor] = None,
+        query_pos: Optional[Tensor] = None,
+    ):
         if self.normalize_before:
-            return self.forward_pre(tgt, memory, tgt_mask, memory_mask,
-                                    tgt_key_padding_mask, memory_key_padding_mask, pos, query_pos)
-        return self.forward_post(tgt, memory, tgt_mask, memory_mask,
-                                 tgt_key_padding_mask, memory_key_padding_mask, pos, query_pos)
+            return self.forward_pre(
+                tgt, memory, tgt_mask, memory_mask, tgt_key_padding_mask, memory_key_padding_mask, pos, query_pos
+            )
+        return self.forward_post(
+            tgt, memory, tgt_mask, memory_mask, tgt_key_padding_mask, memory_key_padding_mask, pos, query_pos
+        )
 
 
 def _get_clones(module, N):
@@ -311,4 +350,4 @@ def _get_activation_fn(activation):
         return F.gelu
     if activation == "glu":
         return F.glu
-    raise RuntimeError(F"activation should be relu/gelu, not {activation}.")
+    raise RuntimeError(f"activation should be relu/gelu, not {activation}.")

--- a/roboverse_learn/il/policies/act/detr/setup.py
+++ b/roboverse_learn/il/policies/act/detr/setup.py
@@ -1,10 +1,11 @@
 from distutils.core import setup
+
 from setuptools import find_packages
 
 setup(
-    name='detr',
-    version='0.0.0',
+    name="detr",
+    version="0.0.0",
     packages=find_packages(),
-    license='MIT License',
-    long_description=open('README.md').read(),
+    license="MIT License",
+    long_description=open("README.md").read(),
 )

--- a/roboverse_learn/il/policies/act/detr/util/__init__.py
+++ b/roboverse_learn/il/policies/act/detr/util/__init__.py
@@ -1,4 +1,4 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from .misc import *
 from .box_ops import *
+from .misc import *
 from .plot_utils import *

--- a/roboverse_learn/il/policies/act/detr/util/box_ops.py
+++ b/roboverse_learn/il/policies/act/detr/util/box_ops.py
@@ -2,21 +2,20 @@
 """
 Utilities for bounding box manipulation and GIoU.
 """
+
 import torch
 from torchvision.ops.boxes import box_area
 
 
 def box_cxcywh_to_xyxy(x):
     x_c, y_c, w, h = x.unbind(-1)
-    b = [(x_c - 0.5 * w), (y_c - 0.5 * h),
-         (x_c + 0.5 * w), (y_c + 0.5 * h)]
+    b = [(x_c - 0.5 * w), (y_c - 0.5 * h), (x_c + 0.5 * w), (y_c + 0.5 * h)]
     return torch.stack(b, dim=-1)
 
 
 def box_xyxy_to_cxcywh(x):
     x0, y0, x1, y1 = x.unbind(-1)
-    b = [(x0 + x1) / 2, (y0 + y1) / 2,
-         (x1 - x0), (y1 - y0)]
+    b = [(x0 + x1) / 2, (y0 + y1) / 2, (x1 - x0), (y1 - y0)]
     return torch.stack(b, dim=-1)
 
 
@@ -77,11 +76,11 @@ def masks_to_boxes(masks):
     x = torch.arange(0, w, dtype=torch.float)
     y, x = torch.meshgrid(y, x)
 
-    x_mask = (masks * x.unsqueeze(0))
+    x_mask = masks * x.unsqueeze(0)
     x_max = x_mask.flatten(1).max(-1)[0]
     x_min = x_mask.masked_fill(~(masks.bool()), 1e8).flatten(1).min(-1)[0]
 
-    y_mask = (masks * y.unsqueeze(0))
+    y_mask = masks * y.unsqueeze(0)
     y_max = y_mask.flatten(1).max(-1)[0]
     y_min = y_mask.masked_fill(~(masks.bool()), 1e8).flatten(1).min(-1)[0]
 

--- a/roboverse_learn/il/policies/act/detr/util/misc.py
+++ b/roboverse_learn/il/policies/act/detr/util/misc.py
@@ -4,27 +4,29 @@ Misc functions, including distributed helpers.
 
 Mostly copy-paste from torchvision references.
 """
+
+import datetime
 import os
+import pickle
 import subprocess
 import time
 from collections import defaultdict, deque
-import datetime
-import pickle
-from packaging import version
-from typing import Optional, List
+from typing import List, Optional
 
 import torch
 import torch.distributed as dist
-from torch import Tensor
 
 # needed due to empty tensor bug in pytorch and torchvision 0.5
 import torchvision
-if version.parse(torchvision.__version__) < version.parse('0.7'):
+from packaging import version
+from torch import Tensor
+
+if version.parse(torchvision.__version__) < version.parse("0.7"):
     from torchvision.ops import _new_empty_tensor
     from torchvision.ops.misc import _output_size
 
 
-class SmoothedValue(object):
+class SmoothedValue:
     """Track a series of values and provide access to smoothed values over a
     window or the global series average.
     """
@@ -48,7 +50,7 @@ class SmoothedValue(object):
         """
         if not is_dist_avail_and_initialized():
             return
-        t = torch.tensor([self.count, self.total], dtype=torch.float64, device='cuda')
+        t = torch.tensor([self.count, self.total], dtype=torch.float64, device="cuda")
         dist.barrier()
         dist.all_reduce(t)
         t = t.tolist()
@@ -79,11 +81,8 @@ class SmoothedValue(object):
 
     def __str__(self):
         return self.fmt.format(
-            median=self.median,
-            avg=self.avg,
-            global_avg=self.global_avg,
-            max=self.max,
-            value=self.value)
+            median=self.median, avg=self.avg, global_avg=self.global_avg, max=self.max, value=self.value
+        )
 
 
 def all_gather(data):
@@ -156,7 +155,7 @@ def reduce_dict(input_dict, average=True):
     return reduced_dict
 
 
-class MetricLogger(object):
+class MetricLogger:
     def __init__(self, delimiter="\t"):
         self.meters = defaultdict(SmoothedValue)
         self.delimiter = delimiter
@@ -173,15 +172,12 @@ class MetricLogger(object):
             return self.meters[attr]
         if attr in self.__dict__:
             return self.__dict__[attr]
-        raise AttributeError("'{}' object has no attribute '{}'".format(
-            type(self).__name__, attr))
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{attr}'")
 
     def __str__(self):
         loss_str = []
         for name, meter in self.meters.items():
-            loss_str.append(
-                "{}: {}".format(name, str(meter))
-            )
+            loss_str.append(f"{name}: {meter!s}")
         return self.delimiter.join(loss_str)
 
     def synchronize_between_processes(self):
@@ -194,30 +190,30 @@ class MetricLogger(object):
     def log_every(self, iterable, print_freq, header=None):
         i = 0
         if not header:
-            header = ''
+            header = ""
         start_time = time.time()
         end = time.time()
-        iter_time = SmoothedValue(fmt='{avg:.4f}')
-        data_time = SmoothedValue(fmt='{avg:.4f}')
-        space_fmt = ':' + str(len(str(len(iterable)))) + 'd'
+        iter_time = SmoothedValue(fmt="{avg:.4f}")
+        data_time = SmoothedValue(fmt="{avg:.4f}")
+        space_fmt = ":" + str(len(str(len(iterable)))) + "d"
         if torch.cuda.is_available():
             log_msg = self.delimiter.join([
                 header,
-                '[{0' + space_fmt + '}/{1}]',
-                'eta: {eta}',
-                '{meters}',
-                'time: {time}',
-                'data: {data}',
-                'max mem: {memory:.0f}'
+                "[{0" + space_fmt + "}/{1}]",
+                "eta: {eta}",
+                "{meters}",
+                "time: {time}",
+                "data: {data}",
+                "max mem: {memory:.0f}",
             ])
         else:
             log_msg = self.delimiter.join([
                 header,
-                '[{0' + space_fmt + '}/{1}]',
-                'eta: {eta}',
-                '{meters}',
-                'time: {time}',
-                'data: {data}'
+                "[{0" + space_fmt + "}/{1}]",
+                "eta: {eta}",
+                "{meters}",
+                "time: {time}",
+                "data: {data}",
             ])
         MB = 1024.0 * 1024.0
         for obj in iterable:
@@ -228,38 +224,45 @@ class MetricLogger(object):
                 eta_seconds = iter_time.global_avg * (len(iterable) - i)
                 eta_string = str(datetime.timedelta(seconds=int(eta_seconds)))
                 if torch.cuda.is_available():
-                    print(log_msg.format(
-                        i, len(iterable), eta=eta_string,
-                        meters=str(self),
-                        time=str(iter_time), data=str(data_time),
-                        memory=torch.cuda.max_memory_allocated() / MB))
+                    print(
+                        log_msg.format(
+                            i,
+                            len(iterable),
+                            eta=eta_string,
+                            meters=str(self),
+                            time=str(iter_time),
+                            data=str(data_time),
+                            memory=torch.cuda.max_memory_allocated() / MB,
+                        )
+                    )
                 else:
-                    print(log_msg.format(
-                        i, len(iterable), eta=eta_string,
-                        meters=str(self),
-                        time=str(iter_time), data=str(data_time)))
+                    print(
+                        log_msg.format(
+                            i, len(iterable), eta=eta_string, meters=str(self), time=str(iter_time), data=str(data_time)
+                        )
+                    )
             i += 1
             end = time.time()
         total_time = time.time() - start_time
         total_time_str = str(datetime.timedelta(seconds=int(total_time)))
-        print('{} Total time: {} ({:.4f} s / it)'.format(
-            header, total_time_str, total_time / len(iterable)))
+        print(f"{header} Total time: {total_time_str} ({total_time / len(iterable):.4f} s / it)")
 
 
 def get_sha():
     cwd = os.path.dirname(os.path.abspath(__file__))
 
     def _run(command):
-        return subprocess.check_output(command, cwd=cwd).decode('ascii').strip()
-    sha = 'N/A'
+        return subprocess.check_output(command, cwd=cwd).decode("ascii").strip()
+
+    sha = "N/A"
     diff = "clean"
-    branch = 'N/A'
+    branch = "N/A"
     try:
-        sha = _run(['git', 'rev-parse', 'HEAD'])
-        subprocess.check_output(['git', 'diff'], cwd=cwd)
-        diff = _run(['git', 'diff-index', 'HEAD'])
+        sha = _run(["git", "rev-parse", "HEAD"])
+        subprocess.check_output(["git", "diff"], cwd=cwd)
+        diff = _run(["git", "diff-index", "HEAD"])
         diff = "has uncommited changes" if diff else "clean"
-        branch = _run(['git', 'rev-parse', '--abbrev-ref', 'HEAD'])
+        branch = _run(["git", "rev-parse", "--abbrev-ref", "HEAD"])
     except Exception:
         pass
     message = f"sha: {sha}, status: {diff}, branch: {branch}"
@@ -281,13 +284,13 @@ def _max_by_axis(the_list):
     return maxes
 
 
-class NestedTensor(object):
+class NestedTensor:
     def __init__(self, tensors, mask: Optional[Tensor]):
         self.tensors = tensors
         self.mask = mask
 
     def to(self, device):
-        # type: (Device) -> NestedTensor # noqa
+        # type: (Device) -> NestedTensor
         cast_tensor = self.tensors.to(device)
         mask = self.mask
         if mask is not None:
@@ -323,9 +326,9 @@ def nested_tensor_from_tensor_list(tensor_list: List[Tensor]):
         mask = torch.ones((b, h, w), dtype=torch.bool, device=device)
         for img, pad_img, m in zip(tensor_list, tensor, mask):
             pad_img[: img.shape[0], : img.shape[1], : img.shape[2]].copy_(img)
-            m[: img.shape[1], :img.shape[2]] = False
+            m[: img.shape[1], : img.shape[2]] = False
     else:
-        raise ValueError('not supported')
+        raise ValueError("not supported")
     return NestedTensor(tensor, mask)
 
 
@@ -365,10 +368,11 @@ def setup_for_distributed(is_master):
     This function disables printing when not in master process
     """
     import builtins as __builtin__
+
     builtin_print = __builtin__.print
 
     def print(*args, **kwargs):
-        force = kwargs.pop('force', False)
+        force = kwargs.pop("force", False)
         if is_master or force:
             builtin_print(*args, **kwargs)
 
@@ -405,26 +409,26 @@ def save_on_master(*args, **kwargs):
 
 
 def init_distributed_mode(args):
-    if 'RANK' in os.environ and 'WORLD_SIZE' in os.environ:
+    if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
         args.rank = int(os.environ["RANK"])
-        args.world_size = int(os.environ['WORLD_SIZE'])
-        args.gpu = int(os.environ['LOCAL_RANK'])
-    elif 'SLURM_PROCID' in os.environ:
-        args.rank = int(os.environ['SLURM_PROCID'])
+        args.world_size = int(os.environ["WORLD_SIZE"])
+        args.gpu = int(os.environ["LOCAL_RANK"])
+    elif "SLURM_PROCID" in os.environ:
+        args.rank = int(os.environ["SLURM_PROCID"])
         args.gpu = args.rank % torch.cuda.device_count()
     else:
-        print('Not using distributed mode')
+        print("Not using distributed mode")
         args.distributed = False
         return
 
     args.distributed = True
 
     torch.cuda.set_device(args.gpu)
-    args.dist_backend = 'nccl'
-    print('| distributed init (rank {}): {}'.format(
-        args.rank, args.dist_url), flush=True)
-    torch.distributed.init_process_group(backend=args.dist_backend, init_method=args.dist_url,
-                                         world_size=args.world_size, rank=args.rank)
+    args.dist_backend = "nccl"
+    print(f"| distributed init (rank {args.rank}): {args.dist_url}", flush=True)
+    torch.distributed.init_process_group(
+        backend=args.dist_backend, init_method=args.dist_url, world_size=args.world_size, rank=args.rank
+    )
     torch.distributed.barrier()
     setup_for_distributed(args.rank == 0)
 
@@ -455,11 +459,9 @@ def interpolate(input, size=None, scale_factor=None, mode="nearest", align_corne
     This will eventually be supported natively by PyTorch, and this
     class can go away.
     """
-    if version.parse(torchvision.__version__) < version.parse('0.7'):
+    if version.parse(torchvision.__version__) < version.parse("0.7"):
         if input.numel() > 0:
-            return torch.nn.functional.interpolate(
-                input, size, scale_factor, mode, align_corners
-            )
+            return torch.nn.functional.interpolate(input, size, scale_factor, mode, align_corners)
 
         output_shape = _output_size(2, input, size, scale_factor)
         output_shape = list(input.shape[:-2]) + list(output_shape)

--- a/roboverse_learn/il/policies/act/detr/util/plot_utils.py
+++ b/roboverse_learn/il/policies/act/detr/util/plot_utils.py
@@ -1,17 +1,18 @@
 """
 Plotting utilities to visualize training logs.
 """
-import torch
-import pandas as pd
-import numpy as np
-import seaborn as sns
-import matplotlib.pyplot as plt
 
 from pathlib import Path, PurePath
 
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import torch
 
-def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col=0, log_name='log.txt'):
-    '''
+
+def plot_logs(logs, fields=("class_error", "loss_bbox_unscaled", "mAP"), ewm_col=0, log_name="log.txt"):
+    """
     Function to plot specific fields from training log(s). Plots both training and test results.
 
     :: Inputs - logs = list containing Path objects, each pointing to individual dir with a log file
@@ -22,7 +23,7 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
     :: Outputs - matplotlib plots of results in fields, color coded for each log file.
                - solid lines are training results, dashed lines are test results.
 
-    '''
+    """
     func_name = "plot_utils.py::plot_logs"
 
     # verify logs is a list of Paths (list[Paths]) or single Pathlib object Path,
@@ -33,8 +34,10 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
             logs = [logs]
             print(f"{func_name} info: logs param expects a list argument, converted to list[Path].")
         else:
-            raise ValueError(f"{func_name} - invalid argument for logs parameter.\n \
-            Expect list[Path] or single Path obj, received {type(logs)}")
+            raise ValueError(
+                f"{func_name} - invalid argument for logs parameter.\n \
+            Expect list[Path] or single Path obj, received {type(logs)}"
+            )
 
     # Quality checks - verify valid dir(s), that every item in list is Path object, and that log_name exists in each dir
     for i, dir in enumerate(logs):
@@ -56,52 +59,48 @@ def plot_logs(logs, fields=('class_error', 'loss_bbox_unscaled', 'mAP'), ewm_col
 
     for df, color in zip(dfs, sns.color_palette(n_colors=len(logs))):
         for j, field in enumerate(fields):
-            if field == 'mAP':
-                coco_eval = pd.DataFrame(
-                    np.stack(df.test_coco_eval_bbox.dropna().values)[:, 1]
-                ).ewm(com=ewm_col).mean()
+            if field == "mAP":
+                coco_eval = pd.DataFrame(np.stack(df.test_coco_eval_bbox.dropna().values)[:, 1]).ewm(com=ewm_col).mean()
                 axs[j].plot(coco_eval, c=color)
             else:
                 df.interpolate().ewm(com=ewm_col).mean().plot(
-                    y=[f'train_{field}', f'test_{field}'],
-                    ax=axs[j],
-                    color=[color] * 2,
-                    style=['-', '--']
+                    y=[f"train_{field}", f"test_{field}"], ax=axs[j], color=[color] * 2, style=["-", "--"]
                 )
     for ax, field in zip(axs, fields):
         ax.legend([Path(p).name for p in logs])
         ax.set_title(field)
 
 
-def plot_precision_recall(files, naming_scheme='iter'):
-    if naming_scheme == 'exp_id':
+def plot_precision_recall(files, naming_scheme="iter"):
+    if naming_scheme == "exp_id":
         # name becomes exp_id
         names = [f.parts[-3] for f in files]
-    elif naming_scheme == 'iter':
+    elif naming_scheme == "iter":
         names = [f.stem for f in files]
     else:
-        raise ValueError(f'not supported {naming_scheme}')
+        raise ValueError(f"not supported {naming_scheme}")
     fig, axs = plt.subplots(ncols=2, figsize=(16, 5))
     for f, color, name in zip(files, sns.color_palette("Blues", n_colors=len(files)), names):
         data = torch.load(f)
         # precision is n_iou, n_points, n_cat, n_area, max_det
-        precision = data['precision']
-        recall = data['params'].recThrs
-        scores = data['scores']
+        precision = data["precision"]
+        recall = data["params"].recThrs
+        scores = data["scores"]
         # take precision for all classes, all areas and 100 detections
         precision = precision[0, :, :, 0, -1].mean(1)
         scores = scores[0, :, :, 0, -1].mean(1)
         prec = precision.mean()
-        rec = data['recall'][0, :, 0, -1].mean()
-        print(f'{naming_scheme} {name}: mAP@50={prec * 100: 05.1f}, ' +
-              f'score={scores.mean():0.3f}, ' +
-              f'f1={2 * prec * rec / (prec + rec + 1e-8):0.3f}'
-              )
+        rec = data["recall"][0, :, 0, -1].mean()
+        print(
+            f"{naming_scheme} {name}: mAP@50={prec * 100: 05.1f}, "
+            + f"score={scores.mean():0.3f}, "
+            + f"f1={2 * prec * rec / (prec + rec + 1e-8):0.3f}"
+        )
         axs[0].plot(recall, precision, c=color)
         axs[1].plot(recall, scores, c=color)
 
-    axs[0].set_title('Precision / Recall')
+    axs[0].set_title("Precision / Recall")
     axs[0].legend(names)
-    axs[1].set_title('Scores / Recall')
+    axs[1].set_title("Scores / Recall")
     axs[1].legend(names)
     return fig, axs

--- a/roboverse_learn/il/policies/act/imitate_episodes.py
+++ b/roboverse_learn/il/policies/act/imitate_episodes.py
@@ -1,127 +1,141 @@
-import torch
-import numpy as np
+import argparse
 import os
 import pickle
-import argparse
-import matplotlib.pyplot as plt
 from copy import deepcopy
-from tqdm import tqdm
-from einops import rearrange
-
-from constants import DT
-from constants import PUPPET_GRIPPER_JOINT_OPEN
-from utils import load_data # data functions
-from utils import sample_box_pose, sample_insertion_pose # robot functions
-from utils import compute_dict_mean, set_seed, detach_dict # helper functions
-from policy import ACTPolicy, CNNMLPPolicy
-from visualize_episodes import save_videos
-
-from sim_env import BOX_POSE
 
 import IPython
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+from constants import DT, PUPPET_GRIPPER_JOINT_OPEN
+from einops import rearrange
+from policy import ACTPolicy, CNNMLPPolicy
+from sim_env import BOX_POSE
+from tqdm import tqdm
+from utils import (  # robot functions  # helper functions
+    compute_dict_mean,
+    detach_dict,
+    load_data,  # data functions
+    sample_box_pose,
+    sample_insertion_pose,
+    set_seed,
+)
+from visualize_episodes import save_videos
+
 e = IPython.embed
+
 
 def main(args):
     set_seed(1)
     # command line parameters
-    is_eval = args['eval']
-    ckpt_dir = args['ckpt_dir']
-    policy_class = args['policy_class']
-    onscreen_render = args['onscreen_render']
-    task_name = args['task_name']
-    batch_size_train = args['batch_size']
-    batch_size_val = args['batch_size']
-    num_epochs = args['num_epochs']
+    is_eval = args["eval"]
+    ckpt_dir = args["ckpt_dir"]
+    policy_class = args["policy_class"]
+    onscreen_render = args["onscreen_render"]
+    task_name = args["task_name"]
+    batch_size_train = args["batch_size"]
+    batch_size_val = args["batch_size"]
+    num_epochs = args["num_epochs"]
 
     # get task parameters
-    is_sim = task_name[:4] == 'sim_'
+    is_sim = task_name[:4] == "sim_"
     if is_sim:
         from constants import SIM_TASK_CONFIGS
+
         task_config = SIM_TASK_CONFIGS[task_name]
     else:
         from roboverse.constants import TASK_CONFIGS
+
         task_config = TASK_CONFIGS[task_name]
-    dataset_dir = task_config['dataset_dir']
-    num_episodes = task_config['num_episodes']
-    episode_len = task_config['episode_len']
-    camera_names = task_config['camera_names']
+    dataset_dir = task_config["dataset_dir"]
+    num_episodes = task_config["num_episodes"]
+    episode_len = task_config["episode_len"]
+    camera_names = task_config["camera_names"]
 
     # fixed parameters
     state_dim = 14
     lr_backbone = 1e-5
-    backbone = 'resnet18'
-    if policy_class == 'ACT':
+    backbone = "resnet18"
+    if policy_class == "ACT":
         enc_layers = 4
         dec_layers = 7
         nheads = 8
-        policy_config = {'lr': args['lr'],
-                         'num_queries': args['chunk_size'],
-                         'kl_weight': args['kl_weight'],
-                         'hidden_dim': args['hidden_dim'],
-                         'dim_feedforward': args['dim_feedforward'],
-                         'lr_backbone': lr_backbone,
-                         'backbone': backbone,
-                         'enc_layers': enc_layers,
-                         'dec_layers': dec_layers,
-                         'nheads': nheads,
-                         'camera_names': camera_names,
-                         }
-    elif policy_class == 'CNNMLP':
-        policy_config = {'lr': args['lr'], 'lr_backbone': lr_backbone, 'backbone' : backbone, 'num_queries': 1,
-                         'camera_names': camera_names,}
+        policy_config = {
+            "lr": args["lr"],
+            "num_queries": args["chunk_size"],
+            "kl_weight": args["kl_weight"],
+            "hidden_dim": args["hidden_dim"],
+            "dim_feedforward": args["dim_feedforward"],
+            "lr_backbone": lr_backbone,
+            "backbone": backbone,
+            "enc_layers": enc_layers,
+            "dec_layers": dec_layers,
+            "nheads": nheads,
+            "camera_names": camera_names,
+        }
+    elif policy_class == "CNNMLP":
+        policy_config = {
+            "lr": args["lr"],
+            "lr_backbone": lr_backbone,
+            "backbone": backbone,
+            "num_queries": 1,
+            "camera_names": camera_names,
+        }
     else:
         raise NotImplementedError
 
     config = {
-        'num_epochs': num_epochs,
-        'ckpt_dir': ckpt_dir,
-        'episode_len': episode_len,
-        'state_dim': state_dim,
-        'lr': args['lr'],
-        'policy_class': policy_class,
-        'onscreen_render': onscreen_render,
-        'policy_config': policy_config,
-        'task_name': task_name,
-        'seed': args['seed'],
-        'temporal_agg': args['temporal_agg'],
-        'camera_names': camera_names,
-        'real_robot': not is_sim
+        "num_epochs": num_epochs,
+        "ckpt_dir": ckpt_dir,
+        "episode_len": episode_len,
+        "state_dim": state_dim,
+        "lr": args["lr"],
+        "policy_class": policy_class,
+        "onscreen_render": onscreen_render,
+        "policy_config": policy_config,
+        "task_name": task_name,
+        "seed": args["seed"],
+        "temporal_agg": args["temporal_agg"],
+        "camera_names": camera_names,
+        "real_robot": not is_sim,
     }
 
     if is_eval:
-        ckpt_names = [f'policy_best.ckpt']
+        ckpt_names = ["policy_best.ckpt"]
         results = []
         for ckpt_name in ckpt_names:
             success_rate, avg_return = eval_bc(config, ckpt_name, save_episode=True)
             results.append([ckpt_name, success_rate, avg_return])
 
         for ckpt_name, success_rate, avg_return in results:
-            print(f'{ckpt_name}: {success_rate=} {avg_return=}')
+            print(f"{ckpt_name}: {success_rate=} {avg_return=}")
         print()
         exit()
 
-    train_dataloader, val_dataloader, stats, _ = load_data(dataset_dir, num_episodes, camera_names, batch_size_train, batch_size_val)
+    train_dataloader, val_dataloader, stats, _ = load_data(
+        dataset_dir, num_episodes, camera_names, batch_size_train, batch_size_val
+    )
 
     # save dataset stats
     if not os.path.isdir(ckpt_dir):
         os.makedirs(ckpt_dir)
-    stats_path = os.path.join(ckpt_dir, f'dataset_stats.pkl')
-    with open(stats_path, 'wb') as f:
+    stats_path = os.path.join(ckpt_dir, "dataset_stats.pkl")
+    with open(stats_path, "wb") as f:
         pickle.dump(stats, f)
 
     best_ckpt_info = train_bc(train_dataloader, val_dataloader, config)
     best_epoch, min_val_loss, best_state_dict = best_ckpt_info
 
     # save best checkpoint
-    ckpt_path = os.path.join(ckpt_dir, f'policy_best.ckpt')
+    ckpt_path = os.path.join(ckpt_dir, "policy_best.ckpt")
     torch.save(best_state_dict, ckpt_path)
-    print(f'Best ckpt, val loss {min_val_loss:.6f} @ epoch{best_epoch}')
+    print(f"Best ckpt, val loss {min_val_loss:.6f} @ epoch{best_epoch}")
 
 
 def make_policy(policy_class, policy_config):
-    if policy_class == 'ACT':
+    if policy_class == "ACT":
         policy = ACTPolicy(policy_config)
-    elif policy_class == 'CNNMLP':
+    elif policy_class == "CNNMLP":
         policy = CNNMLPPolicy(policy_config)
     else:
         raise NotImplementedError
@@ -129,9 +143,9 @@ def make_policy(policy_class, policy_config):
 
 
 def make_optimizer(policy_class, policy):
-    if policy_class == 'ACT':
+    if policy_class == "ACT":
         optimizer = policy.configure_optimizers()
-    elif policy_class == 'CNNMLP':
+    elif policy_class == "CNNMLP":
         optimizer = policy.configure_optimizers()
     else:
         raise NotImplementedError
@@ -141,7 +155,7 @@ def make_optimizer(policy_class, policy):
 def get_image(ts, camera_names):
     curr_images = []
     for cam_name in camera_names:
-        curr_image = rearrange(ts.observation['images'][cam_name], 'h w c -> c h w')
+        curr_image = rearrange(ts.observation["images"][cam_name], "h w c -> c h w")
         curr_images.append(curr_image)
     curr_image = np.stack(curr_images, axis=0)
     curr_image = torch.from_numpy(curr_image / 255.0).float().cuda().unsqueeze(0)
@@ -150,17 +164,17 @@ def get_image(ts, camera_names):
 
 def eval_bc(config, ckpt_name, save_episode=True):
     set_seed(1000)
-    ckpt_dir = config['ckpt_dir']
-    state_dim = config['state_dim']
-    real_robot = config['real_robot']
-    policy_class = config['policy_class']
-    onscreen_render = config['onscreen_render']
-    policy_config = config['policy_config']
-    camera_names = config['camera_names']
-    max_timesteps = config['episode_len']
-    task_name = config['task_name']
-    temporal_agg = config['temporal_agg']
-    onscreen_cam = 'angle'
+    ckpt_dir = config["ckpt_dir"]
+    state_dim = config["state_dim"]
+    real_robot = config["real_robot"]
+    policy_class = config["policy_class"]
+    onscreen_render = config["onscreen_render"]
+    policy_config = config["policy_config"]
+    camera_names = config["camera_names"]
+    max_timesteps = config["episode_len"]
+    task_name = config["task_name"]
+    temporal_agg = config["temporal_agg"]
+    onscreen_cam = "angle"
 
     # load policy and stats
     ckpt_path = os.path.join(ckpt_dir, ckpt_name)
@@ -169,31 +183,33 @@ def eval_bc(config, ckpt_name, save_episode=True):
     print(loading_status)
     policy.cuda()
     policy.eval()
-    print(f'Loaded: {ckpt_path}')
-    stats_path = os.path.join(ckpt_dir, f'dataset_stats.pkl')
-    with open(stats_path, 'rb') as f:
+    print(f"Loaded: {ckpt_path}")
+    stats_path = os.path.join(ckpt_dir, "dataset_stats.pkl")
+    with open(stats_path, "rb") as f:
         stats = pickle.load(f)
 
-    pre_process = lambda s_qpos: (s_qpos - stats['qpos_mean']) / stats['qpos_std']
-    post_process = lambda a: a * stats['action_std'] + stats['action_mean']
+    pre_process = lambda s_qpos: (s_qpos - stats["qpos_mean"]) / stats["qpos_std"]
+    post_process = lambda a: a * stats["action_std"] + stats["action_mean"]
 
     # load environment
     if real_robot:
-        from aloha_scripts.robot_utils import move_grippers # requires aloha
-        from aloha_scripts.real_env import make_real_env # requires aloha
+        from aloha_scripts.real_env import make_real_env  # requires aloha
+        from aloha_scripts.robot_utils import move_grippers  # requires aloha
+
         env = make_real_env(init_node=True)
         env_max_reward = 0
     else:
         from sim_env import make_sim_env
+
         env = make_sim_env(task_name)
         env_max_reward = env.task.max_reward
 
-    query_frequency = policy_config['num_queries']
+    query_frequency = policy_config["num_queries"]
     if temporal_agg:
         query_frequency = 1
-        num_queries = policy_config['num_queries']
+        num_queries = policy_config["num_queries"]
 
-    max_timesteps = int(max_timesteps * 1) # may increase for real-world tasks
+    max_timesteps = int(max_timesteps * 1)  # may increase for real-world tasks
 
     num_rollouts = 50
     episode_returns = []
@@ -201,10 +217,10 @@ def eval_bc(config, ckpt_name, save_episode=True):
     for rollout_id in range(num_rollouts):
         rollout_id += 0
         ### set task
-        if 'sim_transfer_cube' in task_name:
-            BOX_POSE[0] = sample_box_pose() # used in sim reset
-        elif 'sim_insertion' in task_name:
-            BOX_POSE[0] = np.concatenate(sample_insertion_pose()) # used in sim reset
+        if "sim_transfer_cube" in task_name:
+            BOX_POSE[0] = sample_box_pose()  # used in sim reset
+        elif "sim_insertion" in task_name:
+            BOX_POSE[0] = np.concatenate(sample_insertion_pose())  # used in sim reset
 
         ts = env.reset()
 
@@ -216,10 +232,10 @@ def eval_bc(config, ckpt_name, save_episode=True):
 
         ### evaluation loop
         if temporal_agg:
-            all_time_actions = torch.zeros([max_timesteps, max_timesteps+num_queries, state_dim]).cuda()
+            all_time_actions = torch.zeros([max_timesteps, max_timesteps + num_queries, state_dim]).cuda()
 
         qpos_history = torch.zeros((1, max_timesteps, state_dim)).cuda()
-        image_list = [] # for visualization
+        image_list = []  # for visualization
         qpos_list = []
         target_qpos_list = []
         rewards = []
@@ -233,22 +249,22 @@ def eval_bc(config, ckpt_name, save_episode=True):
 
                 ### process previous timestep to get qpos and image_list
                 obs = ts.observation
-                if 'images' in obs:
-                    image_list.append(obs['images'])
+                if "images" in obs:
+                    image_list.append(obs["images"])
                 else:
-                    image_list.append({'main': obs['image']})
-                qpos_numpy = np.array(obs['qpos'])
+                    image_list.append({"main": obs["image"]})
+                qpos_numpy = np.array(obs["qpos"])
                 qpos = pre_process(qpos_numpy)
                 qpos = torch.from_numpy(qpos).float().cuda().unsqueeze(0)
                 qpos_history[:, t] = qpos
                 curr_image = get_image(ts, camera_names)
 
                 ### query policy
-                if config['policy_class'] == "ACT":
+                if config["policy_class"] == "ACT":
                     if t % query_frequency == 0:
                         all_actions = policy(qpos, curr_image)
                     if temporal_agg:
-                        all_time_actions[[t], t:t+num_queries] = all_actions
+                        all_time_actions[[t], t : t + num_queries] = all_actions
                         actions_for_curr_step = all_time_actions[:, t]
                         actions_populated = torch.all(actions_for_curr_step != 0, axis=1)
                         actions_for_curr_step = actions_for_curr_step[actions_populated]
@@ -259,7 +275,7 @@ def eval_bc(config, ckpt_name, save_episode=True):
                         raw_action = (actions_for_curr_step * exp_weights).sum(dim=0, keepdim=True)
                     else:
                         raw_action = all_actions[:, t % query_frequency]
-                elif config['policy_class'] == "CNNMLP":
+                elif config["policy_class"] == "CNNMLP":
                     raw_action = policy(qpos, curr_image)
                 else:
                     raise NotImplementedError
@@ -279,7 +295,9 @@ def eval_bc(config, ckpt_name, save_episode=True):
 
             plt.close()
         if real_robot:
-            move_grippers([env.puppet_bot_left, env.puppet_bot_right], [PUPPET_GRIPPER_JOINT_OPEN] * 2, move_time=0.5)  # open
+            move_grippers(
+                [env.puppet_bot_left, env.puppet_bot_right], [PUPPET_GRIPPER_JOINT_OPEN] * 2, move_time=0.5
+            )  # open
             pass
 
         rewards = np.array([r for r in rewards if r is not None])
@@ -287,27 +305,29 @@ def eval_bc(config, ckpt_name, save_episode=True):
         episode_returns.append(episode_return)
         episode_highest_reward = np.max(rewards)
         highest_rewards.append(episode_highest_reward)
-        print(f'Rollout {rollout_id}\n{episode_return=}, {episode_highest_reward=}, {env_max_reward=}, Success: {episode_highest_reward==env_max_reward}')
+        print(
+            f"Rollout {rollout_id}\n{episode_return=}, {episode_highest_reward=}, {env_max_reward=}, Success: {episode_highest_reward == env_max_reward}"
+        )
 
         if save_episode:
-            save_videos(image_list, DT, video_path=os.path.join(ckpt_dir, f'video{rollout_id}.mp4'))
+            save_videos(image_list, DT, video_path=os.path.join(ckpt_dir, f"video{rollout_id}.mp4"))
 
     success_rate = np.mean(np.array(highest_rewards) == env_max_reward)
     avg_return = np.mean(episode_returns)
-    summary_str = f'\nSuccess rate: {success_rate}\nAverage return: {avg_return}\n\n'
-    for r in range(env_max_reward+1):
+    summary_str = f"\nSuccess rate: {success_rate}\nAverage return: {avg_return}\n\n"
+    for r in range(env_max_reward + 1):
         more_or_equal_r = (np.array(highest_rewards) >= r).sum()
         more_or_equal_r_rate = more_or_equal_r / num_rollouts
-        summary_str += f'Reward >= {r}: {more_or_equal_r}/{num_rollouts} = {more_or_equal_r_rate*100}%\n'
+        summary_str += f"Reward >= {r}: {more_or_equal_r}/{num_rollouts} = {more_or_equal_r_rate * 100}%\n"
 
     print(summary_str)
 
     # save success rate to txt
-    result_file_name = 'result_' + ckpt_name.split('.')[0] + '.txt'
-    with open(os.path.join(ckpt_dir, result_file_name), 'w') as f:
+    result_file_name = "result_" + ckpt_name.split(".")[0] + ".txt"
+    with open(os.path.join(ckpt_dir, result_file_name), "w") as f:
         f.write(summary_str)
         f.write(repr(episode_returns))
-        f.write('\n\n')
+        f.write("\n\n")
         f.write(repr(highest_rewards))
 
     return success_rate, avg_return
@@ -316,15 +336,15 @@ def eval_bc(config, ckpt_name, save_episode=True):
 def forward_pass(data, policy):
     image_data, qpos_data, action_data, is_pad = data
     image_data, qpos_data, action_data, is_pad = image_data.cuda(), qpos_data.cuda(), action_data.cuda(), is_pad.cuda()
-    return policy(qpos_data, image_data, action_data, is_pad) # TODO remove None
+    return policy(qpos_data, image_data, action_data, is_pad)  # TODO remove None
 
 
 def train_bc(train_dataloader, val_dataloader, config):
-    num_epochs = config['num_epochs']
-    ckpt_dir = config['ckpt_dir']
-    seed = config['seed']
-    policy_class = config['policy_class']
-    policy_config = config['policy_config']
+    num_epochs = config["num_epochs"]
+    ckpt_dir = config["ckpt_dir"]
+    seed = config["seed"]
+    policy_class = config["policy_class"]
+    policy_config = config["policy_config"]
 
     set_seed(seed)
 
@@ -337,7 +357,7 @@ def train_bc(train_dataloader, val_dataloader, config):
     min_val_loss = np.inf
     best_ckpt_info = None
     for epoch in tqdm(range(num_epochs)):
-        print(f'\nEpoch {epoch}')
+        print(f"\nEpoch {epoch}")
         # validation
         with torch.inference_mode():
             policy.eval()
@@ -348,14 +368,14 @@ def train_bc(train_dataloader, val_dataloader, config):
             epoch_summary = compute_dict_mean(epoch_dicts)
             validation_history.append(epoch_summary)
 
-            epoch_val_loss = epoch_summary['loss']
+            epoch_val_loss = epoch_summary["loss"]
             if epoch_val_loss < min_val_loss:
                 min_val_loss = epoch_val_loss
                 best_ckpt_info = (epoch, min_val_loss, deepcopy(policy.state_dict()))
-        print(f'Val loss:   {epoch_val_loss:.5f}')
-        summary_string = ''
+        print(f"Val loss:   {epoch_val_loss:.5f}")
+        summary_string = ""
         for k, v in epoch_summary.items():
-            summary_string += f'{k}: {v.item():.3f} '
+            summary_string += f"{k}: {v.item():.3f} "
         print(summary_string)
 
         # training
@@ -364,31 +384,31 @@ def train_bc(train_dataloader, val_dataloader, config):
         for batch_idx, data in enumerate(train_dataloader):
             forward_dict = forward_pass(data, policy)
             # backward
-            loss = forward_dict['loss']
+            loss = forward_dict["loss"]
             loss.backward()
             optimizer.step()
             optimizer.zero_grad()
             train_history.append(detach_dict(forward_dict))
-        epoch_summary = compute_dict_mean(train_history[(batch_idx+1)*epoch:(batch_idx+1)*(epoch+1)])
-        epoch_train_loss = epoch_summary['loss']
-        print(f'Train loss: {epoch_train_loss:.5f}')
-        summary_string = ''
+        epoch_summary = compute_dict_mean(train_history[(batch_idx + 1) * epoch : (batch_idx + 1) * (epoch + 1)])
+        epoch_train_loss = epoch_summary["loss"]
+        print(f"Train loss: {epoch_train_loss:.5f}")
+        summary_string = ""
         for k, v in epoch_summary.items():
-            summary_string += f'{k}: {v.item():.3f} '
+            summary_string += f"{k}: {v.item():.3f} "
         print(summary_string)
 
         if epoch % 100 == 0:
-            ckpt_path = os.path.join(ckpt_dir, f'policy_epoch_{epoch}_seed_{seed}.ckpt')
+            ckpt_path = os.path.join(ckpt_dir, f"policy_epoch_{epoch}_seed_{seed}.ckpt")
             torch.save(policy.state_dict(), ckpt_path)
             plot_history(train_history, validation_history, epoch, ckpt_dir, seed)
 
-    ckpt_path = os.path.join(ckpt_dir, f'policy_last.ckpt')
+    ckpt_path = os.path.join(ckpt_dir, "policy_last.ckpt")
     torch.save(policy.state_dict(), ckpt_path)
 
     best_epoch, min_val_loss, best_state_dict = best_ckpt_info
-    ckpt_path = os.path.join(ckpt_dir, f'policy_epoch_{best_epoch}_seed_{seed}.ckpt')
+    ckpt_path = os.path.join(ckpt_dir, f"policy_epoch_{best_epoch}_seed_{seed}.ckpt")
     torch.save(best_state_dict, ckpt_path)
-    print(f'Training finished:\nSeed {seed}, val loss {min_val_loss:.6f} at epoch {best_epoch}')
+    print(f"Training finished:\nSeed {seed}, val loss {min_val_loss:.6f} at epoch {best_epoch}")
 
     # save training curves
     plot_history(train_history, validation_history, num_epochs, ckpt_dir, seed)
@@ -399,37 +419,37 @@ def train_bc(train_dataloader, val_dataloader, config):
 def plot_history(train_history, validation_history, num_epochs, ckpt_dir, seed):
     # save training curves
     for key in train_history[0]:
-        plot_path = os.path.join(ckpt_dir, f'train_val_{key}_seed_{seed}.png')
+        plot_path = os.path.join(ckpt_dir, f"train_val_{key}_seed_{seed}.png")
         plt.figure()
         train_values = [summary[key].item() for summary in train_history]
         val_values = [summary[key].item() for summary in validation_history]
-        plt.plot(np.linspace(0, num_epochs-1, len(train_history)), train_values, label='train')
-        plt.plot(np.linspace(0, num_epochs-1, len(validation_history)), val_values, label='validation')
+        plt.plot(np.linspace(0, num_epochs - 1, len(train_history)), train_values, label="train")
+        plt.plot(np.linspace(0, num_epochs - 1, len(validation_history)), val_values, label="validation")
         # plt.ylim([-0.1, 1])
         plt.tight_layout()
         plt.legend()
         plt.title(key)
         plt.savefig(plot_path)
-    print(f'Saved plots to {ckpt_dir}')
+    print(f"Saved plots to {ckpt_dir}")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--eval', action='store_true')
-    parser.add_argument('--onscreen_render', action='store_true')
-    parser.add_argument('--ckpt_dir', action='store', type=str, help='ckpt_dir', required=True)
-    parser.add_argument('--policy_class', action='store', type=str, help='policy_class, capitalize', required=True)
-    parser.add_argument('--task_name', action='store', type=str, help='task_name', required=True)
-    parser.add_argument('--batch_size', action='store', type=int, help='batch_size', required=True)
-    parser.add_argument('--seed', action='store', type=int, help='seed', required=True)
-    parser.add_argument('--num_epochs', action='store', type=int, help='num_epochs', required=True)
-    parser.add_argument('--lr', action='store', type=float, help='lr', required=True)
+    parser.add_argument("--eval", action="store_true")
+    parser.add_argument("--onscreen_render", action="store_true")
+    parser.add_argument("--ckpt_dir", action="store", type=str, help="ckpt_dir", required=True)
+    parser.add_argument("--policy_class", action="store", type=str, help="policy_class, capitalize", required=True)
+    parser.add_argument("--task_name", action="store", type=str, help="task_name", required=True)
+    parser.add_argument("--batch_size", action="store", type=int, help="batch_size", required=True)
+    parser.add_argument("--seed", action="store", type=int, help="seed", required=True)
+    parser.add_argument("--num_epochs", action="store", type=int, help="num_epochs", required=True)
+    parser.add_argument("--lr", action="store", type=float, help="lr", required=True)
 
     # for ACT
-    parser.add_argument('--kl_weight', action='store', type=int, help='KL Weight', required=False)
-    parser.add_argument('--chunk_size', action='store', type=int, help='chunk_size', required=False)
-    parser.add_argument('--hidden_dim', action='store', type=int, help='hidden_dim', required=False)
-    parser.add_argument('--dim_feedforward', action='store', type=int, help='dim_feedforward', required=False)
-    parser.add_argument('--temporal_agg', action='store_true')
+    parser.add_argument("--kl_weight", action="store", type=int, help="KL Weight", required=False)
+    parser.add_argument("--chunk_size", action="store", type=int, help="chunk_size", required=False)
+    parser.add_argument("--hidden_dim", action="store", type=int, help="hidden_dim", required=False)
+    parser.add_argument("--dim_feedforward", action="store", type=int, help="dim_feedforward", required=False)
+    parser.add_argument("--temporal_agg", action="store_true")
 
     main(vars(parser.parse_args()))

--- a/roboverse_learn/il/policies/act/policy.py
+++ b/roboverse_learn/il/policies/act/policy.py
@@ -1,40 +1,41 @@
+import IPython
 import torch.nn as nn
-from torch.nn import functional as F
 import torchvision.transforms as transforms
+from torch.nn import functional as F
 
 from .detr.main import build_ACT_model_and_optimizer, build_CNNMLP_model_and_optimizer
-import IPython
+
 e = IPython.embed
+
 
 class ACTPolicy(nn.Module):
     def __init__(self, args_override):
         super().__init__()
         model, optimizer = build_ACT_model_and_optimizer(args_override)
-        self.model = model # CVAE decoder
+        self.model = model  # CVAE decoder
         self.optimizer = optimizer
-        self.kl_weight = args_override['kl_weight']
-        print(f'KL Weight {self.kl_weight}')
+        self.kl_weight = args_override["kl_weight"]
+        print(f"KL Weight {self.kl_weight}")
 
     def __call__(self, qpos, image, actions=None, is_pad=None):
         env_state = None
-        normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                                         std=[0.229, 0.224, 0.225])
+        normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
         image = normalize(image)
-        if actions is not None: # training time
-            actions = actions[:, :self.model.num_queries]
-            is_pad = is_pad[:, :self.model.num_queries]
+        if actions is not None:  # training time
+            actions = actions[:, : self.model.num_queries]
+            is_pad = is_pad[:, : self.model.num_queries]
 
             a_hat, is_pad_hat, (mu, logvar) = self.model(qpos, image, env_state, actions, is_pad)
             total_kld, dim_wise_kld, mean_kld = kl_divergence(mu, logvar)
             loss_dict = dict()
-            all_l1 = F.l1_loss(actions, a_hat, reduction='none')
+            all_l1 = F.l1_loss(actions, a_hat, reduction="none")
             l1 = (all_l1 * ~is_pad.unsqueeze(-1)).mean()
-            loss_dict['l1'] = l1
-            loss_dict['kl'] = total_kld[0]
-            loss_dict['loss'] = loss_dict['l1'] + loss_dict['kl'] * self.kl_weight
+            loss_dict["l1"] = l1
+            loss_dict["kl"] = total_kld[0]
+            loss_dict["loss"] = loss_dict["l1"] + loss_dict["kl"] * self.kl_weight
             return loss_dict
-        else: # inference time
-            a_hat, _, (_, _) = self.model(qpos, image, env_state) # no action, sample from prior
+        else:  # inference time
+            a_hat, _, (_, _) = self.model(qpos, image, env_state)  # no action, sample from prior
             return a_hat
 
     def configure_optimizers(self):
@@ -45,28 +46,28 @@ class CNNMLPPolicy(nn.Module):
     def __init__(self, args_override):
         super().__init__()
         model, optimizer = build_CNNMLP_model_and_optimizer(args_override)
-        self.model = model # decoder
+        self.model = model  # decoder
         self.optimizer = optimizer
 
     def __call__(self, qpos, image, actions=None, is_pad=None):
-        env_state = None # TODO
-        normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406],
-                                         std=[0.229, 0.224, 0.225])
+        env_state = None  # TODO
+        normalize = transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225])
         image = normalize(image)
-        if actions is not None: # training time
+        if actions is not None:  # training time
             actions = actions[:, 0]
             a_hat = self.model(qpos, image, env_state, actions)
             mse = F.mse_loss(actions, a_hat)
             loss_dict = dict()
-            loss_dict['mse'] = mse
-            loss_dict['loss'] = loss_dict['mse']
+            loss_dict["mse"] = mse
+            loss_dict["loss"] = loss_dict["mse"]
             return loss_dict
-        else: # inference time
-            a_hat = self.model(qpos, image, env_state) # no action, sample from prior
+        else:  # inference time
+            a_hat = self.model(qpos, image, env_state)  # no action, sample from prior
             return a_hat
 
     def configure_optimizers(self):
         return self.optimizer
+
 
 def kl_divergence(mu, logvar):
     batch_size = mu.size(0)

--- a/roboverse_learn/il/policies/act/scripted_policy.py
+++ b/roboverse_learn/il/policies/act/scripted_policy.py
@@ -1,11 +1,10 @@
-import numpy as np
+import IPython
 import matplotlib.pyplot as plt
+import numpy as np
 import quaternion
-
 from constants import SIM_TASK_CONFIGS
 from ee_sim_env import make_ee_sim_env
 
-import IPython
 e = IPython.embed
 
 
@@ -22,12 +21,12 @@ class BasePolicy:
     @staticmethod
     def interpolate(curr_waypoint, next_waypoint, t):
         t_frac = (t - curr_waypoint["t"]) / (next_waypoint["t"] - curr_waypoint["t"])
-        curr_xyz = curr_waypoint['xyz']
-        curr_quat = curr_waypoint['quat']
-        curr_grip = curr_waypoint['gripper']
-        next_xyz = next_waypoint['xyz']
-        next_quat = next_waypoint['quat']
-        next_grip = next_waypoint['gripper']
+        curr_xyz = curr_waypoint["xyz"]
+        curr_quat = curr_waypoint["quat"]
+        curr_grip = curr_waypoint["gripper"]
+        next_xyz = next_waypoint["xyz"]
+        next_quat = next_waypoint["quat"]
+        next_grip = next_waypoint["gripper"]
         xyz = curr_xyz + (next_xyz - curr_xyz) * t_frac
         quat = curr_quat + (next_quat - curr_quat) * t_frac
         gripper = curr_grip + (next_grip - curr_grip) * t_frac
@@ -39,17 +38,21 @@ class BasePolicy:
             self.generate_trajectory(ts)
 
         # obtain left and right waypoints
-        if self.left_trajectory[0]['t'] == self.step_count:
+        if self.left_trajectory[0]["t"] == self.step_count:
             self.curr_left_waypoint = self.left_trajectory.pop(0)
         next_left_waypoint = self.left_trajectory[0]
 
-        if self.right_trajectory[0]['t'] == self.step_count:
+        if self.right_trajectory[0]["t"] == self.step_count:
             self.curr_right_waypoint = self.right_trajectory.pop(0)
         next_right_waypoint = self.right_trajectory[0]
 
         # interpolate between waypoints to obtain current pose and gripper command
-        left_xyz, left_quat, left_gripper = self.interpolate(self.curr_left_waypoint, next_left_waypoint, self.step_count)
-        right_xyz, right_quat, right_gripper = self.interpolate(self.curr_right_waypoint, next_right_waypoint, self.step_count)
+        left_xyz, left_quat, left_gripper = self.interpolate(
+            self.curr_left_waypoint, next_left_waypoint, self.step_count
+        )
+        right_xyz, right_quat, right_gripper = self.interpolate(
+            self.curr_right_waypoint, next_right_waypoint, self.step_count
+        )
 
         # Inject noise
         if self.inject_noise:
@@ -65,12 +68,11 @@ class BasePolicy:
 
 
 class PickAndTransferPolicy(BasePolicy):
-
     def generate_trajectory(self, ts_first):
-        init_mocap_pose_right = ts_first.observation['mocap_pose_right']
-        init_mocap_pose_left = ts_first.observation['mocap_pose_left']
+        init_mocap_pose_right = ts_first.observation["mocap_pose_right"]
+        init_mocap_pose_left = ts_first.observation["mocap_pose_left"]
 
-        box_info = np.array(ts_first.observation['env_state'])
+        box_info = np.array(ts_first.observation["env_state"])
         box_xyz = box_info[:3]
         box_quat = box_info[3:]
         # print(f"Generate trajectory for {box_xyz=}")
@@ -87,38 +89,87 @@ class PickAndTransferPolicy(BasePolicy):
         gripper_pick_quat_array = quaternion.as_float_array(gripper_pick_quat)
 
         self.left_trajectory = [
-            {"t": 0, "xyz": init_mocap_pose_left[:3], "quat": init_mocap_pose_left[3:], "gripper": 0}, # sleep
-            {"t": 100, "xyz": meet_xyz + np.array([-0.1, 0, -0.02]), "quat": meet_left_quat_array, "gripper": 1}, # approach meet position
-            {"t": 260, "xyz": meet_xyz + np.array([0.02, 0, -0.02]), "quat": meet_left_quat_array, "gripper": 1}, # move to meet position
-            {"t": 310, "xyz": meet_xyz + np.array([0.02, 0, -0.02]), "quat": meet_left_quat_array, "gripper": 0}, # close gripper
-            {"t": 360, "xyz": meet_xyz + np.array([-0.1, 0, -0.02]), "quat": np.array([1, 0, 0, 0]), "gripper": 0}, # move left
-            {"t": 400, "xyz": meet_xyz + np.array([-0.1, 0, -0.02]), "quat": np.array([1, 0, 0, 0]), "gripper": 0}, # stay
+            {"t": 0, "xyz": init_mocap_pose_left[:3], "quat": init_mocap_pose_left[3:], "gripper": 0},  # sleep
+            {
+                "t": 100,
+                "xyz": meet_xyz + np.array([-0.1, 0, -0.02]),
+                "quat": meet_left_quat_array,
+                "gripper": 1,
+            },  # approach meet position
+            {
+                "t": 260,
+                "xyz": meet_xyz + np.array([0.02, 0, -0.02]),
+                "quat": meet_left_quat_array,
+                "gripper": 1,
+            },  # move to meet position
+            {
+                "t": 310,
+                "xyz": meet_xyz + np.array([0.02, 0, -0.02]),
+                "quat": meet_left_quat_array,
+                "gripper": 0,
+            },  # close gripper
+            {
+                "t": 360,
+                "xyz": meet_xyz + np.array([-0.1, 0, -0.02]),
+                "quat": np.array([1, 0, 0, 0]),
+                "gripper": 0,
+            },  # move left
+            {
+                "t": 400,
+                "xyz": meet_xyz + np.array([-0.1, 0, -0.02]),
+                "quat": np.array([1, 0, 0, 0]),
+                "gripper": 0,
+            },  # stay
         ]
 
         self.right_trajectory = [
-            {"t": 0, "xyz": init_mocap_pose_right[:3], "quat": init_mocap_pose_right[3:], "gripper": 0}, # sleep
-            {"t": 90, "xyz": box_xyz + np.array([0, 0, 0.08]), "quat": gripper_pick_quat_array, "gripper": 1}, # approach the cube
-            {"t": 130, "xyz": box_xyz + np.array([0, 0, -0.015]), "quat": gripper_pick_quat_array, "gripper": 1}, # go down
-            {"t": 170, "xyz": box_xyz + np.array([0, 0, -0.015]), "quat": gripper_pick_quat_array, "gripper": 0}, # close gripper
-            {"t": 200, "xyz": meet_xyz + np.array([0.05, 0, 0]), "quat": gripper_pick_quat_array, "gripper": 0}, # approach meet position
-            {"t": 220, "xyz": meet_xyz, "quat": gripper_pick_quat_array, "gripper": 0}, # move to meet position
-            {"t": 310, "xyz": meet_xyz, "quat": gripper_pick_quat_array, "gripper": 1}, # open gripper
-            {"t": 360, "xyz": meet_xyz + np.array([0.1, 0, 0]), "quat": gripper_pick_quat_array, "gripper": 1}, # move to right
-            {"t": 400, "xyz": meet_xyz + np.array([0.1, 0, 0]), "quat": gripper_pick_quat_array, "gripper": 1}, # stay
+            {"t": 0, "xyz": init_mocap_pose_right[:3], "quat": init_mocap_pose_right[3:], "gripper": 0},  # sleep
+            {
+                "t": 90,
+                "xyz": box_xyz + np.array([0, 0, 0.08]),
+                "quat": gripper_pick_quat_array,
+                "gripper": 1,
+            },  # approach the cube
+            {
+                "t": 130,
+                "xyz": box_xyz + np.array([0, 0, -0.015]),
+                "quat": gripper_pick_quat_array,
+                "gripper": 1,
+            },  # go down
+            {
+                "t": 170,
+                "xyz": box_xyz + np.array([0, 0, -0.015]),
+                "quat": gripper_pick_quat_array,
+                "gripper": 0,
+            },  # close gripper
+            {
+                "t": 200,
+                "xyz": meet_xyz + np.array([0.05, 0, 0]),
+                "quat": gripper_pick_quat_array,
+                "gripper": 0,
+            },  # approach meet position
+            {"t": 220, "xyz": meet_xyz, "quat": gripper_pick_quat_array, "gripper": 0},  # move to meet position
+            {"t": 310, "xyz": meet_xyz, "quat": gripper_pick_quat_array, "gripper": 1},  # open gripper
+            {
+                "t": 360,
+                "xyz": meet_xyz + np.array([0.1, 0, 0]),
+                "quat": gripper_pick_quat_array,
+                "gripper": 1,
+            },  # move to right
+            {"t": 400, "xyz": meet_xyz + np.array([0.1, 0, 0]), "quat": gripper_pick_quat_array, "gripper": 1},  # stay
         ]
 
 
 class InsertionPolicy(BasePolicy):
-
     def generate_trajectory(self, ts_first):
-        init_mocap_pose_right = ts_first.observation['mocap_pose_right']
-        init_mocap_pose_left = ts_first.observation['mocap_pose_left']
+        init_mocap_pose_right = ts_first.observation["mocap_pose_right"]
+        init_mocap_pose_left = ts_first.observation["mocap_pose_left"]
 
-        peg_info = np.array(ts_first.observation['env_state'])[:7]
+        peg_info = np.array(ts_first.observation["env_state"])[:7]
         peg_xyz = peg_info[:3]
         peg_quat = peg_info[3:]
 
-        socket_info = np.array(ts_first.observation['env_state'])[7:]
+        socket_info = np.array(ts_first.observation["env_state"])[7:]
         socket_xyz = socket_info[:3]
         socket_quat = socket_info[3:]
 
@@ -137,24 +188,83 @@ class InsertionPolicy(BasePolicy):
         gripper_pick_quat_right_array = quaternion.as_float_array(gripper_pick_quat_right)
 
         self.left_trajectory = [
-            {"t": 0, "xyz": init_mocap_pose_left[:3], "quat": init_mocap_pose_left[3:], "gripper": 0}, # sleep
-            {"t": 120, "xyz": socket_xyz + np.array([0, 0, 0.08]), "quat": gripper_pick_quat_left_array, "gripper": 1}, # approach the cube
-            {"t": 170, "xyz": socket_xyz + np.array([0, 0, -0.03]), "quat": gripper_pick_quat_left_array, "gripper": 1}, # go down
-            {"t": 220, "xyz": socket_xyz + np.array([0, 0, -0.03]), "quat": gripper_pick_quat_left_array, "gripper": 0}, # close gripper
-            {"t": 285, "xyz": meet_xyz + np.array([-0.1, 0, 0]), "quat": gripper_pick_quat_left_array, "gripper": 0}, # approach meet position
-            {"t": 340, "xyz": meet_xyz + np.array([-0.05, 0, 0]), "quat": gripper_pick_quat_left_array,"gripper": 0},  # insertion
-            {"t": 400, "xyz": meet_xyz + np.array([-0.05, 0, 0]), "quat": gripper_pick_quat_left_array, "gripper": 0},  # insertion
+            {"t": 0, "xyz": init_mocap_pose_left[:3], "quat": init_mocap_pose_left[3:], "gripper": 0},  # sleep
+            {
+                "t": 120,
+                "xyz": socket_xyz + np.array([0, 0, 0.08]),
+                "quat": gripper_pick_quat_left_array,
+                "gripper": 1,
+            },  # approach the cube
+            {
+                "t": 170,
+                "xyz": socket_xyz + np.array([0, 0, -0.03]),
+                "quat": gripper_pick_quat_left_array,
+                "gripper": 1,
+            },  # go down
+            {
+                "t": 220,
+                "xyz": socket_xyz + np.array([0, 0, -0.03]),
+                "quat": gripper_pick_quat_left_array,
+                "gripper": 0,
+            },  # close gripper
+            {
+                "t": 285,
+                "xyz": meet_xyz + np.array([-0.1, 0, 0]),
+                "quat": gripper_pick_quat_left_array,
+                "gripper": 0,
+            },  # approach meet position
+            {
+                "t": 340,
+                "xyz": meet_xyz + np.array([-0.05, 0, 0]),
+                "quat": gripper_pick_quat_left_array,
+                "gripper": 0,
+            },  # insertion
+            {
+                "t": 400,
+                "xyz": meet_xyz + np.array([-0.05, 0, 0]),
+                "quat": gripper_pick_quat_left_array,
+                "gripper": 0,
+            },  # insertion
         ]
 
         self.right_trajectory = [
-            {"t": 0, "xyz": init_mocap_pose_right[:3], "quat": init_mocap_pose_right[3:], "gripper": 0}, # sleep
-            {"t": 120, "xyz": peg_xyz + np.array([0, 0, 0.08]), "quat": gripper_pick_quat_right_array, "gripper": 1}, # approach the cube
-            {"t": 170, "xyz": peg_xyz + np.array([0, 0, -0.03]), "quat": gripper_pick_quat_right_array, "gripper": 1}, # go down
-            {"t": 220, "xyz": peg_xyz + np.array([0, 0, -0.03]), "quat": gripper_pick_quat_right_array, "gripper": 0}, # close gripper
-            {"t": 285, "xyz": meet_xyz + np.array([0.1, 0, lift_right]), "quat": gripper_pick_quat_right_array, "gripper": 0}, # approach meet position
-            {"t": 340, "xyz": meet_xyz + np.array([0.05, 0, lift_right]), "quat": gripper_pick_quat_right_array, "gripper": 0},  # insertion
-            {"t": 400, "xyz": meet_xyz + np.array([0.05, 0, lift_right]), "quat": gripper_pick_quat_right_array, "gripper": 0},  # insertion
-
+            {"t": 0, "xyz": init_mocap_pose_right[:3], "quat": init_mocap_pose_right[3:], "gripper": 0},  # sleep
+            {
+                "t": 120,
+                "xyz": peg_xyz + np.array([0, 0, 0.08]),
+                "quat": gripper_pick_quat_right_array,
+                "gripper": 1,
+            },  # approach the cube
+            {
+                "t": 170,
+                "xyz": peg_xyz + np.array([0, 0, -0.03]),
+                "quat": gripper_pick_quat_right_array,
+                "gripper": 1,
+            },  # go down
+            {
+                "t": 220,
+                "xyz": peg_xyz + np.array([0, 0, -0.03]),
+                "quat": gripper_pick_quat_right_array,
+                "gripper": 0,
+            },  # close gripper
+            {
+                "t": 285,
+                "xyz": meet_xyz + np.array([0.1, 0, lift_right]),
+                "quat": gripper_pick_quat_right_array,
+                "gripper": 0,
+            },  # approach meet position
+            {
+                "t": 340,
+                "xyz": meet_xyz + np.array([0.05, 0, lift_right]),
+                "quat": gripper_pick_quat_right_array,
+                "gripper": 0,
+            },  # insertion
+            {
+                "t": 400,
+                "xyz": meet_xyz + np.array([0.05, 0, lift_right]),
+                "quat": gripper_pick_quat_right_array,
+                "gripper": 0,
+            },  # insertion
         ]
 
 
@@ -164,11 +274,11 @@ def test_policy(task_name):
     inject_noise = False
 
     # setup the environment
-    episode_len = SIM_TASK_CONFIGS[task_name]['episode_len']
-    if 'sim_transfer_cube' in task_name:
-        env = make_ee_sim_env('sim_transfer_cube')
-    elif 'sim_insertion' in task_name:
-        env = make_ee_sim_env('sim_insertion')
+    episode_len = SIM_TASK_CONFIGS[task_name]["episode_len"]
+    if "sim_transfer_cube" in task_name:
+        env = make_ee_sim_env("sim_transfer_cube")
+    elif "sim_insertion" in task_name:
+        env = make_ee_sim_env("sim_insertion")
     else:
         raise NotImplementedError
 
@@ -177,7 +287,7 @@ def test_policy(task_name):
         episode = [ts]
         if onscreen_render:
             ax = plt.subplot()
-            plt_img = ax.imshow(ts.observation['images']['angle'])
+            plt_img = ax.imshow(ts.observation["images"]["angle"])
             plt.ion()
 
         policy = PickAndTransferPolicy(inject_noise)
@@ -186,7 +296,7 @@ def test_policy(task_name):
             ts = env.step(action)
             episode.append(ts)
             if onscreen_render:
-                plt_img.set_data(ts.observation['images']['angle'])
+                plt_img.set_data(ts.observation["images"]["angle"])
                 plt.pause(0.02)
         plt.close()
 
@@ -197,6 +307,6 @@ def test_policy(task_name):
             print(f"{episode_idx=} Failed")
 
 
-if __name__ == '__main__':
-    test_task_name = 'sim_transfer_cube_scripted'
+if __name__ == "__main__":
+    test_task_name = "sim_transfer_cube_scripted"
     test_policy(test_task_name)

--- a/roboverse_learn/il/policies/act/train.py
+++ b/roboverse_learn/il/policies/act/train.py
@@ -1,23 +1,27 @@
-import torch
-import numpy as np
+import argparse
+import json
 import os
 import pickle
-import argparse
-import matplotlib.pyplot as plt
-import yaml
-import json
 from copy import deepcopy
-from tqdm import tqdm
-from omegaconf import OmegaConf
-
-from .utils import load_data  # data functions
-from .utils import compute_dict_mean, set_seed, detach_dict  # helper functions
-from .policy import ACTPolicy, CNNMLPPolicy
-from roboverse_learn.il.runners.base_runner import BaseRunner
 
 import IPython
+import matplotlib.pyplot as plt
+import numpy as np
+import torch
+import yaml
+from omegaconf import OmegaConf
+from tqdm import tqdm
+
+from roboverse_learn.il.runners.base_runner import BaseRunner
+
+from .policy import ACTPolicy, CNNMLPPolicy
+from .utils import (  # helper functions
+    compute_dict_mean,
+    load_data,  # data functions
+    set_seed,
+)
+
 e = IPython.embed
-from datetime import datetime
 
 
 class ACTRunner(BaseRunner):
@@ -25,14 +29,14 @@ class ACTRunner(BaseRunner):
         super().__init__(cfg, output_dir=output_dir)
 
         # Determine device
-        self.device = torch.device(cfg.get('device', 'cuda' if torch.cuda.is_available() else 'cpu'))
+        self.device = torch.device(cfg.get("device", "cuda" if torch.cuda.is_available() else "cpu"))
 
         # Set seed
-        set_seed(cfg['seed'])
+        set_seed(cfg["seed"])
 
         # Policy configuration
-        self.policy_class = cfg['policy_class']
-        self.policy_config = cfg['policy_config']
+        self.policy_class = cfg["policy_class"]
+        self.policy_config = cfg["policy_config"]
 
         # Initialize policy and optimizer
         self.policy = self._make_policy()
@@ -40,18 +44,18 @@ class ACTRunner(BaseRunner):
         self.optimizer = self._make_optimizer()
 
     def _make_policy(self):
-        if self.policy_class == 'ACT':
+        if self.policy_class == "ACT":
             policy = ACTPolicy(self.policy_config)
-        elif self.policy_class == 'CNNMLP':
+        elif self.policy_class == "CNNMLP":
             policy = CNNMLPPolicy(self.policy_config)
         else:
             raise NotImplementedError
         return policy
 
     def _make_optimizer(self):
-        if self.policy_class == 'ACT':
+        if self.policy_class == "ACT":
             optimizer = self.policy.configure_optimizers()
-        elif self.policy_class == 'CNNMLP':
+        elif self.policy_class == "CNNMLP":
             optimizer = self.policy.configure_optimizers()
         else:
             raise NotImplementedError
@@ -67,29 +71,25 @@ class ACTRunner(BaseRunner):
 
     def train(self):
         cfg = self.cfg
-        num_epochs = cfg['num_epochs']
+        num_epochs = cfg["num_epochs"]
         ckpt_dir = self.output_dir
-        seed = cfg['seed']
+        seed = cfg["seed"]
 
         # Load data
         train_dataloader, val_dataloader, stats, _ = load_data(
-            cfg['dataset_dir'],
-            cfg['num_episodes'],
-            cfg['camera_names'],
-            cfg['batch_size'],
-            cfg['batch_size']
+            cfg["dataset_dir"], cfg["num_episodes"], cfg["camera_names"], cfg["batch_size"], cfg["batch_size"]
         )
 
         # Save dataset stats
         if not os.path.isdir(ckpt_dir):
             os.makedirs(ckpt_dir)
-        stats_path = os.path.join(ckpt_dir, f'dataset_stats.pkl')
-        with open(stats_path, 'wb') as f:
+        stats_path = os.path.join(ckpt_dir, "dataset_stats.pkl")
+        with open(stats_path, "wb") as f:
             pickle.dump(stats, f)
 
         # Save config to cfg.yaml
-        config_path = os.path.join(ckpt_dir, 'cfg.yaml')
-        with open(config_path, 'w') as f:
+        config_path = os.path.join(ckpt_dir, "cfg.yaml")
+        with open(config_path, "w") as f:
             # Convert OmegaConf to dict if needed, or just dump the dict
             if isinstance(cfg, (dict, list)):
                 yaml.dump(cfg, f, default_flow_style=False)
@@ -102,7 +102,7 @@ class ACTRunner(BaseRunner):
         best_ckpt_info = None
 
         for epoch in tqdm(range(num_epochs)):
-            print(f'\nEpoch {epoch}')
+            print(f"\nEpoch {epoch}")
             # Validation
             with torch.inference_mode():
                 self.policy.eval()
@@ -113,15 +113,15 @@ class ACTRunner(BaseRunner):
                 epoch_summary = compute_dict_mean(epoch_dicts)
                 validation_history.append(epoch_summary)
 
-                epoch_val_loss = epoch_summary['loss']
+                epoch_val_loss = epoch_summary["loss"]
                 if epoch_val_loss < min_val_loss:
                     min_val_loss = epoch_val_loss
                     best_ckpt_info = (epoch, min_val_loss, deepcopy(self.policy.state_dict()))
 
-            print(f'Val loss:   {epoch_val_loss:.5f}')
-            summary_string = ''
+            print(f"Val loss:   {epoch_val_loss:.5f}")
+            summary_string = ""
             for k, v in epoch_summary.items():
-                summary_string += f'{k}: {v.item():.3f} '
+                summary_string += f"{k}: {v.item():.3f} "
             print(summary_string)
 
             # Training
@@ -131,7 +131,7 @@ class ACTRunner(BaseRunner):
             for batch_idx, data in enumerate(train_dataloader):
                 forward_dict = self.forward_pass(data)
                 # Backward
-                loss = forward_dict['loss']
+                loss = forward_dict["loss"]
                 loss.backward()
                 self.optimizer.step()
                 self.optimizer.zero_grad()
@@ -139,32 +139,32 @@ class ACTRunner(BaseRunner):
 
             epoch_train_summary = compute_dict_mean(epoch_train_dicts)
             train_history.append(epoch_train_summary)
-            epoch_train_loss = epoch_train_summary['loss']
-            print(f'Train loss: {epoch_train_loss:.5f}')
+            epoch_train_loss = epoch_train_summary["loss"]
+            print(f"Train loss: {epoch_train_loss:.5f}")
 
-            summary_string = ''
+            summary_string = ""
             for k, v in epoch_train_summary.items():
-                summary_string += f'{k}: {v.item():.3f} '
+                summary_string += f"{k}: {v.item():.3f} "
             print(summary_string)
 
             if epoch % 100 == 0:
-                ckpt_path = os.path.join(ckpt_dir, f'policy_epoch_{epoch}_seed_{seed}.ckpt')
+                ckpt_path = os.path.join(ckpt_dir, f"policy_epoch_{epoch}_seed_{seed}.ckpt")
                 torch.save(self.policy.state_dict(), ckpt_path)
                 plot_history(train_history, validation_history, epoch, ckpt_dir, seed)
 
-        ckpt_path = os.path.join(ckpt_dir, f'policy_last.ckpt')
+        ckpt_path = os.path.join(ckpt_dir, "policy_last.ckpt")
         torch.save(self.policy.state_dict(), ckpt_path)
 
         best_epoch, min_val_loss, best_state_dict = best_ckpt_info
-        ckpt_path = os.path.join(ckpt_dir, f'policy_best.ckpt')
+        ckpt_path = os.path.join(ckpt_dir, "policy_best.ckpt")
         torch.save(best_state_dict, ckpt_path)
-        print(f'Training finished:\nSeed {seed}, val loss {min_val_loss:.6f} at epoch {best_epoch}')
+        print(f"Training finished:\nSeed {seed}, val loss {min_val_loss:.6f} at epoch {best_epoch}")
 
         # Save training curves
         plot_history(train_history, validation_history, num_epochs, ckpt_dir, seed)
 
         file_path = os.path.join("./roboverse_learn/il/policies/act", "ckpt_dir_path.txt")
-        with open(file_path, 'w') as f:
+        with open(file_path, "w") as f:
             f.write(ckpt_dir)
 
         return best_ckpt_info
@@ -173,79 +173,85 @@ class ACTRunner(BaseRunner):
 def plot_history(train_history, validation_history, num_epochs, ckpt_dir, seed):
     # save training curves
     for key in train_history[0]:
-        plot_path = os.path.join(ckpt_dir, f'train_val_{key}_seed_{seed}.png')
+        plot_path = os.path.join(ckpt_dir, f"train_val_{key}_seed_{seed}.png")
         plt.figure()
         train_values = [summary[key].item() for summary in train_history]
         val_values = [summary[key].item() for summary in validation_history]
-        plt.plot(np.linspace(0, num_epochs-1, len(train_history)), train_values, label='train')
-        plt.plot(np.linspace(0, num_epochs-1, len(validation_history)), val_values, label='validation')
+        plt.plot(np.linspace(0, num_epochs - 1, len(train_history)), train_values, label="train")
+        plt.plot(np.linspace(0, num_epochs - 1, len(validation_history)), val_values, label="validation")
         # plt.ylim([-0.1, 1])
         plt.tight_layout()
         plt.legend()
         plt.title(key)
         plt.savefig(plot_path)
-    print(f'Saved plots to {ckpt_dir}')
+    print(f"Saved plots to {ckpt_dir}")
 
 
 def main(args):
     # Prepare configuration
-    policy_class = args['policy_class']
-    task_name = args['task_name']
-    camera_names = args['camera_names']
+    policy_class = args["policy_class"]
+    task_name = args["task_name"]
+    camera_names = args["camera_names"]
 
     # fixed parameters
     lr_backbone = 1e-5
-    backbone = 'resnet18'
-    if policy_class == 'ACT':
+    backbone = "resnet18"
+    if policy_class == "ACT":
         enc_layers = 4
         dec_layers = 7
         nheads = 8
-        policy_config = {'lr': args['lr'],
-                         'num_queries': args['chunk_size'],
-                         'kl_weight': args['kl_weight'],
-                         'hidden_dim': args['hidden_dim'],
-                         'dim_feedforward': args['dim_feedforward'],
-                         'lr_backbone': lr_backbone,
-                         'backbone': backbone,
-                         'enc_layers': enc_layers,
-                         'dec_layers': dec_layers,
-                         'nheads': nheads,
-                         'camera_names': camera_names,
-                         'state_dim': args['state_dim']
-                         }
-    elif policy_class == 'CNNMLP':
-        policy_config = {'lr': args['lr'], 'lr_backbone': lr_backbone, 'backbone': backbone, 'num_queries': 1,
-                         'camera_names': camera_names, }
+        policy_config = {
+            "lr": args["lr"],
+            "num_queries": args["chunk_size"],
+            "kl_weight": args["kl_weight"],
+            "hidden_dim": args["hidden_dim"],
+            "dim_feedforward": args["dim_feedforward"],
+            "lr_backbone": lr_backbone,
+            "backbone": backbone,
+            "enc_layers": enc_layers,
+            "dec_layers": dec_layers,
+            "nheads": nheads,
+            "camera_names": camera_names,
+            "state_dim": args["state_dim"],
+        }
+    elif policy_class == "CNNMLP":
+        policy_config = {
+            "lr": args["lr"],
+            "lr_backbone": lr_backbone,
+            "backbone": backbone,
+            "num_queries": 1,
+            "camera_names": camera_names,
+        }
     else:
         raise NotImplementedError
 
-    level = args.get('level', 0)
+    level = args.get("level", 0)
     ckpt_dir = f"il_outputs/act/{task_name}/ckpt/level{level}"
 
     # Load metadata from dataset directory
-    dataset_dir = args['dataset_dir']
-    metadata_path = os.path.join(dataset_dir, 'metadata.json')
+    dataset_dir = args["dataset_dir"]
+    metadata_path = os.path.join(dataset_dir, "metadata.json")
     dataset_metadata = {}
     if os.path.exists(metadata_path):
-        with open(metadata_path, 'r') as f:
+        with open(metadata_path) as f:
             dataset_metadata = json.load(f)
 
     config = {
-        'num_epochs': args['num_epochs'],
-        'episode_len': args['episode_len'],
-        'lr': args['lr'],
-        'policy_class': policy_class,
-        'policy_config': policy_config,
-        'task_name': task_name,
-        'seed': args['seed'],
-        'temporal_agg': args['temporal_agg'],
-        'camera_names': camera_names,
-        'real_robot': True,
-        'data': dataset_metadata,
-        'dataset_dir': dataset_dir,
-        'num_episodes': args['num_episodes'],
-        'batch_size': args['batch_size'],
-        'device': args.get('device', 'cuda' if torch.cuda.is_available() else 'cpu')
+        "num_epochs": args["num_epochs"],
+        "episode_len": args["episode_len"],
+        "lr": args["lr"],
+        "policy_class": policy_class,
+        "policy_config": policy_config,
+        "task_name": task_name,
+        "seed": args["seed"],
+        "temporal_agg": args["temporal_agg"],
+        "camera_names": camera_names,
+        "real_robot": True,
+        "data": dataset_metadata,
+        "dataset_dir": dataset_dir,
+        "num_episodes": args["num_episodes"],
+        "batch_size": args["batch_size"],
+        "device": args.get("device", "cuda" if torch.cuda.is_available() else "cpu"),
     }
 
     # Convert to OmegaConf for compatibility with BaseRunner if needed,
@@ -257,28 +263,28 @@ def main(args):
     runner.train()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument('--policy_class', action='store', type=str, help='policy_class, capitalize', required=True)
-    parser.add_argument('--task_name', action='store', type=str, help='task_name', required=True)
-    parser.add_argument('--batch_size', action='store', type=int, help='batch_size', required=True)
-    parser.add_argument('--seed', action='store', type=int, help='seed', required=True)
-    parser.add_argument('--num_epochs', action='store', type=int, help='num_epochs', required=True)
-    parser.add_argument('--lr', action='store', type=float, help='lr', required=True)
+    parser.add_argument("--policy_class", action="store", type=str, help="policy_class, capitalize", required=True)
+    parser.add_argument("--task_name", action="store", type=str, help="task_name", required=True)
+    parser.add_argument("--batch_size", action="store", type=int, help="batch_size", required=True)
+    parser.add_argument("--seed", action="store", type=int, help="seed", required=True)
+    parser.add_argument("--num_epochs", action="store", type=int, help="num_epochs", required=True)
+    parser.add_argument("--lr", action="store", type=float, help="lr", required=True)
 
     # for ACT
-    parser.add_argument('--camera_names', nargs='+', type=str, default=['head_camera'], help='camera names')
-    parser.add_argument('--episode_len', action='store', type=int, default=400, help='episode length')
+    parser.add_argument("--camera_names", nargs="+", type=str, default=["head_camera"], help="camera names")
+    parser.add_argument("--episode_len", action="store", type=int, default=400, help="episode length")
 
-    parser.add_argument('--num_episodes', action='store', type=int, help='num_episodes', required=False)
-    parser.add_argument('--dataset_dir', action='store', type=str, help='dataset_dir', required=False)
-    parser.add_argument('--kl_weight', action='store', type=int, help='KL Weight', required=False)
-    parser.add_argument('--chunk_size', action='store', type=int, help='chunk_size', required=False)
-    parser.add_argument('--hidden_dim', action='store', type=int, help='hidden_dim', required=False)
-    parser.add_argument('--dim_feedforward', action='store', type=int, help='dim_feedforward', required=False)
-    parser.add_argument('--temporal_agg', action='store_true')
-    parser.add_argument('--state_dim', action='store', type=int, help='state_dim', required=False, default=9)
-    parser.add_argument('--level', action='store', type=str, help='level', required=False, default=0)
-    parser.add_argument('--device', action='store', type=str, help='device', required=False, default='cuda')
+    parser.add_argument("--num_episodes", action="store", type=int, help="num_episodes", required=False)
+    parser.add_argument("--dataset_dir", action="store", type=str, help="dataset_dir", required=False)
+    parser.add_argument("--kl_weight", action="store", type=int, help="KL Weight", required=False)
+    parser.add_argument("--chunk_size", action="store", type=int, help="chunk_size", required=False)
+    parser.add_argument("--hidden_dim", action="store", type=int, help="hidden_dim", required=False)
+    parser.add_argument("--dim_feedforward", action="store", type=int, help="dim_feedforward", required=False)
+    parser.add_argument("--temporal_agg", action="store_true")
+    parser.add_argument("--state_dim", action="store", type=int, help="state_dim", required=False, default=9)
+    parser.add_argument("--level", action="store", type=str, help="level", required=False, default=0)
+    parser.add_argument("--device", action="store", type=str, help="device", required=False, default="cuda")
 
     main(vars(parser.parse_args()))

--- a/roboverse_learn/il/policies/act/utils.py
+++ b/roboverse_learn/il/policies/act/utils.py
@@ -1,15 +1,15 @@
-import sys
 import os
 
+import h5py
+import IPython
 import numpy as np
 import torch
-import h5py
-import json
-from torch.utils.data import TensorDataset, DataLoader
+from torch.utils.data import DataLoader
+
 from roboverse_learn.il.utils.replay_buffer import ReplayBuffer
 
-import IPython
 e = IPython.embed
+
 
 class ZarrEpisodicRoboVerseDataset(torch.utils.data.Dataset):
     def __init__(self, episode_ids, dataset_dir, camera_names, norm_stats):
@@ -22,10 +22,7 @@ class ZarrEpisodicRoboVerseDataset(torch.utils.data.Dataset):
 
         # Load zarr data
         zarr_path = dataset_dir
-        self.replay_buffer = ReplayBuffer.copy_from_path(
-            zarr_path,
-            keys=["head_camera", "state", "action"]
-        )
+        self.replay_buffer = ReplayBuffer.copy_from_path(zarr_path, keys=["head_camera", "state", "action"])
 
         # Construct indices for all possible (episode_id, start_ts) pairs
         self.indices = []
@@ -34,7 +31,6 @@ class ZarrEpisodicRoboVerseDataset(torch.utils.data.Dataset):
             episode_len = episode_slice.stop - episode_slice.start
             for ts in range(episode_len):
                 self.indices.append((episode_id, ts))
-
 
     def __len__(self):
         return len(self.indices)
@@ -54,16 +50,16 @@ class ZarrEpisodicRoboVerseDataset(torch.utils.data.Dataset):
         # Take the first frame as the starting point
         state = state_sequence[start_ts]
 
-        head_camera = head_camera_sequence[start_ts:start_ts+1]
+        head_camera = head_camera_sequence[start_ts : start_ts + 1]
         # Assumes the zarr stores images in NCHW format, convert to NHWC
         # Get actions starting from the first time step
         action = action_sequence[start_ts:]
         action_len = len(action)
 
         # Pad action sequence to max episode length
-        padded_action = np.zeros([self.norm_stats['max_episode_len'], action_sequence.shape[1]], dtype=np.float32)
+        padded_action = np.zeros([self.norm_stats["max_episode_len"], action_sequence.shape[1]], dtype=np.float32)
         padded_action[:action_len] = action
-        is_pad = np.zeros(self.norm_stats['max_episode_len'])
+        is_pad = np.zeros(self.norm_stats["max_episode_len"])
         is_pad[action_len:] = 1
 
         # Format observations
@@ -82,6 +78,7 @@ class ZarrEpisodicRoboVerseDataset(torch.utils.data.Dataset):
 
         return image_data, state_data, action_data, is_pad
 
+
 class EpisodicDataset(torch.utils.data.Dataset):
     def __init__(self, episode_ids, dataset_dir, camera_names, norm_stats):
         super(EpisodicDataset).__init__()
@@ -90,37 +87,37 @@ class EpisodicDataset(torch.utils.data.Dataset):
         self.camera_names = camera_names
         self.norm_stats = norm_stats
         self.is_sim = None
-        self.__getitem__(0) # initialize self.is_sim
+        self.__getitem__(0)  # initialize self.is_sim
 
     def __len__(self):
         return len(self.episode_ids)
 
     def __getitem__(self, index):
-        sample_full_episode = False # hardcode
+        sample_full_episode = False  # hardcode
 
         episode_id = self.episode_ids[index]
-        dataset_path = os.path.join(self.dataset_dir, f'episode_{episode_id}.hdf5')
-        with h5py.File(dataset_path, 'r') as root:
-            is_sim = root.attrs['sim']
-            original_action_shape = root['/action'].shape
+        dataset_path = os.path.join(self.dataset_dir, f"episode_{episode_id}.hdf5")
+        with h5py.File(dataset_path, "r") as root:
+            is_sim = root.attrs["sim"]
+            original_action_shape = root["/action"].shape
             episode_len = original_action_shape[0]
             if sample_full_episode:
                 start_ts = 0
             else:
                 start_ts = np.random.choice(episode_len)
             # get observation at start_ts only
-            qpos = root['/observations/qpos'][start_ts]
-            qvel = root['/observations/qvel'][start_ts]
+            qpos = root["/observations/qpos"][start_ts]
+            qvel = root["/observations/qvel"][start_ts]
             image_dict = dict()
             for cam_name in self.camera_names:
-                image_dict[cam_name] = root[f'/observations/images/{cam_name}'][start_ts]
+                image_dict[cam_name] = root[f"/observations/images/{cam_name}"][start_ts]
             # get all actions after and including start_ts
             if is_sim:
-                action = root['/action'][start_ts:]
+                action = root["/action"][start_ts:]
                 action_len = episode_len - start_ts
             else:
-                action = root['/action'][max(0, start_ts - 1):] # hack, to make timesteps more aligned
-                action_len = episode_len - max(0, start_ts - 1) # hack, to make timesteps more aligned
+                action = root["/action"][max(0, start_ts - 1) :]  # hack, to make timesteps more aligned
+                action_len = episode_len - max(0, start_ts - 1)  # hack, to make timesteps more aligned
 
         self.is_sim = is_sim
         padded_action = np.zeros(original_action_shape, dtype=np.float32)
@@ -141,7 +138,7 @@ class EpisodicDataset(torch.utils.data.Dataset):
         is_pad = torch.from_numpy(is_pad).bool()
 
         # channel last
-        image_data = torch.einsum('k h w c -> k c h w', image_data)
+        image_data = torch.einsum("k h w c -> k c h w", image_data)
 
         # normalize image and change dtype to float
         image_data = image_data / 255.0
@@ -154,10 +151,7 @@ class EpisodicDataset(torch.utils.data.Dataset):
 def get_norm_stats(dataset_dir, num_episodes):
     # Load the zarr data
     zarr_path = dataset_dir
-    replay_buffer = ReplayBuffer.copy_from_path(
-        zarr_path,
-        keys=["state", "action"]
-    )
+    replay_buffer = ReplayBuffer.copy_from_path(zarr_path, keys=["state", "action"])
     actual_episodes = replay_buffer.n_episodes
     if num_episodes > actual_episodes:
         print(f"Warning: Requested {num_episodes} episodes, but dataset only has {actual_episodes}")
@@ -199,34 +193,38 @@ def get_norm_stats(dataset_dir, num_episodes):
         "state_mean": state_mean.numpy().squeeze(),
         "state_std": state_std.numpy().squeeze(),
         "example_state": state,
-        "max_episode_len": max_episode_len
+        "max_episode_len": max_episode_len,
     }
 
     return stats, num_episodes
 
 
-
 def load_data(dataset_dir, num_episodes, camera_names, batch_size_train, batch_size_val):
-    print(f'\nData from: {dataset_dir}\n')
+    print(f"\nData from: {dataset_dir}\n")
 
     norm_stats, num_episodes = get_norm_stats(dataset_dir, num_episodes)
 
     # obtain train test split
     train_ratio = 0.8
     shuffled_indices = np.random.permutation(num_episodes)
-    train_indices = shuffled_indices[:int(train_ratio * num_episodes)]
-    val_indices = shuffled_indices[int(train_ratio * num_episodes):]
+    train_indices = shuffled_indices[: int(train_ratio * num_episodes)]
+    val_indices = shuffled_indices[int(train_ratio * num_episodes) :]
 
     # construct dataset and dataloader
     train_dataset = ZarrEpisodicRoboVerseDataset(train_indices, dataset_dir, camera_names, norm_stats)
     val_dataset = ZarrEpisodicRoboVerseDataset(val_indices, dataset_dir, camera_names, norm_stats)
-    train_dataloader = DataLoader(train_dataset, batch_size=batch_size_train, shuffle=True, pin_memory=True, num_workers=1, prefetch_factor=1)
-    val_dataloader = DataLoader(val_dataset, batch_size=batch_size_val, shuffle=True, pin_memory=True, num_workers=1, prefetch_factor=1)
+    train_dataloader = DataLoader(
+        train_dataset, batch_size=batch_size_train, shuffle=True, pin_memory=True, num_workers=1, prefetch_factor=1
+    )
+    val_dataloader = DataLoader(
+        val_dataset, batch_size=batch_size_val, shuffle=True, pin_memory=True, num_workers=1, prefetch_factor=1
+    )
 
     return train_dataloader, val_dataloader, norm_stats, train_dataset.is_sim
 
 
 ### env utils
+
 
 def sample_box_pose():
     x_range = [0.0, 0.2]
@@ -238,6 +236,7 @@ def sample_box_pose():
 
     cube_quat = np.array([1, 0, 0, 0])
     return np.concatenate([cube_position, cube_quat])
+
 
 def sample_insertion_pose():
     # Peg
@@ -264,7 +263,9 @@ def sample_insertion_pose():
 
     return peg_pose, socket_pose
 
+
 ### helper functions
+
 
 def compute_dict_mean(epoch_dicts):
     result = {k: None for k in epoch_dicts[0]}
@@ -276,11 +277,13 @@ def compute_dict_mean(epoch_dicts):
         result[k] = value_sum / num_items
     return result
 
+
 def detach_dict(d):
     new_d = dict()
     for k, v in d.items():
         new_d[k] = v.detach()
     return new_d
+
 
 def set_seed(seed):
     torch.manual_seed(seed)

--- a/roboverse_learn/il/policies/base_image_policy.py
+++ b/roboverse_learn/il/policies/base_image_policy.py
@@ -1,6 +1,7 @@
 from typing import Dict
 
 import torch
+
 from roboverse_learn.il.utils.module_attr_mixin import ModuleAttrMixin
 from roboverse_learn.il.utils.normalizer import LinearNormalizer
 

--- a/roboverse_learn/il/policies/dp/ddim_unet_image_policy.py
+++ b/roboverse_learn/il/policies/dp/ddim_unet_image_policy.py
@@ -3,15 +3,15 @@ from typing import Dict
 import torch
 import torch.nn.functional as F
 from diffusers.schedulers.scheduling_ddim import DDIMScheduler
+from einops import reduce
+
+from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
 from roboverse_learn.il.policies.dp.models.diffusion.conditional_unet1d import ConditionalUnet1D
 from roboverse_learn.il.policies.dp.models.diffusion.mask_generator import LowdimMaskGenerator
-from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
-from einops import rearrange, reduce
-
 from roboverse_learn.il.utils.module_attr_mixin import ModuleAttrMixin
 from roboverse_learn.il.utils.normalizer import LinearNormalizer
 from roboverse_learn.il.utils.pytorch_util import dict_apply
-from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
+from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
 
 
 class BaseImagePolicy(ModuleAttrMixin):
@@ -134,7 +134,6 @@ class DiffusionUnetImagePolicy(BaseImagePolicy):
         scheduler.eta = self.eta  # set eta for DDIM
 
         for t in scheduler.timesteps:
-
             # 1. apply conditioning
             trajectory[condition_mask] = condition_data[condition_mask]
 

--- a/roboverse_learn/il/policies/dp/ddpm_dit_image_policy.py
+++ b/roboverse_learn/il/policies/dp/ddpm_dit_image_policy.py
@@ -5,13 +5,12 @@ from typing import Any, Dict, Mapping, Optional
 import torch
 from diffusers.schedulers.scheduling_ddpm import DDPMScheduler
 
+from roboverse_learn.il.policies.dp.ddpm_image_policy import DiffusionDenoisingImagePolicy
 from roboverse_learn.il.utils.models.flow_net import FlowTransformer
 from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
-from roboverse_learn.il.policies.dp.ddpm_image_policy import DiffusionDenoisingImagePolicy
 
 
 class DiffusionDiTImagePolicy(DiffusionDenoisingImagePolicy):
-
     def __init__(
         self,
         shape_meta: Mapping[str, Any],

--- a/roboverse_learn/il/policies/dp/ddpm_image_policy.py
+++ b/roboverse_learn/il/policies/dp/ddpm_image_policy.py
@@ -5,17 +5,16 @@ from typing import Any, Dict, Mapping, Optional
 import torch
 import torch.nn.functional as F
 from diffusers.schedulers.scheduling_ddpm import DDPMScheduler
-from roboverse_learn.il.policies.dp.models.diffusion.mask_generator import LowdimMaskGenerator
-from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
 from einops import reduce
 
+from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
+from roboverse_learn.il.policies.dp.models.diffusion.mask_generator import LowdimMaskGenerator
 from roboverse_learn.il.utils.normalizer import LinearNormalizer
 from roboverse_learn.il.utils.pytorch_util import dict_apply
-from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
+from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
 
 
 class DiffusionDenoisingImagePolicy(BaseImagePolicy):
-
     def __init__(
         self,
         shape_meta: Mapping[str, Any],

--- a/roboverse_learn/il/policies/dp/ddpm_unet_image_policy.py
+++ b/roboverse_learn/il/policies/dp/ddpm_unet_image_policy.py
@@ -2,16 +2,15 @@ from __future__ import annotations
 
 from typing import Any, Dict, Mapping, Optional, Sequence
 
-from diffusers.schedulers.scheduling_ddpm import DDPMScheduler
-from roboverse_learn.il.policies.dp.models.diffusion.conditional_unet1d import ConditionalUnet1D
-from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
 import torch
+from diffusers.schedulers.scheduling_ddpm import DDPMScheduler
 
 from roboverse_learn.il.policies.dp.ddpm_image_policy import DiffusionDenoisingImagePolicy
+from roboverse_learn.il.policies.dp.models.diffusion.conditional_unet1d import ConditionalUnet1D
+from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
 
 
 class DiffusionUnetImagePolicy(DiffusionDenoisingImagePolicy):
-
     def __init__(
         self,
         shape_meta: Mapping[str, Any],

--- a/roboverse_learn/il/policies/dp/models/bet/action_ae/__init__.py
+++ b/roboverse_learn/il/policies/dp/models/bet/action_ae/__init__.py
@@ -1,10 +1,11 @@
 import abc
 from typing import Optional, Union
 
-import roboverse_learn.il.policies.dp.models.bet.utils as utils
 import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
+
+import roboverse_learn.il.policies.dp.models.bet.utils as utils
 
 
 class AbstractActionAE(utils.SaveModule, abc.ABC):

--- a/roboverse_learn/il/policies/dp/models/bet/action_ae/discretizers/k_means.py
+++ b/roboverse_learn/il/policies/dp/models/bet/action_ae/discretizers/k_means.py
@@ -1,8 +1,8 @@
-from typing import Optional, Tuple, Union
+from typing import Optional
 
-import numpy as np
 import torch
 import tqdm
+
 from roboverse_learn.il.utils.dict_of_tensor_mixin import DictOfTensorMixin
 
 
@@ -23,9 +23,9 @@ class KMeansDiscretizer(DictOfTensorMixin):
         self.predict_offsets = predict_offsets
 
     def fit_discretizer(self, input_actions: torch.Tensor) -> None:
-        assert (
-            self.action_dim == input_actions.shape[-1]
-        ), f"Input action dimension {self.action_dim} does not match fitted model {input_actions.shape[-1]}"
+        assert self.action_dim == input_actions.shape[-1], (
+            f"Input action dimension {self.action_dim} does not match fitted model {input_actions.shape[-1]}"
+        )
 
         flattened_actions = input_actions.view(-1, self.action_dim)
         cluster_centers = KMeansDiscretizer._kmeans(flattened_actions, ncluster=self.n_bins)

--- a/roboverse_learn/il/policies/dp/models/bet/action_ae/discretizers/k_means.py
+++ b/roboverse_learn/il/policies/dp/models/bet/action_ae/discretizers/k_means.py
@@ -113,7 +113,7 @@ class KMeansDiscretizer(DictOfTensorMixin):
         reconstructed_action (shape: ... x action_dim): The reconstructed action.
         """
         offsets = None
-        if type(latent_action_batch) == tuple:
+        if isinstance(latent_action_batch, tuple):
             latent_action_batch, offsets = latent_action_batch
         # get the closest cluster center
         closest_cluster_center = self.params_dict["bin_centers"][latent_action_batch]

--- a/roboverse_learn/il/policies/dp/models/bet/latent_generators/latent_generator.py
+++ b/roboverse_learn/il/policies/dp/models/bet/latent_generators/latent_generator.py
@@ -1,8 +1,9 @@
 import abc
 from typing import Optional, Tuple
 
-import roboverse_learn.il.policies.dp.models.bet.utils as utils
 import torch
+
+import roboverse_learn.il.policies.dp.models.bet.utils as utils
 
 
 class AbstractLatentGenerator(abc.ABC, utils.SaveModule):

--- a/roboverse_learn/il/policies/dp/models/bet/latent_generators/mingpt.py
+++ b/roboverse_learn/il/policies/dp/models/bet/latent_generators/mingpt.py
@@ -1,12 +1,12 @@
 from typing import Optional, Tuple
 
+import einops
+import torch
+import torch.nn.functional as F
+
 import roboverse_learn.il.policies.dp.models.bet.latent_generators.latent_generator as latent_generator
 import roboverse_learn.il.policies.dp.models.bet.libraries.mingpt.model as mingpt_model
 import roboverse_learn.il.policies.dp.models.bet.libraries.mingpt.trainer as mingpt_trainer
-import einops
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
 from roboverse_learn.il.policies.dp.models.bet.libraries.loss_fn import FocalLoss, soft_cross_entropy
 
 
@@ -28,7 +28,7 @@ class MinGPT(latent_generator.AbstractLatentGenerator):
         predict_offsets: bool = False,
         offset_loss_scale: float = 1.0,
         focal_loss_gamma: float = 0.0,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self.input_size = input_dim

--- a/roboverse_learn/il/policies/dp/models/bet/latent_generators/transformer.py
+++ b/roboverse_learn/il/policies/dp/models/bet/latent_generators/transformer.py
@@ -1,11 +1,11 @@
-from typing import Optional, Tuple
+from typing import Tuple
 
-import roboverse_learn.il.policies.dp.models.bet.latent_generators.latent_generator as latent_generator
 import einops
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
-from roboverse_learn.il.policies.dp.models.bet.libraries.loss_fn import FocalLoss, soft_cross_entropy
+
+import roboverse_learn.il.policies.dp.models.bet.latent_generators.latent_generator as latent_generator
+from roboverse_learn.il.policies.dp.models.bet.libraries.loss_fn import FocalLoss
 from roboverse_learn.il.policies.dp.models.diffusion.transformer_for_diffusion import (
     TransformerForDiffusion,
 )
@@ -20,7 +20,7 @@ class Transformer(latent_generator.AbstractLatentGenerator):
         horizon: int,
         focal_loss_gamma: float,
         offset_loss_scale: float,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self.model = TransformerForDiffusion(

--- a/roboverse_learn/il/policies/dp/models/bet/libraries/mingpt/model.py
+++ b/roboverse_learn/il/policies/dp/models/bet/libraries/mingpt/model.py
@@ -191,9 +191,10 @@ class GPT(nn.Module):
         inter_params = decay & no_decay
         union_params = decay | no_decay
         assert len(inter_params) == 0, "parameters %s made it into both decay/no_decay sets!" % (str(inter_params),)
-        assert (
-            len(param_dict.keys() - union_params) == 0
-        ), "parameters %s were not separated into either decay/no_decay set!" % (str(param_dict.keys() - union_params),)
+        assert len(param_dict.keys() - union_params) == 0, (
+            "parameters %s were not separated into either decay/no_decay set!"
+            % (str(param_dict.keys() - union_params),)
+        )
 
         # create the pytorch optimizer object
         optim_groups = [

--- a/roboverse_learn/il/policies/dp/models/bet/libraries/mingpt/trainer.py
+++ b/roboverse_learn/il/policies/dp/models/bet/libraries/mingpt/trainer.py
@@ -8,8 +8,6 @@ import math
 
 import numpy as np
 import torch
-import torch.optim as optim
-from torch.optim.lr_scheduler import LambdaLR
 from torch.utils.data.dataloader import DataLoader
 from tqdm import tqdm
 
@@ -67,7 +65,6 @@ class Trainer:
             losses = []
             pbar = tqdm(enumerate(loader), total=len(loader)) if is_train else enumerate(loader)
             for it, (x, y) in pbar:
-
                 # place data on the correct device
                 x = x.to(self.device)
                 y = y.to(self.device)
@@ -79,7 +76,6 @@ class Trainer:
                     losses.append(loss.item())
 
                 if is_train:
-
                     # backprop and update the parameters
                     model.zero_grad()
                     loss.backward()
@@ -106,7 +102,7 @@ class Trainer:
 
                     # report progress
                     pbar.set_description(  # type: ignore
-                        f"epoch {epoch+1} iter {it}: train loss {loss.item():.5f}. lr {lr:e}"
+                        f"epoch {epoch + 1} iter {it}: train loss {loss.item():.5f}. lr {lr:e}"
                     )
 
             if not is_train:

--- a/roboverse_learn/il/policies/dp/models/bet/libraries/mingpt/utils.py
+++ b/roboverse_learn/il/policies/dp/models/bet/libraries/mingpt/utils.py
@@ -2,7 +2,6 @@ import random
 
 import numpy as np
 import torch
-import torch.nn as nn
 from torch.nn import functional as F
 
 

--- a/roboverse_learn/il/policies/dp/models/bet/utils.py
+++ b/roboverse_learn/il/policies/dp/models/bet/utils.py
@@ -1,7 +1,6 @@
 import os
 import random
 from collections import OrderedDict
-from typing import List, Optional
 
 import einops
 import numpy as np
@@ -95,9 +94,7 @@ class TrainWithLogger:
             log_key, name_key = key.split("/")
             iterator_log_name = f"{log_key[0]}{name_key[0]}".upper()
             iterator_log_component[iterator_log_name] = to_log
-        postfix = ",".join(
-            "{}:{:.2e}".format(key, iterator_log_component[key]) for key in iterator_log_component.keys()
-        )
+        postfix = ",".join(f"{key}:{iterator_log_component[key]:.2e}" for key in iterator_log_component.keys())
         if iterator is not None:
             iterator.set_postfix_str(postfix)
         wandb.log(log_components, step=epoch)

--- a/roboverse_learn/il/policies/dp/models/diffusion/conditional_unet1d.py
+++ b/roboverse_learn/il/policies/dp/models/diffusion/conditional_unet1d.py
@@ -4,13 +4,14 @@ from typing import Union
 import einops
 import torch
 import torch.nn as nn
+from einops.layers.torch import Rearrange
+
 from roboverse_learn.il.policies.dp.models.diffusion.conv1d_components import (
     Conv1dBlock,
     Downsample1d,
     Upsample1d,
 )
 from roboverse_learn.il.policies.dp.models.diffusion.positional_embedding import SinusoidalPosEmb
-from einops.layers.torch import Rearrange
 
 logger = logging.getLogger(__name__)
 
@@ -216,7 +217,7 @@ class ConditionalUnet1D(nn.Module):
         timestep: Union[torch.Tensor, float, int],
         local_cond=None,
         global_cond=None,
-        **kwargs
+        **kwargs,
     ):
         """
         x: (B,T,input_dim)

--- a/roboverse_learn/il/policies/dp/models/diffusion/conv1d_components.py
+++ b/roboverse_learn/il/policies/dp/models/diffusion/conv1d_components.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
 
 # from einops.layers.torch import Rearrange
 

--- a/roboverse_learn/il/policies/dp/models/diffusion/mask_generator.py
+++ b/roboverse_learn/il/policies/dp/models/diffusion/mask_generator.py
@@ -1,8 +1,8 @@
 from typing import Optional, Sequence
 
 import torch
+
 from roboverse_learn.il.utils.module_attr_mixin import ModuleAttrMixin
-from torch import nn
 
 
 def get_intersection_slice_mask(shape: tuple, dim_slices: Sequence[slice], device: Optional[torch.device] = None):

--- a/roboverse_learn/il/policies/dp/models/diffusion/positional_embedding.py
+++ b/roboverse_learn/il/policies/dp/models/diffusion/positional_embedding.py
@@ -20,7 +20,7 @@ class SinusoidalPosEmb(nn.Module):
 
 
 class RotaryPosEmb(nn.Module):
-    """ Rotary Positional Embedding (RoPE) (torchtune)"""
+    """Rotary Positional Embedding (RoPE) (torchtune)"""
 
     def __init__(
         self,
@@ -35,10 +35,7 @@ class RotaryPosEmb(nn.Module):
         self._rope_init()
 
     def _rope_init(self):
-        theta = 1.0 / (
-            self.base
-            ** (torch.arange(0, self.dim, 2)[: (self.dim // 2)].float() / self.dim)
-        )
+        theta = 1.0 / (self.base ** (torch.arange(0, self.dim, 2)[: (self.dim // 2)].float() / self.dim))
         self.register_buffer("theta", theta, persistent=False)
         self._build_rope_cache(self.max_seq_len)
 
@@ -57,16 +54,14 @@ class RotaryPosEmb(nn.Module):
         x = x.permute(0, 2, 1, 3)  # [B, S, num_heads, head_dim]
         B, S, num_heads, head_dim = x.size()
 
-        rope_cache = (self.cache[:S])
+        rope_cache = self.cache[:S]
         xshaped = x.float().reshape(*x.shape[:-1], head_dim // 2, 2)
         rope_cache = rope_cache.view(1, S, num_heads, head_dim // 2, 2)
 
         x_out = torch.stack(
             [
-                xshaped[..., 0] * rope_cache[..., 0]
-                - xshaped[..., 1] * rope_cache[..., 1],
-                xshaped[..., 1] * rope_cache[..., 0]
-                + xshaped[..., 0] * rope_cache[..., 1],
+                xshaped[..., 0] * rope_cache[..., 0] - xshaped[..., 1] * rope_cache[..., 1],
+                xshaped[..., 1] * rope_cache[..., 0] + xshaped[..., 0] * rope_cache[..., 1],
             ],
             -1,
         )

--- a/roboverse_learn/il/policies/dp/models/diffusion/transformer_for_diffusion.py
+++ b/roboverse_learn/il/policies/dp/models/diffusion/transformer_for_diffusion.py
@@ -3,8 +3,9 @@ from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
-from roboverse_learn.il.utils.module_attr_mixin import ModuleAttrMixin
+
 from roboverse_learn.il.policies.dp.models.diffusion.positional_embedding import SinusoidalPosEmb
+from roboverse_learn.il.utils.module_attr_mixin import ModuleAttrMixin
 
 logger = logging.getLogger(__name__)
 
@@ -107,14 +108,14 @@ class TransformerForDiffusion(ModuleAttrMixin):
             # therefore, the upper triangle should be -inf and others (including diag) should be 0.
             sz = T
             mask = (torch.triu(torch.ones(sz, sz)) == 1).transpose(0, 1)
-            mask = mask.float().masked_fill(mask == 0, float("-inf")).masked_fill(mask == 1, float(0.0))
+            mask = mask.float().masked_fill(mask == 0, float("-inf")).masked_fill(mask == 1, 0.0)
             self.register_buffer("mask", mask)
 
             if time_as_cond and obs_as_cond:
                 S = T_cond
                 t, s = torch.meshgrid(torch.arange(T), torch.arange(S), indexing="ij")
                 mask = t >= (s - 1)  # add one dimension since time is the first token in cond
-                mask = mask.float().masked_fill(mask == 0, float("-inf")).masked_fill(mask == 1, float(0.0))
+                mask = mask.float().masked_fill(mask == 0, float("-inf")).masked_fill(mask == 1, 0.0)
                 self.register_buffer("memory_mask", mask)
             else:
                 self.memory_mask = None
@@ -182,7 +183,7 @@ class TransformerForDiffusion(ModuleAttrMixin):
             # no param
             pass
         else:
-            raise RuntimeError("Unaccounted module {}".format(module))
+            raise RuntimeError(f"Unaccounted module {module}")
 
     def get_optim_groups(self, weight_decay: float = 1e-3):
         """
@@ -225,9 +226,10 @@ class TransformerForDiffusion(ModuleAttrMixin):
         inter_params = decay & no_decay
         union_params = decay | no_decay
         assert len(inter_params) == 0, "parameters %s made it into both decay/no_decay sets!" % (str(inter_params),)
-        assert (
-            len(param_dict.keys() - union_params) == 0
-        ), "parameters %s were not separated into either decay/no_decay set!" % (str(param_dict.keys() - union_params),)
+        assert len(param_dict.keys() - union_params) == 0, (
+            "parameters %s were not separated into either decay/no_decay set!"
+            % (str(param_dict.keys() - union_params),)
+        )
 
         # create the pytorch optimizer object
         optim_groups = [
@@ -257,7 +259,7 @@ class TransformerForDiffusion(ModuleAttrMixin):
         sample: torch.Tensor,
         timestep: Union[torch.Tensor, float, int],
         cond: Optional[torch.Tensor] = None,
-        **kwargs
+        **kwargs,
     ):
         """
         x: (B,T,input_dim)

--- a/roboverse_learn/il/policies/dp/score_unet_image_policy.py
+++ b/roboverse_learn/il/policies/dp/score_unet_image_policy.py
@@ -1,18 +1,16 @@
 from typing import Dict
 
 import torch
-import torch.nn as nn
 import torch.nn.functional as F
 from diffusers.schedulers.scheduling_ddpm import DDPMScheduler
+from einops import reduce
+
+from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
 from roboverse_learn.il.policies.dp.models.diffusion.conditional_unet1d import ConditionalUnet1D
 from roboverse_learn.il.policies.dp.models.diffusion.mask_generator import LowdimMaskGenerator
-from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
-from einops import rearrange, reduce
-from loguru import logger as log
-
 from roboverse_learn.il.utils.normalizer import LinearNormalizer
 from roboverse_learn.il.utils.pytorch_util import dict_apply
-from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
+from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
 
 
 class ScoreMatchingUnetImagePolicy(BaseImagePolicy):
@@ -102,7 +100,7 @@ class ScoreMatchingUnetImagePolicy(BaseImagePolicy):
         scheduler.set_timesteps(self.num_inference_steps)
 
         for t in scheduler.timesteps:
-           # log.info(f"Using algorithm: Score Matching")
+            # log.info(f"Using algorithm: Score Matching")
 
             trajectory[condition_mask] = condition_data[condition_mask]
 

--- a/roboverse_learn/il/policies/dp/shared_memory/shared_memory_queue.py
+++ b/roboverse_learn/il/policies/dp/shared_memory/shared_memory_queue.py
@@ -4,6 +4,7 @@ from queue import Empty, Full
 from typing import Dict, List, Union
 
 import numpy as np
+
 from roboverse_learn.il.policies.dp.shared_memory.shared_memory_util import (
     ArraySpec,
     SharedAtomicCounter,

--- a/roboverse_learn/il/policies/dp/shared_memory/shared_memory_ring_buffer.py
+++ b/roboverse_learn/il/policies/dp/shared_memory/shared_memory_ring_buffer.py
@@ -1,10 +1,10 @@
 import numbers
 import time
 from multiprocessing.managers import SharedMemoryManager
-from queue import Empty
 from typing import Dict, List, Union
 
 import numpy as np
+
 from roboverse_learn.il.policies.dp.shared_memory.shared_memory_util import (
     ArraySpec,
     SharedAtomicCounter,
@@ -136,7 +136,7 @@ class SharedMemoryRingBuffer:
                 # throw an error
                 past_iters = self.buffer_size - self.get_max_k
                 hz = past_iters / deltat
-                raise TimeoutError("Put executed too fast {}items/{:.4f}s ~= {}Hz".format(past_iters, deltat, hz))
+                raise TimeoutError(f"Put executed too fast {past_iters}items/{deltat:.4f}s ~= {hz}Hz")
 
         # write to shared memory
         for key, value in data.items():

--- a/roboverse_learn/il/policies/dp/shared_memory/shared_ndarray.py
+++ b/roboverse_learn/il/policies/dp/shared_memory/shared_ndarray.py
@@ -4,11 +4,10 @@ import multiprocessing
 import multiprocessing.synchronize
 from multiprocessing.managers import SharedMemoryManager
 from multiprocessing.shared_memory import SharedMemory
-from typing import TYPE_CHECKING, Any, Generic, Optional, Tuple, TypeVar, Union
+from typing import Generic, Optional, Tuple, TypeVar, Union
 
 import numpy as np
 import numpy.typing as npt
-from roboverse_learn.il.utils.nested_dict_util import nested_dict_check, nested_dict_map
 
 SharedMemoryLike = Union[str, SharedMemory]  # shared memory or name of shared memory
 SharedT = TypeVar("SharedT", bound=np.generic)

--- a/roboverse_learn/il/policies/fm/fm_dit_image_policy.py
+++ b/roboverse_learn/il/policies/fm/fm_dit_image_policy.py
@@ -4,12 +4,12 @@ import torch
 import torch.nn.functional as F
 from einops import reduce
 
-from roboverse_learn.il.utils.models.flow_net import FlowTransformer
+from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
 from roboverse_learn.il.policies.dp.models.diffusion.mask_generator import LowdimMaskGenerator
-from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
+from roboverse_learn.il.utils.models.flow_net import FlowTransformer
 from roboverse_learn.il.utils.normalizer import LinearNormalizer
 from roboverse_learn.il.utils.pytorch_util import dict_apply
-from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
+from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
 
 
 class FlowMatchingDiTImagePolicy(BaseImagePolicy):
@@ -102,7 +102,6 @@ class FlowMatchingDiTImagePolicy(BaseImagePolicy):
 
         time_steps = torch.linspace(0, 1.0, self.num_inference_steps + 1)
         for i in range(self.num_inference_steps):
-
             # 1. apply conditioning
             trajectory[condition_mask] = condition_data[condition_mask]
 

--- a/roboverse_learn/il/policies/fm/fm_unet_image_policy.py
+++ b/roboverse_learn/il/policies/fm/fm_unet_image_policy.py
@@ -4,12 +4,12 @@ import torch
 import torch.nn.functional as F
 from einops import reduce
 
+from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
 from roboverse_learn.il.policies.dp.models.diffusion.conditional_unet1d import ConditionalUnet1D
 from roboverse_learn.il.policies.dp.models.diffusion.mask_generator import LowdimMaskGenerator
-from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
 from roboverse_learn.il.utils.normalizer import LinearNormalizer
 from roboverse_learn.il.utils.pytorch_util import dict_apply
-from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
+from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
 
 
 class FlowMatchingUnetImagePolicy(BaseImagePolicy):
@@ -101,7 +101,6 @@ class FlowMatchingUnetImagePolicy(BaseImagePolicy):
 
         time_steps = torch.linspace(0, 1.0, self.num_inference_steps + 1)
         for i in range(self.num_inference_steps):
-
             # 1. apply conditioning
             trajectory[condition_mask] = condition_data[condition_mask]
 

--- a/roboverse_learn/il/policies/vita/action_ae.py
+++ b/roboverse_learn/il/policies/vita/action_ae.py
@@ -1,5 +1,5 @@
 import torch.nn as nn
-import torch.nn.functional as F
+
 from roboverse_learn.il.utils.models.layers import Mlp
 
 
@@ -42,7 +42,7 @@ class CNNActionEncoder(nn.Module):
 
         self.encoder = nn.Sequential(*layers)
 
-        conv_output_length = pred_horizon // (2 ** num_layers)
+        conv_output_length = pred_horizon // (2**num_layers)
         conv_output_dim = hidden_dim * conv_output_length
 
         self.latent_proj = nn.Linear(conv_output_dim, latent_dim)
@@ -86,7 +86,7 @@ class SimpleActionDecoder(nn.Module):
                     out_features=dec_hidden_dim,
                     norm_layer=None,
                     bias=True,
-                    drop=dropout
+                    drop=dropout,
                 )
             )
 

--- a/roboverse_learn/il/policies/vita/vita_policy.py
+++ b/roboverse_learn/il/policies/vita/vita_policy.py
@@ -4,14 +4,13 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
+from roboverse_learn.il.policies.vita.action_ae import CNNActionEncoder, SimpleActionDecoder
+from roboverse_learn.il.utils.flow.flow_matchers import TorchFlowMatcher
+from roboverse_learn.il.utils.models.flow_net import SimpleFlowNet
 from roboverse_learn.il.utils.normalizer import LinearNormalizer
 from roboverse_learn.il.utils.pytorch_util import dict_apply
-from roboverse_learn.il.policies.base_image_policy import BaseImagePolicy
-
-from roboverse_learn.il.utils.models.flow_net import SimpleFlowNet
-from roboverse_learn.il.policies.vita.action_ae import CNNActionEncoder, SimpleActionDecoder
 from roboverse_learn.il.utils.vision.multi_image_obs_encoder import MultiImageObsEncoder
-from roboverse_learn.il.utils.flow.flow_matchers import TorchFlowMatcher
 
 
 class VITAImagePolicy(BaseImagePolicy):
@@ -59,10 +58,7 @@ class VITAImagePolicy(BaseImagePolicy):
         self.action_ae = action_ae
 
         self.obs_encoder = obs_encoder
-        self.obs_projector = nn.Linear(
-            obs_feature_dim * n_obs_steps,
-            latent_dim
-        )
+        self.obs_projector = nn.Linear(obs_feature_dim * n_obs_steps, latent_dim)
 
         self.flow_net = SimpleFlowNet(
             input_dim=latent_dim,
@@ -70,7 +66,7 @@ class VITAImagePolicy(BaseImagePolicy):
             output_dim=latent_dim,
             num_layers=flow_net.num_layers,
             mlp_ratio=flow_net.mlp_ratio,
-            dropout=flow_net.dropout
+            dropout=flow_net.dropout,
         )
         self.action_encoder = CNNActionEncoder(
             pred_horizon=horizon,
@@ -118,7 +114,7 @@ class VITAImagePolicy(BaseImagePolicy):
             start=obs_latents,  # Use visual latents as the flow source
         )
         loss = flow_loss
-        metrics['flow_loss'] = flow_loss.item()
+        metrics["flow_loss"] = flow_loss.item()
 
         # Encoder contrastive loss
         if self.enc_contrastive_weight > 0:
@@ -126,7 +122,7 @@ class VITAImagePolicy(BaseImagePolicy):
             action_features = action_latents.view(batch_size, -1)
             contrastive_loss = compute_contrastive_loss(image_features, action_features)
             loss += self.enc_contrastive_weight * contrastive_loss
-            metrics['enc_contrastive_loss'] = contrastive_loss.item()
+            metrics["enc_contrastive_loss"] = contrastive_loss.item()
 
         # Flow latent decoding
         if self.decode_flow_latents:
@@ -135,25 +131,25 @@ class VITAImagePolicy(BaseImagePolicy):
                 shape=(batch_size, self.latent_dim),
                 device=obs_latents.device,
                 start=obs_latents,  # Use visual latents as the flow source
-                num_steps=self.num_sampling_steps
+                num_steps=self.num_sampling_steps,
             )
 
             if self.consistency_weight > 0:
                 consistency_loss = F.mse_loss(action_latents_pred, action_latents)
                 loss += self.consistency_weight * consistency_loss
-                metrics['consistency_loss'] = consistency_loss.item()
+                metrics["consistency_loss"] = consistency_loss.item()
 
             if self.flow_contrastive_weight > 0:
                 image_features = obs_latents.view(batch_size, -1)
                 action_features = action_latents_pred.view(batch_size, -1)
                 contrastive_loss = compute_contrastive_loss(image_features, action_features)
                 loss += self.flow_contrastive_weight * contrastive_loss
-                metrics['flow_contrastive_loss'] = contrastive_loss.item()
+                metrics["flow_contrastive_loss"] = contrastive_loss.item()
 
             if self.action_ae["flow_recon_weight"] > 0:
                 actions_recon = self.action_decoder(action_latents_pred)
                 action_recon_loss = F.l1_loss(actions_recon, nactions)
-                metrics['flow_action_recon_loss'] = action_recon_loss.item()
+                metrics["flow_action_recon_loss"] = action_recon_loss.item()
                 loss += self.action_ae["flow_recon_weight"] * action_recon_loss
         else:
             action_latents_pred = action_latents
@@ -162,7 +158,7 @@ class VITAImagePolicy(BaseImagePolicy):
         if self.action_ae["enc_recon_weight"] > 0:
             actions_recon = self.action_decoder(action_latents)
             action_recon_loss = F.l1_loss(actions_recon, nactions)
-            metrics['enc_action_recon_loss'] = action_recon_loss.item()
+            metrics["enc_action_recon_loss"] = action_recon_loss.item()
             loss += self.action_ae["enc_recon_weight"] * action_recon_loss
 
         return loss
@@ -174,7 +170,7 @@ class VITAImagePolicy(BaseImagePolicy):
         B = value.shape[0]
 
         # reshape B, T, ... to B*T
-        this_nobs = dict_apply(nobs, lambda x: x[:, :self.n_obs_steps, ...].reshape(-1, *x.shape[2:]))
+        this_nobs = dict_apply(nobs, lambda x: x[:, : self.n_obs_steps, ...].reshape(-1, *x.shape[2:]))
         nobs_features = self.obs_encoder(this_nobs)
         nobs_features = nobs_features.reshape(B, -1)
         obs_latents = self.obs_projector(nobs_features)
@@ -186,7 +182,7 @@ class VITAImagePolicy(BaseImagePolicy):
             device=obs_latents.device,
             num_steps=self.num_sampling_steps,
             start=obs_latents,  # Use visual latents as the flow source
-            return_traces=False
+            return_traces=False,
         )
 
         with torch.no_grad():

--- a/roboverse_learn/il/runners/base_eval_runner.py
+++ b/roboverse_learn/il/runners/base_eval_runner.py
@@ -2,15 +2,16 @@ from roboverse_learn.il.configs.base_config import BasePolicyCfg
 
 try:
     from curobo.types.math import Pose
-    from metasim.utils.kinematics import get_curobo_models
     from pytorch3d import transforms
+
+    from metasim.utils.kinematics import get_curobo_models
 except ImportError:
     pass
 
-import sys
 
 import torch
 from loguru import logger as log
+
 from metasim.scenario.scenario import ScenarioCfg
 from roboverse_learn.il.utils.pytorch_util import dict_apply
 
@@ -48,8 +49,7 @@ class BaseEvalRunner:
                 [
                     self.num_envs,
                     self.scenario.episode_length,
-                    self.scenario.episode_length
-                    + self.policy_cfg.action_config.action_chunk_steps,
+                    self.scenario.episode_length + self.policy_cfg.action_config.action_chunk_steps,
                     self.policy_cfg.action_config.action_dim,
                 ],
                 device=self.device,
@@ -80,9 +80,7 @@ class BaseEvalRunner:
             curr_ee_pos_local = transforms.quaternion_apply(
                 transforms.quaternion_invert(robot_quat), curr_ee_pos - robot_pos
             )
-            curr_ee_quat_local = transforms.quaternion_multiply(
-                transforms.quaternion_invert(robot_quat), curr_ee_quat
-            )
+            curr_ee_quat_local = transforms.quaternion_multiply(transforms.quaternion_invert(robot_quat), curr_ee_quat)
 
             if self.policy_cfg.obs_config.ee_cfg.gripper_rep == "q_pos":
                 gripper_state = obs["joint_qpos"][:, -2:]
@@ -97,14 +95,10 @@ class BaseEvalRunner:
                     convention="XYZ",
                 )
 
-            obs_dict["agent_pos"] = torch.cat(
-                [curr_ee_pos_local, curr_ee_rot_local, gripper_state], dim=1
-            )
+            obs_dict["agent_pos"] = torch.cat([curr_ee_pos_local, curr_ee_rot_local, gripper_state], dim=1)
 
         if self.policy_cfg.obs_config.obs_padding > 0:
-            padding_len = (
-                self.policy_cfg.obs_config.obs_padding - obs_dict["agent_pos"].shape[1]
-            )
+            padding_len = self.policy_cfg.obs_config.obs_padding - obs_dict["agent_pos"].shape[1]
             padding = torch.zeros(self.num_envs, padding_len, device=self.device)
             obs_dict["agent_pos"] = torch.cat([obs_dict["agent_pos"], padding], dim=1)
 
@@ -113,11 +107,7 @@ class BaseEvalRunner:
             self.policy_cfg.obs_config.obs_dim,
         )
         # flush unused keys
-        obs_dict = {
-            k: v
-            for k, v in obs_dict.items()
-            if k in self.policy_cfg.obs_config.obs_keys
-        }
+        obs_dict = {k: v for k, v in obs_dict.items() if k in self.policy_cfg.obs_config.obs_keys}
         return obs_dict
 
     def action_to_dict(self, curr_action: torch.Tensor):
@@ -130,9 +120,7 @@ class BaseEvalRunner:
                 self.scenario.robots[0].name: {
                     "dof_pos_target": {
                         joint_name: action_nested_list[i][index]
-                        for index, joint_name in enumerate(
-                            sorted(self.scenario.robots[0].joint_limits.keys())
-                        )
+                        for index, joint_name in enumerate(sorted(self.scenario.robots[0].joint_limits.keys()))
                     }
                 }
             }
@@ -159,9 +147,7 @@ class BaseEvalRunner:
 
         actions_for_curr_step = self.all_time_actions[:, :, self.step]
 
-        actions_populated = torch.all(
-            torch.all(actions_for_curr_step != 0, dim=2), dim=0
-        )
+        actions_populated = torch.all(torch.all(actions_for_curr_step != 0, dim=2), dim=0)
         actions_for_curr_step = actions_for_curr_step[:, actions_populated]
 
         time_indices = torch.arange(
@@ -172,9 +158,7 @@ class BaseEvalRunner:
         exp_weights = torch.exp(self.k * time_indices)
         exp_weights = exp_weights / exp_weights.sum()
 
-        weighted_actions = actions_for_curr_step * exp_weights.unsqueeze(-1).unsqueeze(
-            0
-        )
+        weighted_actions = actions_for_curr_step * exp_weights.unsqueeze(-1).unsqueeze(0)
 
         raw_action = weighted_actions.sum(dim=1)
 
@@ -188,17 +172,13 @@ class BaseEvalRunner:
             curr_action = self.action_cache.pop(0)
         else:
             processed_obs = self.process_obs(obs)
-            action_chunk = self.predict_action(
-                processed_obs
-            )  # shape: (action_chunk_steps, num_envs, action_dim)
+            action_chunk = self.predict_action(processed_obs)  # shape: (action_chunk_steps, num_envs, action_dim)
             if self.policy_cfg.action_config.temporal_agg:
                 curr_action = self.get_temporal_agg_action(action_chunk)
                 curr_action = self.process_action([curr_action], obs)[0]
             else:
                 qpos_action = self.process_action(action_chunk, obs)
-                assert (
-                    len(qpos_action) == self.policy_cfg.action_config.action_chunk_steps
-                ), (
+                assert len(qpos_action) == self.policy_cfg.action_config.action_chunk_steps, (
                     f"Expected {self.policy_cfg.action_config.action_chunk_steps} actions, got {len(qpos_action)}"
                 )
                 self.action_cache = qpos_action
@@ -231,25 +211,17 @@ class BaseEvalRunner:
             quat_norm = torch.norm(ee_quat_action, dim=1, keepdim=True)
             ee_quat_action = ee_quat_action / (quat_norm + 1e-5)
         else:
-            ee_quat_action = transforms.matrix_to_quaternion(
-                transforms.euler_angles_to_matrix(action[:, 3:6], "XYZ")
-            )
+            ee_quat_action = transforms.matrix_to_quaternion(transforms.euler_angles_to_matrix(action[:, 3:6], "XYZ"))
 
         if self.policy_cfg.action_config.delta:
             ee_pos_target = curr_ee_pos_local + action[:, :3]
-            ee_quat_target = transforms.quaternion_multiply(
-                curr_ee_quat_local, ee_quat_action
-            )
+            ee_quat_target = transforms.quaternion_multiply(curr_ee_quat_local, ee_quat_action)
         else:
             ee_pos_target = action[:, :3]
             ee_quat_target = ee_quat_action
 
         # Solve IK
-        seed_config = (
-            curr_robot_q[:, : self.curobo_n_dof]
-            .unsqueeze(1)
-            .tile([1, self.robot_ik._num_seeds, 1])
-        )
+        seed_config = curr_robot_q[:, : self.curobo_n_dof].unsqueeze(1).tile([1, self.robot_ik._num_seeds, 1])
         result = self.robot_ik.solve_batch(
             Pose(ee_pos_target.cuda(0), ee_quat_target.cuda(0)),
             seed_config=seed_config.cuda(0),
@@ -257,18 +229,12 @@ class BaseEvalRunner:
 
         if self.policy_cfg.action_config.ee_cfg.gripper_rep == "strength":
             gripper_pos = 1 - action[:, -1]
-            gripper_widths = torch.zeros(
-                self.num_envs, self.ee_n_dof, device=self.device
-            )
+            gripper_widths = torch.zeros(self.num_envs, self.ee_n_dof, device=self.device)
             for i in range(self.num_envs):
                 if gripper_pos[i] < 0.5:
-                    gripper_widths[i] = torch.tensor(
-                        self.scenario.robots[0].gripper_close_q, device=self.device
-                    )
+                    gripper_widths[i] = torch.tensor(self.scenario.robots[0].gripper_close_q, device=self.device)
                 else:
-                    gripper_widths[i] = torch.tensor(
-                        self.scenario.robots[0].gripper_open_q, device=self.device
-                    )
+                    gripper_widths[i] = torch.tensor(self.scenario.robots[0].gripper_open_q, device=self.device)
         else:
             gripper_widths = action[:, -self.ee_n_dof :]
 
@@ -278,9 +244,7 @@ class BaseEvalRunner:
             log.warning(f"IK failed: {ik_succ}")
             log.info("Trying to POS delta: ", action[:, :3])
 
-        q[ik_succ, : self.curobo_n_dof] = result.solution.to(self.device)[
-            ik_succ, 0
-        ].clone()
+        q[ik_succ, : self.curobo_n_dof] = result.solution.to(self.device)[ik_succ, 0].clone()
         q[:, -self.ee_n_dof :] = gripper_widths
         return q
 
@@ -307,20 +271,14 @@ class BaseEvalRunner:
             curr_ee_pos_local = transforms.quaternion_apply(
                 transforms.quaternion_invert(robot_quat), curr_ee_pos - robot_pos
             )
-            curr_ee_quat_local = transforms.quaternion_multiply(
-                transforms.quaternion_invert(robot_quat), curr_ee_quat
-            )
+            curr_ee_quat_local = transforms.quaternion_multiply(transforms.quaternion_invert(robot_quat), curr_ee_quat)
             curr_robot_q = obs["joint_qpos"].to(self.device)
             for action in action_chunk:
-                target_qpos = self._solve_ik(
-                    action, curr_ee_pos_local, curr_ee_quat_local, curr_robot_q
-                )
+                target_qpos = self._solve_ik(action, curr_ee_pos_local, curr_ee_quat_local, curr_robot_q)
                 qpos_action_chunk.append(target_qpos)
 
         if self.policy_cfg.action_config.interpolate_chunk:
-            return self._interpolate_chunk(
-                obs["joint_qpos"].to(self.device), qpos_action_chunk
-            )
+            return self._interpolate_chunk(obs["joint_qpos"].to(self.device), qpos_action_chunk)
         else:
             return qpos_action_chunk
 
@@ -332,10 +290,7 @@ class BaseEvalRunner:
         )
 
         return [
-            curr_qpos
-            + (last_action - curr_qpos)
-            * (i + 1)
-            / self.policy_cfg.action_config.action_chunk_steps
+            curr_qpos + (last_action - curr_qpos) * (i + 1) / self.policy_cfg.action_config.action_chunk_steps
             for i in range(self.policy_cfg.action_config.action_chunk_steps)
         ]
 

--- a/roboverse_learn/il/runners/default_eval_runner.py
+++ b/roboverse_learn/il/runners/default_eval_runner.py
@@ -1,9 +1,9 @@
 from collections import deque
 
 import dill
-import hydra
 import numpy as np
 import torch
+
 from roboverse_learn.il.configs.base_config import DiffusionPolicyCfg
 from roboverse_learn.il.runners.base_eval_runner import BaseEvalRunner
 from roboverse_learn.il.runners.default_runner import DefaultRunner
@@ -34,9 +34,7 @@ class DefaultEvalRunner(BaseEvalRunner):
 
         if "policy_runner" in cfg.eval_config:
             self.policy_cfg.obs_config.from_dict(cfg.eval_config.policy_runner.obs)
-            self.policy_cfg.action_config.from_dict(
-                cfg.eval_config.policy_runner.action
-            )
+            self.policy_cfg.action_config.from_dict(cfg.eval_config.policy_runner.action)
             self.policy_cfg.obs_config.obs_dim = cfg.shape_meta.obs.agent_pos.shape[0]
             self.policy_cfg.action_config.action_dim = cfg.shape_meta.action.shape[0]
 
@@ -57,13 +55,9 @@ class DefaultEvalRunner(BaseEvalRunner):
             if n_steps > len(all_obs):
                 # pad
                 result[:start_idx] = result[start_idx]
-            result = np.swapaxes(
-                result, 0, 1
-            )  # Policy expects (Batch_size, n_steps, ...)
+            result = np.swapaxes(result, 0, 1)  # Policy expects (Batch_size, n_steps, ...)
         elif isinstance(all_obs[0], torch.Tensor):
-            result = torch.zeros(
-                (n_steps,) + all_obs[-1].shape, dtype=all_obs[-1].dtype
-            )
+            result = torch.zeros((n_steps,) + all_obs[-1].shape, dtype=all_obs[-1].dtype)
             start_idx = -min(n_steps, len(all_obs))
             result[start_idx:] = torch.stack(all_obs[start_idx:])
             if n_steps > len(all_obs):
@@ -86,9 +80,7 @@ class DefaultEvalRunner(BaseEvalRunner):
 
         result = dict()
         for key in self.obs[0].keys():
-            result[key] = self._stack_last_n_obs(
-                [obs[key] for obs in self.obs], self.yaml_cfg.n_obs_steps
-            )
+            result[key] = self._stack_last_n_obs([obs[key] for obs in self.obs], self.yaml_cfg.n_obs_steps)
 
         return result
 
@@ -98,8 +90,6 @@ class DefaultEvalRunner(BaseEvalRunner):
         obs = self._get_n_steps_obs()
 
         with torch.no_grad():
-            action_chunk = (
-                self.policy.predict_action(obs)["action"].detach().to(torch.float32)
-            )
+            action_chunk = self.policy.predict_action(obs)["action"].detach().to(torch.float32)
             action_chunk = action_chunk.transpose(0, 1)
         return action_chunk

--- a/roboverse_learn/il/utils/ema_model.py
+++ b/roboverse_learn/il/utils/ema_model.py
@@ -1,5 +1,3 @@
-import copy
-
 import torch
 from torch.nn.modules.batchnorm import _BatchNorm
 

--- a/roboverse_learn/il/utils/eval_args.py
+++ b/roboverse_learn/il/utils/eval_args.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Literal
 
 from loguru import logger as log

--- a/roboverse_learn/il/utils/flow/base_flow_matcher.py
+++ b/roboverse_learn/il/utils/flow/base_flow_matcher.py
@@ -1,4 +1,4 @@
-class BaseFlowMatcher():
+class BaseFlowMatcher:
     def compute_loss(self, model, target, **kwargs):
         raise NotImplementedError
 

--- a/roboverse_learn/il/utils/flow/consistency_flow_matcher.py
+++ b/roboverse_learn/il/utils/flow/consistency_flow_matcher.py
@@ -1,6 +1,5 @@
-import torch
 import numpy as np
-import torchcfm.conditional_flow_matching as cfm
+import torch
 
 from roboverse_learn.il.utils.flow.base_flow_matcher import BaseFlowMatcher
 
@@ -27,7 +26,7 @@ class ConsistencyFlowMatcher(BaseFlowMatcher):
         self.noise_scale = noise_scale
         self.sigma_var = sigma_var
         self.ode_tol = ode_tol
-        self.sigma_t = lambda t: (1. - t) * sigma_var
+        self.sigma_t = lambda t: (1.0 - t) * sigma_var
         self.num_sampling_steps = num_sampling_steps
 
     def compute_loss(self, model, target, start=None, **kwargs):
@@ -65,9 +64,9 @@ class ConsistencyFlowMatcher(BaseFlowMatcher):
 
         loss = torch.mean(losses_f + self.alpha * losses_v)
         return loss, {
-            'loss': loss.item(),
-            'flow_loss': torch.mean(losses_f).item(),
-            'velocity_loss': torch.mean(losses_v).item()
+            "loss": loss.item(),
+            "flow_loss": torch.mean(losses_f).item(),
+            "velocity_loss": torch.mean(losses_v).item(),
         }
 
     def sample(self, model, shape, device, num_steps=None, return_traces=False, start=None, **kwargs):
@@ -92,8 +91,9 @@ class ConsistencyFlowMatcher(BaseFlowMatcher):
             vt = model(z, t, **kwargs)
             sigma_t = self.sigma_t(num_t)
             if sigma_t > 0:
-                pred_sigma = vt + (sigma_t**2) / (2 * (self.noise_scale**2) * ((1-num_t)**2)) * \
-                    (0.5 * num_t * (1-num_t) * vt - 0.5 * (2-num_t) * z.detach().clone())
+                pred_sigma = vt + (sigma_t**2) / (2 * (self.noise_scale**2) * ((1 - num_t) ** 2)) * (
+                    0.5 * num_t * (1 - num_t) * vt - 0.5 * (2 - num_t) * z.detach().clone()
+                )
                 z = z.detach().clone() + pred_sigma * dt + sigma_t * np.sqrt(dt) * torch.randn_like(pred_sigma)
             else:
                 z = z.detach().clone() + vt * dt
@@ -113,8 +113,10 @@ class ConsistencyFlowMatcher(BaseFlowMatcher):
         if isinstance(threshold, int) and threshold == 0:
             return x_at_segment_ends
         less_than_threshold = t_expand < threshold
-        return less_than_threshold * self._f_euler(t_expand, segment_ends_expand, xt, vt) + \
-            (~less_than_threshold) * x_at_segment_ends
+        return (
+            less_than_threshold * self._f_euler(t_expand, segment_ends_expand, xt, vt)
+            + (~less_than_threshold) * x_at_segment_ends
+        )
 
     def _masked_losses_v(self, vt, vr, threshold, segment_ends, t, batch_size):
         if isinstance(threshold, int) and threshold == 0:

--- a/roboverse_learn/il/utils/flow/flow_matchers.py
+++ b/roboverse_learn/il/utils/flow/flow_matchers.py
@@ -1,10 +1,10 @@
-import torch
 import numpy as np
+import torch
 import torchcfm.conditional_flow_matching as cfm
 
 from roboverse_learn.il.utils.flow.base_flow_matcher import BaseFlowMatcher
-from roboverse_learn.il.utils.flow.mean_flow_matcher import MeanFlowMatcher
 from roboverse_learn.il.utils.flow.consistency_flow_matcher import ConsistencyFlowMatcher
+from roboverse_learn.il.utils.flow.mean_flow_matcher import MeanFlowMatcher
 
 
 class TorchFlowMatcher(BaseFlowMatcher):
@@ -36,7 +36,7 @@ class TorchFlowMatcher(BaseFlowMatcher):
         loss = torch.mean((vt - ut) ** 2)
         # Use L1 loss
         # loss = torch.mean(torch.abs(vt - ut))
-        return loss, {'loss': loss.item()}
+        return loss, {"loss": loss.item()}
 
     def sample(self, model, shape, device, num_steps=None, return_traces=False, start=None, **kwargs):
         """
@@ -100,12 +100,13 @@ class ExactOptimalTransportConditionalFlowMatcher(TorchFlowMatcher):
 
 
 class MeanFlowConditionalFlowMatcher(TorchFlowMatcher):
-    '''
+    """
     Implementation of MeanFlow, a 1-step flow matching method.
     [1] Geng, Zhengyang, et al. "Mean flows for one-step generative modeling." arXiv preprint arXiv:2505.13447 (2025).
     Used dispersive losses:
     [2] Sheng, Juyi, et al. "MP1: MeanFlow Tames Policy Learning in 1-step for Robotic Manipulation." arXiv preprint arXiv:2507.10543 (2025).
-    '''
+    """
+
     def __init__(self, num_sampling_steps=1, **kwargs):
         if num_sampling_steps != 1:
             print("Warning: MeanFlow is designed for 1-NFE generation.")
@@ -113,13 +114,14 @@ class MeanFlowConditionalFlowMatcher(TorchFlowMatcher):
 
 
 class ImprovedMeanFlowConditionalFlowMatcher(TorchFlowMatcher):
-    '''
+    """
     Implementation of Improved MeanFlow, a 1-step flow matching method.
     [1] Geng, Zhengyang, et al. "Improved Mean Flows: On the Challenges of Fastforward Generative Models." arXiv preprint arXiv:2512.02012 (2025).
-    '''
+    """
+
     def __init__(self, num_sampling_steps=1, **kwargs):
         # Overwrite use_imf to True
-        kwargs['use_imf'] = True
+        kwargs["use_imf"] = True
         if num_sampling_steps != 1:
             print("Warning: Improved MeanFlow is designed for 1-NFE generation.")
         super().__init__(MeanFlowMatcher(**kwargs), num_sampling_steps)

--- a/roboverse_learn/il/utils/flow/mean_flow_matcher.py
+++ b/roboverse_learn/il/utils/flow/mean_flow_matcher.py
@@ -1,5 +1,4 @@
 import torch
-from functools import partial
 
 from roboverse_learn.il.utils.flow.base_flow_matcher import BaseFlowMatcher
 
@@ -12,7 +11,7 @@ def adaptive_l2_loss(error, gamma=0.5, c=1e-3):
     """
     Adaptive L2 loss.
     """
-    delta_sq = torch.mean(error ** 2, dim=tuple(range(1, error.ndim)))
+    delta_sq = torch.mean(error**2, dim=tuple(range(1, error.ndim)))
     p = 1.0 - gamma
     w = 1.0 / (delta_sq + c).pow(p)
     loss = delta_sq
@@ -62,10 +61,7 @@ class MeanFlowMatcher(BaseFlowMatcher):
         Samples t and r from a log-normal distribution.
         """
         # Log-normal distribution
-        normal_samples = (
-            torch.randn(batch_size, 2, device=device) * self.time_dist_sigma
-            + self.time_dist_mu
-        )
+        normal_samples = torch.randn(batch_size, 2, device=device) * self.time_dist_sigma + self.time_dist_mu
         samples = torch.sigmoid(normal_samples)
 
         # t = max, r = min
@@ -127,7 +123,7 @@ class MeanFlowMatcher(BaseFlowMatcher):
         meanflow_loss = adaptive_l2_loss(error, gamma=self.adaptive_loss_gamma)
 
         loss = meanflow_loss
-        metrics = {'meanflow_loss': meanflow_loss.item()}
+        metrics = {"meanflow_loss": meanflow_loss.item()}
 
         # Dispersive Loss
         if self.dispersive_loss_weight > 0 and internal_features is not None:
@@ -136,10 +132,10 @@ class MeanFlowMatcher(BaseFlowMatcher):
             for features in internal_features:
                 dis_loss_total += dispersive_loss(features, tau=self.dispersive_loss_tau)
 
-            metrics['dispersive_loss'] = dis_loss_total.item()
+            metrics["dispersive_loss"] = dis_loss_total.item()
             loss += self.dispersive_loss_weight * dis_loss_total
 
-        metrics['loss'] = loss.item()
+        metrics["loss"] = loss.item()
         return loss, metrics
 
     def sample(self, model, shape, device, num_steps=None, return_traces=False, start=None, **kwargs):

--- a/roboverse_learn/il/utils/json_logger.py
+++ b/roboverse_learn/il/utils/json_logger.py
@@ -13,7 +13,7 @@ def read_json_log(path: str, required_keys: Sequence[str] = tuple(), **kwargs) -
     kwargs passed to pd.read_json
     """
     lines = list()
-    with open(path, "r") as f:
+    with open(path) as f:
         while True:
             # one json per line
             line = f.readline()
@@ -32,7 +32,7 @@ def read_json_log(path: str, required_keys: Sequence[str] = tuple(), **kwargs) -
                 lines.append(line)
     if len(lines) < 1:
         return pd.DataFrame()
-    json_buf = f'[{",".join([line for line in (line.strip() for line in lines) if line])}]'
+    json_buf = f"[{','.join([line for line in (line.strip() for line in lines) if line])}]"
     df = pd.read_json(json_buf, **kwargs)
     return df
 

--- a/roboverse_learn/il/utils/models/flow_net.py
+++ b/roboverse_learn/il/utils/models/flow_net.py
@@ -12,13 +12,13 @@ class Attention(nn.Module):
         dim,
         num_heads=8,
         qkv_bias=True,
-        attn_drop=0.,
-        proj_drop=0.,
+        attn_drop=0.0,
+        proj_drop=0.0,
         max_seq_len=16,
         qk_norm=True,
     ):
         super().__init__()
-        assert dim % num_heads == 0, 'dim should be divisible by num_heads'
+        assert dim % num_heads == 0, "dim should be divisible by num_heads"
         self.num_heads = num_heads
         self.head_dim = dim // num_heads
         # self.attn_norm = self.head_dim ** -0.5
@@ -51,40 +51,28 @@ class Attention(nn.Module):
 
 
 class AdaLNBlock(nn.Module):
-    """ Adaptive LayerNorm Transformer Block as in DiT (Peebles et al. 2022) """
+    """Adaptive LayerNorm Transformer Block as in DiT (Peebles et al. 2022)"""
 
     def __init__(
         self,
         dim,
         num_heads,
-        mlp_ratio=4.,
-        dropout=0.,
+        mlp_ratio=4.0,
+        dropout=0.0,
     ):
         super().__init__()
         # self.norm1 = RMSNorm(dim)
         self.norm1 = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
-        self.attn = Attention(
-            dim,
-            num_heads=num_heads,
-            attn_drop=dropout,
-            proj_drop=dropout
-        )
+        self.attn = Attention(dim, num_heads=num_heads, attn_drop=dropout, proj_drop=dropout)
 
-        def approx_gelu(): return nn.GELU(approximate="tanh")
+        def approx_gelu():
+            return nn.GELU(approximate="tanh")
 
         # self.norm2 = RMSNorm(dim)
         self.norm2 = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
-        self.mlp = Mlp(
-            in_features=dim,
-            hidden_features=int(dim * mlp_ratio),
-            act_layer=approx_gelu,
-            drop=0
-        )
+        self.mlp = Mlp(in_features=dim, hidden_features=int(dim * mlp_ratio), act_layer=approx_gelu, drop=0)
 
-        self.ada_ln = nn.Sequential(
-            nn.SiLU(),
-            nn.Linear(dim, 6*dim)
-        )
+        self.ada_ln = nn.Sequential(nn.SiLU(), nn.Linear(dim, 6 * dim))
         self.dim = dim
 
         self._init_weights()
@@ -95,7 +83,7 @@ class AdaLNBlock(nn.Module):
 
     def forward(self, x, t, c):
         B = x.shape[0]
-        features = self.ada_ln(nn.SiLU()(t+c)).view(B, 6, 1, self.dim).unbind(1)
+        features = self.ada_ln(nn.SiLU()(t + c)).view(B, 6, 1, self.dim).unbind(1)
         gamma1, gamma2, scale1, scale2, shift1, shift2 = features
 
         x_norm1 = self.norm1(x)
@@ -134,12 +122,8 @@ class FlowTransformer(nn.Module):
         self.cond_embed = nn.Linear(condition_dim, hidden_dim)
 
         self.transformer_blocks = nn.ModuleList([
-            AdaLNBlock(
-                dim=hidden_dim,
-                num_heads=num_heads,
-                mlp_ratio=mlp_ratio,
-                dropout=dropout
-            ) for _ in range(num_layers)
+            AdaLNBlock(dim=hidden_dim, num_heads=num_heads, mlp_ratio=mlp_ratio, dropout=dropout)
+            for _ in range(num_layers)
         ])
 
         self.norm = nn.LayerNorm(hidden_dim)
@@ -154,6 +138,7 @@ class FlowTransformer(nn.Module):
                 torch.nn.init.xavier_uniform_(module.weight)
                 if module.bias is not None:
                     nn.init.constant_(module.bias, 0)
+
         self.apply(_basic_init)
 
         # Initialize timestep embedding MLP
@@ -180,23 +165,17 @@ class FlowTransformer(nn.Module):
 
 
 class FlowNetLayer(nn.Module):
-    def __init__(self, dim, mlp_ratio=4., dropout=0.0):
+    def __init__(self, dim, mlp_ratio=4.0, dropout=0.0):
         super().__init__()
-        def approx_gelu(): return nn.GELU(approximate="tanh")
+
+        def approx_gelu():
+            return nn.GELU(approximate="tanh")
 
         self.norm = nn.LayerNorm(dim, elementwise_affine=False, eps=1e-6)
-        self.mlp = Mlp(
-            in_features=dim,
-            hidden_features=int(dim * mlp_ratio),
-            act_layer=approx_gelu,
-            drop=dropout
-        )
+        self.mlp = Mlp(in_features=dim, hidden_features=int(dim * mlp_ratio), act_layer=approx_gelu, drop=dropout)
 
         # Injects timestep t
-        self.time_modulator = nn.Sequential(
-            nn.SiLU(),
-            nn.Linear(dim, 3*dim)
-        )
+        self.time_modulator = nn.Sequential(nn.SiLU(), nn.Linear(dim, 3 * dim))
         self.dim = dim
 
         self._init_weights()
@@ -218,7 +197,7 @@ class FlowNetLayer(nn.Module):
 
 
 class SimpleFlowNet(nn.Module):
-    """ A simple flow network with only MLP layers for VITA policy (Gao et al. 2025) """
+    """A simple flow network with only MLP layers for VITA policy (Gao et al. 2025)"""
 
     def __init__(
         self,
@@ -242,11 +221,7 @@ class SimpleFlowNet(nn.Module):
         )
 
         self.layers = nn.ModuleList([
-            FlowNetLayer(
-                dim=hidden_dim,
-                mlp_ratio=mlp_ratio,
-                dropout=dropout
-            ) for _ in range(num_layers)
+            FlowNetLayer(dim=hidden_dim, mlp_ratio=mlp_ratio, dropout=dropout) for _ in range(num_layers)
         ])
 
         self.norm = nn.LayerNorm(hidden_dim)
@@ -261,6 +236,7 @@ class SimpleFlowNet(nn.Module):
                 torch.nn.init.xavier_uniform_(module.weight)
                 if module.bias is not None:
                     nn.init.constant_(module.bias, 0)
+
         self.apply(_basic_init)
 
         # Initialize timestep embedding MLP

--- a/roboverse_learn/il/utils/models/layers.py
+++ b/roboverse_learn/il/utils/models/layers.py
@@ -1,10 +1,8 @@
-import torch
-import torch.nn as nn
-import torch.nn.functional as F
-
+import collections.abc
 from functools import partial
 from itertools import repeat
-import collections.abc
+
+import torch.nn as nn
 
 
 def _ntuple(n):
@@ -12,6 +10,7 @@ def _ntuple(n):
         if isinstance(x, collections.abc.Iterable) and not isinstance(x, str):
             return tuple(x)
         return tuple(repeat(x, n))
+
     return parse
 
 
@@ -19,18 +18,18 @@ to_2tuple = _ntuple(2)
 
 
 class Mlp(nn.Module):
-    """ MLP as used in Vision Transformer (timm.layers)"""
+    """MLP as used in Vision Transformer (timm.layers)"""
 
     def __init__(
-            self,
-            in_features,
-            hidden_features=None,
-            out_features=None,
-            act_layer=nn.GELU,
-            norm_layer=None,
-            bias=True,
-            drop=0.,
-            use_conv=False,
+        self,
+        in_features,
+        hidden_features=None,
+        out_features=None,
+        act_layer=nn.GELU,
+        norm_layer=None,
+        bias=True,
+        drop=0.0,
+        use_conv=False,
     ):
         super().__init__()
         out_features = out_features or in_features

--- a/roboverse_learn/il/utils/normalize_util.py
+++ b/roboverse_learn/il/utils/normalize_util.py
@@ -1,10 +1,10 @@
 import numpy as np
+
+from roboverse_learn.il.utils.normalizer import SingleFieldLinearNormalizer
 from roboverse_learn.il.utils.pytorch_util import (
-    dict_apply,
     dict_apply_reduce,
     dict_apply_split,
 )
-from roboverse_learn.il.utils.normalizer import SingleFieldLinearNormalizer
 
 
 def get_range_normalizer_from_stat(stat, output_max=1, output_min=-1, range_eps=1e-7):

--- a/roboverse_learn/il/utils/normalizer.py
+++ b/roboverse_learn/il/utils/normalizer.py
@@ -4,8 +4,9 @@ import numpy as np
 import torch
 import torch.nn as nn
 import zarr
-from roboverse_learn.il.utils.pytorch_util import dict_apply
+
 from roboverse_learn.il.utils.dict_of_tensor_mixin import DictOfTensorMixin
+from roboverse_learn.il.utils.pytorch_util import dict_apply
 
 
 class LinearNormalizer(DictOfTensorMixin):

--- a/roboverse_learn/il/utils/pose_trajectory_interpolator.py
+++ b/roboverse_learn/il/utils/pose_trajectory_interpolator.py
@@ -88,7 +88,7 @@ class PoseTrajectoryInterpolator:
         pos_min_duration = pos_dist / max_pos_speed
         rot_min_duration = rot_dist / max_rot_speed
         duration = time - curr_time
-        duration = max(duration, max(pos_min_duration, rot_min_duration))
+        duration = max(duration, pos_min_duration, rot_min_duration)
         assert duration >= 0
         last_waypoint_time = curr_time + duration
 
@@ -173,7 +173,7 @@ class PoseTrajectoryInterpolator:
         pos_dist, rot_dist = pose_distance(pose, end_pose)
         pos_min_duration = pos_dist / max_pos_speed
         rot_min_duration = rot_dist / max_rot_speed
-        duration = max(duration, max(pos_min_duration, rot_min_duration))
+        duration = max(duration, pos_min_duration, rot_min_duration)
         assert duration >= 0
         last_waypoint_time = end_time + duration
 

--- a/roboverse_learn/il/utils/pymunk_override.py
+++ b/roboverse_learn/il/utils/pymunk_override.py
@@ -33,14 +33,13 @@ __docformat__ = "reStructuredText"
 
 __all__ = [
     "DrawOptions",
-    "get_mouse_pos",
-    "to_pygame",
     "from_pygame",
-    "lighten",
+    "get_mouse_pos",
     "positive_y_is_up",
+    "to_pygame",
 ]
 
-from typing import List, Sequence, Tuple
+from typing import Sequence, Tuple
 
 import numpy as np
 import pygame
@@ -122,7 +121,7 @@ class DrawOptions(pymunk.SpaceDebugDrawOptions):
                     Surface that the objects will be drawn on
         """
         self.surface = surface
-        super(DrawOptions, self).__init__()
+        super().__init__()
 
     def draw_circle(
         self,

--- a/roboverse_learn/il/utils/pymunk_util.py
+++ b/roboverse_learn/il/utils/pymunk_util.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pygame
 import pymunk
 import pymunk.pygame_util
 

--- a/roboverse_learn/il/utils/robomimic_config_util.py
+++ b/roboverse_learn/il/utils/robomimic_config_util.py
@@ -1,5 +1,4 @@
 import robomimic.scripts.generate_paper_configs as gpc
-from omegaconf import OmegaConf
 from robomimic.config import config_factory
 from robomimic.scripts.generate_paper_configs import (
     modify_config_for_dataset,

--- a/roboverse_learn/il/utils/sampler.py
+++ b/roboverse_learn/il/utils/sampler.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 import numpy as np
+
 from roboverse_learn.il.utils.replay_buffer import ReplayBuffer
 
 try:

--- a/roboverse_learn/il/utils/shape_util.py
+++ b/roboverse_learn/il/utils/shape_util.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict, List, Tuple
+from typing import Callable, Tuple
 
 import torch
 import torch.nn as nn

--- a/roboverse_learn/il/utils/tensor_util.py
+++ b/roboverse_learn/il/utils/tensor_util.py
@@ -40,8 +40,7 @@ def recursive_dict_list_tuple_apply(x, type_func_dict):
         for t, f in type_func_dict.items():
             if isinstance(x, t):
                 return f(x)
-        else:
-            raise NotImplementedError("Cannot handle data type %s" % str(type(x)))
+        raise NotImplementedError("Cannot handle data type %s" % str(type(x)))
 
 
 def map_tensor(x, func):

--- a/roboverse_learn/il/utils/vision/crop_randomizer.py
+++ b/roboverse_learn/il/utils/vision/crop_randomizer.py
@@ -1,7 +1,8 @@
-import roboverse_learn.il.utils.tensor_util as tu
 import torch
 import torch.nn as nn
 import torchvision.transforms.functional as ttf
+
+import roboverse_learn.il.utils.tensor_util as tu
 
 
 class CropRandomizer(nn.Module):
@@ -128,9 +129,10 @@ class CropRandomizer(nn.Module):
 
     def __repr__(self):
         """Pretty print network."""
-        header = "{}".format(str(self.__class__.__name__))
-        msg = header + "(input_shape={}, crop_size=[{}, {}], num_crops={})".format(
-            self.input_shape, self.crop_height, self.crop_width, self.num_crops
+        header = f"{self.__class__.__name__!s}"
+        msg = (
+            header
+            + f"(input_shape={self.input_shape}, crop_size=[{self.crop_height}, {self.crop_width}], num_crops={self.num_crops})"
         )
         return msg
 

--- a/roboverse_learn/il/utils/vision/multi_image_obs_encoder.py
+++ b/roboverse_learn/il/utils/vision/multi_image_obs_encoder.py
@@ -4,8 +4,9 @@ from typing import Dict, Tuple, Union
 import torch
 import torch.nn as nn
 import torchvision
-from roboverse_learn.il.utils.pytorch_util import dict_apply, replace_submodules
+
 from roboverse_learn.il.utils.module_attr_mixin import ModuleAttrMixin
+from roboverse_learn.il.utils.pytorch_util import replace_submodules
 from roboverse_learn.il.utils.vision.crop_randomizer import CropRandomizer
 
 

--- a/roboverse_learn/managers/__init__.py
+++ b/roboverse_learn/managers/__init__.py
@@ -33,6 +33,10 @@ Public surface
 
 from __future__ import annotations
 
+from .manager_based_rv_env import (
+    ManagerBasedRVEnv,
+    ManagerBasedRVEnvCfg,
+)
 from .term_cfgs import (
     CfgTerm,
     CurriculumTerm,
@@ -41,18 +45,14 @@ from .term_cfgs import (
     ObsTerm,
     RewTerm,
 )
-from .manager_based_rv_env import (
-    ManagerBasedRVEnv,
-    ManagerBasedRVEnvCfg,
-)
 
 __all__ = [
     "CfgTerm",
-    "ObsTerm",
-    "RewTerm",
-    "DoneTerm",
     "CurriculumTerm",
+    "DoneTerm",
     "EventTerm",
     "ManagerBasedRVEnv",
     "ManagerBasedRVEnvCfg",
+    "ObsTerm",
+    "RewTerm",
 ]

--- a/roboverse_learn/rl/clean_rl/buffer.py
+++ b/roboverse_learn/rl/clean_rl/buffer.py
@@ -37,10 +37,10 @@ except ImportError:
 
 __all__ = [
     "BaseBuffer",
-    "RolloutBuffer",
     "ReplayBuffer",
-    "RolloutBufferSamples",
     "ReplayBufferSamples",
+    "RolloutBuffer",
+    "RolloutBufferSamples",
 ]
 
 
@@ -75,12 +75,12 @@ def get_action_dim(action_space: spaces.Space) -> int:
         return 1
     elif isinstance(action_space, spaces.MultiDiscrete):
         # Number of discrete actions
-        return int(len(action_space.nvec))
+        return len(action_space.nvec)
     elif isinstance(action_space, spaces.MultiBinary):
         # Number of binary actions
-        assert isinstance(
-            action_space.n, int
-        ), f"Multi-dimensional MultiBinary({action_space.n}) action space is not supported. You can flatten it instead."
+        assert isinstance(action_space.n, int), (
+            f"Multi-dimensional MultiBinary({action_space.n}) action space is not supported. You can flatten it instead."
+        )
         return int(action_space.n)
     else:
         raise NotImplementedError(f"{action_space} action space is not supported")
@@ -102,7 +102,7 @@ def get_obs_shape(
         return (1,)
     elif isinstance(observation_space, spaces.MultiDiscrete):
         # Number of discrete features
-        return (int(len(observation_space.nvec)),)
+        return (len(observation_space.nvec),)
     elif isinstance(observation_space, spaces.MultiBinary):
         # Number of binary features
         return observation_space.shape
@@ -306,7 +306,9 @@ class ReplayBuffer(BaseBuffer):
 
         if not optimize_memory_usage:
             # When optimizing memory, `observations` contains also the next observation
-            self.next_observations = np.zeros((self.buffer_size, self.n_envs, *self.obs_shape), dtype=observation_space.dtype)
+            self.next_observations = np.zeros(
+                (self.buffer_size, self.n_envs, *self.obs_shape), dtype=observation_space.dtype
+            )
 
         self.actions = np.zeros(
             (self.buffer_size, self.n_envs, self.action_dim), dtype=self._maybe_cast_dtype(action_space.dtype)
@@ -333,7 +335,8 @@ class ReplayBuffer(BaseBuffer):
                 mem_available /= 1e9
                 warnings.warn(
                     "This system does not have apparently enough memory to store the complete "
-                    f"replay buffer {total_memory_usage:.2f}GB > {mem_available:.2f}GB"
+                    f"replay buffer {total_memory_usage:.2f}GB > {mem_available:.2f}GB",
+                    stacklevel=2,
                 )
 
     def add(

--- a/roboverse_learn/rl/clean_rl/ppo.py
+++ b/roboverse_learn/rl/clean_rl/ppo.py
@@ -49,7 +49,10 @@ def make_roboverse_env(args):
     return env
 
 
-def layer_init(layer, std=np.sqrt(2), bias_const=0.0):
+_ORTHOGONAL_GAIN = float(np.sqrt(2))
+
+
+def layer_init(layer, std=_ORTHOGONAL_GAIN, bias_const=0.0):
     torch.nn.init.orthogonal_(layer.weight, std)
     torch.nn.init.constant_(layer.bias, bias_const)
     return layer

--- a/roboverse_learn/rl/clean_rl/sac.py
+++ b/roboverse_learn/rl/clean_rl/sac.py
@@ -5,7 +5,6 @@
 
 import random
 import time
-from typing import Literal
 
 try:
     import isaacgym  # noqa: F401
@@ -26,13 +25,14 @@ from torch.utils.tensorboard import SummaryWriter
 
 rootutils.setup_root(__file__, pythonpath=True)
 from gymnasium import make_vec
+
 import metasim
 
 metasim.register_gym_envs()
 
 from roboverse_learn.rl.clean_rl.buffer import ReplayBuffer
-from roboverse_learn.rl.episode_tracker import EpisodeTracker
 from roboverse_learn.rl.configs.clean_rl.sac import CleanRLSACConfig
+from roboverse_learn.rl.episode_tracker import EpisodeTracker
 
 
 def make_roboverse_env(args):
@@ -122,7 +122,6 @@ class Actor(nn.Module):
 
 
 if __name__ == "__main__":
-
     args = tyro.cli(CleanRLSACConfig)
     run_name = f"{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
@@ -220,10 +219,16 @@ if __name__ == "__main__":
         next_obs, rewards, terminations, truncations, infos = envs.step(actions)
         next_obs = next_obs.to(device)
 
-
         # Compute 'true' next_obs for saving (similar to fast_td3)
         true_next_obs = torch.where(truncations[:, None] > 0, infos["observations"]["raw"]["obs"], next_obs)
-        rb.add(obs.cpu().numpy(), true_next_obs.cpu().numpy(), actions.cpu().numpy(), rewards.cpu().numpy(), terminations.cpu().numpy(), infos)
+        rb.add(
+            obs.cpu().numpy(),
+            true_next_obs.cpu().numpy(),
+            actions.cpu().numpy(),
+            rewards.cpu().numpy(),
+            terminations.cpu().numpy(),
+            infos,
+        )
 
         # Update episode tracker
         episode_tracker.update(rewards, terminations, truncations)
@@ -241,7 +246,9 @@ if __name__ == "__main__":
                 qf1_next_target = qf1_target(data.next_observations, next_state_actions)
                 qf2_next_target = qf2_target(data.next_observations, next_state_actions)
                 min_qf_next_target = torch.min(qf1_next_target, qf2_next_target) - alpha * next_state_log_pi
-                next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (min_qf_next_target).view(-1)
+                next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (
+                    min_qf_next_target
+                ).view(-1)
 
             qf1_a_values = qf1(data.observations, data.actions).view(-1)
             qf2_a_values = qf2(data.observations, data.actions).view(-1)
@@ -300,7 +307,9 @@ if __name__ == "__main__":
                 if episode_tracker.get_episode_count() > 0:
                     writer.add_scalar("charts/avg_episodic_return", avg_return, global_step)
                     writer.add_scalar("charts/avg_episodic_length", avg_length, global_step)
-                    print(f"SPS: {int(global_step / (time.time() - start_time))}, avg_return: {avg_return:.2f}, avg_length: {avg_length:.1f}, timesteps: {global_step}")
+                    print(
+                        f"SPS: {int(global_step / (time.time() - start_time))}, avg_return: {avg_return:.2f}, avg_length: {avg_length:.1f}, timesteps: {global_step}"
+                    )
                 else:
                     print(f"SPS: {int(global_step / (time.time() - start_time))}, timesteps: {global_step}")
                 writer.add_scalar(

--- a/roboverse_learn/rl/clean_rl/td3.py
+++ b/roboverse_learn/rl/clean_rl/td3.py
@@ -25,14 +25,14 @@ from torch.utils.tensorboard import SummaryWriter
 
 rootutils.setup_root(__file__, pythonpath=True)
 from gymnasium import make_vec
+
 import metasim
 
 metasim.register_gym_envs()
 
 from roboverse_learn.rl.clean_rl.buffer import ReplayBuffer
-from roboverse_learn.rl.episode_tracker import EpisodeTracker
 from roboverse_learn.rl.configs.clean_rl.td3 import CleanRLTD3Config
-
+from roboverse_learn.rl.episode_tracker import EpisodeTracker
 
 
 def make_roboverse_env(args):
@@ -99,7 +99,6 @@ class Actor(nn.Module):
 
 
 if __name__ == "__main__":
-
     args = tyro.cli(CleanRLTD3Config)
     run_name = f"{args.exp_name}__{args.seed}__{int(time.time())}"
     if args.track:
@@ -177,7 +176,7 @@ if __name__ == "__main__":
     while global_step < args.total_timesteps:
         # ALGO LOGIC: put action logic here
         if global_step < args.learning_starts:
-             actions = torch.tensor([envs.single_action_space.sample() for _ in range(envs.num_envs)], device=device)
+            actions = torch.tensor([envs.single_action_space.sample() for _ in range(envs.num_envs)], device=device)
         else:
             with torch.no_grad():
                 actions = actor(torch.Tensor(obs).to(device))
@@ -189,7 +188,14 @@ if __name__ == "__main__":
         # TRY NOT TO MODIFY: save data to reply buffer; handle `final_observation`
         # Compute 'true' next_obs for saving (similar to fast_td3)
         true_next_obs = torch.where(truncations[:, None] > 0, infos["observations"]["raw"]["obs"], next_obs)
-        rb.add(obs.cpu().numpy(), true_next_obs.cpu().numpy(), actions.cpu().numpy(), rewards.cpu().numpy(), terminations.cpu().numpy(), infos)
+        rb.add(
+            obs.cpu().numpy(),
+            true_next_obs.cpu().numpy(),
+            actions.cpu().numpy(),
+            rewards.cpu().numpy(),
+            terminations.cpu().numpy(),
+            infos,
+        )
 
         # Update episode tracker
         episode_tracker.update(rewards, terminations, truncations)
@@ -213,7 +219,9 @@ if __name__ == "__main__":
                 qf1_next_target = qf1_target(data.next_observations, next_state_actions)
                 qf2_next_target = qf2_target(data.next_observations, next_state_actions)
                 min_qf_next_target = torch.min(qf1_next_target, qf2_next_target)
-                next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (min_qf_next_target).view(-1)
+                next_q_value = data.rewards.flatten() + (1 - data.dones.flatten()) * args.gamma * (
+                    min_qf_next_target
+                ).view(-1)
 
             qf1_a_values = qf1(data.observations, data.actions).view(-1)
             qf2_a_values = qf2(data.observations, data.actions).view(-1)
@@ -254,7 +262,9 @@ if __name__ == "__main__":
                 if episode_tracker.get_episode_count() > 0:
                     writer.add_scalar("charts/avg_episodic_return", avg_return, global_step)
                     writer.add_scalar("charts/avg_episodic_length", avg_length, global_step)
-                    print(f"SPS: {int(global_step / (time.time() - start_time))}, avg_return: {avg_return:.2f}, avg_length: {avg_length:.1f}, timesteps: {global_step}")
+                    print(
+                        f"SPS: {int(global_step / (time.time() - start_time))}, avg_return: {avg_return:.2f}, avg_length: {avg_length:.1f}, timesteps: {global_step}"
+                    )
                 else:
                     print(f"SPS: {int(global_step / (time.time() - start_time))}, timesteps: {global_step}")
                 writer.add_scalar(

--- a/roboverse_learn/rl/configs/__init__.py
+++ b/roboverse_learn/rl/configs/__init__.py
@@ -1,13 +1,13 @@
 from roboverse_learn.rl.configs.clean_rl.ppo import CleanRLPPOConfig
-from roboverse_learn.rl.configs.clean_rl.td3 import CleanRLTD3Config
 from roboverse_learn.rl.configs.clean_rl.sac import CleanRLSACConfig
-from roboverse_learn.rl.configs.rsl_rl.ppo import RslRlPPOConfig
+from roboverse_learn.rl.configs.clean_rl.td3 import CleanRLTD3Config
 from roboverse_learn.rl.configs.fast_td3 import FastTD3Config
+from roboverse_learn.rl.configs.rsl_rl.ppo import RslRlPPOConfig
 
 __all__ = [
     "CleanRLPPOConfig",
-    "CleanRLTD3Config",
     "CleanRLSACConfig",
-    "RslRlPPOConfig",
+    "CleanRLTD3Config",
     "FastTD3Config",
+    "RslRlPPOConfig",
 ]

--- a/roboverse_learn/rl/configs/clean_rl/__init__.py
+++ b/roboverse_learn/rl/configs/clean_rl/__init__.py
@@ -1,12 +1,12 @@
 from roboverse_learn.rl.configs.clean_rl.base import BaseRLConfig, SimBackend
 from roboverse_learn.rl.configs.clean_rl.ppo import CleanRLPPOConfig
-from roboverse_learn.rl.configs.clean_rl.td3 import CleanRLTD3Config
 from roboverse_learn.rl.configs.clean_rl.sac import CleanRLSACConfig
+from roboverse_learn.rl.configs.clean_rl.td3 import CleanRLTD3Config
 
 __all__ = [
     "BaseRLConfig",
-    "SimBackend",
     "CleanRLPPOConfig",
-    "CleanRLTD3Config",
     "CleanRLSACConfig",
+    "CleanRLTD3Config",
+    "SimBackend",
 ]

--- a/roboverse_learn/rl/configs/clean_rl/base.py
+++ b/roboverse_learn/rl/configs/clean_rl/base.py
@@ -2,7 +2,6 @@ from typing import Literal, Optional
 
 from metasim.utils import configclass
 
-
 SimBackend = Literal[
     "isaacgym",
     "isaacsim",

--- a/roboverse_learn/rl/configs/clean_rl/ppo.py
+++ b/roboverse_learn/rl/configs/clean_rl/ppo.py
@@ -1,7 +1,6 @@
 from typing import Optional
 
 from metasim.utils import configclass
-
 from roboverse_learn.rl.configs.clean_rl.base import BaseRLConfig, SimBackend
 
 

--- a/roboverse_learn/rl/configs/clean_rl/sac.py
+++ b/roboverse_learn/rl/configs/clean_rl/sac.py
@@ -1,7 +1,4 @@
-from typing import Optional
-
 from metasim.utils import configclass
-
 from roboverse_learn.rl.configs.clean_rl.base import BaseRLConfig, SimBackend
 
 

--- a/roboverse_learn/rl/configs/clean_rl/td3.py
+++ b/roboverse_learn/rl/configs/clean_rl/td3.py
@@ -1,7 +1,4 @@
-from typing import Optional
-
 from metasim.utils import configclass
-
 from roboverse_learn.rl.configs.clean_rl.base import BaseRLConfig, SimBackend
 
 

--- a/roboverse_learn/rl/configs/rsl_rl/algorithm.py
+++ b/roboverse_learn/rl/configs/rsl_rl/algorithm.py
@@ -10,7 +10,6 @@ from typing import List, Literal
 
 from metasim.utils import configclass
 
-
 #########################
 # Policy configurations #
 #########################
@@ -208,9 +207,9 @@ class RslRlOnPolicyRunnerCfg(RslRlBaseRunnerCfg):
 
 
 __all__ = [
+    "RslRlBaseRunnerCfg",
+    "RslRlOnPolicyRunnerCfg",
     "RslRlPpoActorCriticCfg",
     "RslRlPpoActorCriticRecurrentCfg",
     "RslRlPpoAlgorithmCfg",
-    "RslRlBaseRunnerCfg",
-    "RslRlOnPolicyRunnerCfg",
 ]

--- a/roboverse_learn/rl/configs/rsl_rl/ppo.py
+++ b/roboverse_learn/rl/configs/rsl_rl/ppo.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from typing import Literal, Optional
 from datetime import datetime
+from typing import Literal, Optional
 
 from metasim.utils import configclass
-from datetime import datetime
 
 SimBackend = Literal[
     "isaacgym",
@@ -147,9 +146,9 @@ class RslRlPPOConfig(RslRlOnPolicyRunnerCfg):
             "load_run": self.load_run,
             "load_checkpoint": self.load_checkpoint,
             "obs_groups": self.obs_groups,
-            "policy": policy_cfg,       # legacy rsl_rl key
-            "actor": actor_cfg,         # new rsl_rl key
-            "critic": critic_cfg,       # new rsl_rl key
+            "policy": policy_cfg,  # legacy rsl_rl key
+            "actor": actor_cfg,  # new rsl_rl key
+            "critic": critic_cfg,  # new rsl_rl key
             "algorithm": algo_cfg,
         }
 

--- a/roboverse_learn/rl/configs/rsl_rl/ppo_tracking.py
+++ b/roboverse_learn/rl/configs/rsl_rl/ppo_tracking.py
@@ -1,13 +1,13 @@
 import os
-import wandb
 import pathlib
 from typing import Literal, Optional
+
+import wandb
 from loguru import logger as log
 
 from metasim.utils import configclass
-from roboverse_learn.rl.configs.rsl_rl.ppo import RslRlPPOConfig
 from roboverse_learn.rl.configs.rsl_rl.algorithm import RslRlPpoActorCriticCfg, RslRlPpoAlgorithmCfg
-
+from roboverse_learn.rl.configs.rsl_rl.ppo import RslRlPPOConfig
 
 SimBackend = Literal[
     "isaacgym",
@@ -22,6 +22,7 @@ SimBackend = Literal[
 @configclass
 class RslRlPPOTrackingConfig(RslRlPPOConfig):
     """RSL-RL PPO configs for motion tracking task."""
+
     # Experiment / runner settings
     exp_name: str = "rsl_rl_ppo_tracking"
     max_iterations = 30000

--- a/roboverse_learn/rl/episode_tracker.py
+++ b/roboverse_learn/rl/episode_tracker.py
@@ -1,6 +1,7 @@
-import torch
-import numpy as np
 from collections import deque
+
+import numpy as np
+import torch
 
 
 class EpisodeTracker:

--- a/roboverse_learn/rl/fast_td3/evaluate.py
+++ b/roboverse_learn/rl/fast_td3/evaluate.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-import os
-import sys
 import argparse
-from typing import Any
-import yaml
-
 import os
 import sys
 
@@ -27,16 +22,17 @@ try:
 except ImportError:
     pass
 
-import torch
-import numpy as np
-from loguru import logger as log
-from torch.amp import autocast
 from datetime import datetime
 
-from roboverse_learn.rl.fast_td3.fttd3_module import Actor, EmpiricalNormalization
+import numpy as np
+import torch
+from loguru import logger as log
+from torch.amp import autocast
+
 from metasim.scenario.cameras import PinholeCameraCfg
 from metasim.task.registry import get_task_class
 from metasim.utils.demo_util import save_traj_file
+from roboverse_learn.rl.fast_td3.fttd3_module import Actor, EmpiricalNormalization
 
 
 def extract_state_dict(env, scenario, env_idx=0):
@@ -53,7 +49,7 @@ def extract_state_dict(env, scenario, env_idx=0):
     state_dict = {}
 
     # Get states from handler (returns TensorState object)
-    if not hasattr(env, 'handler') or env.handler is None:
+    if not hasattr(env, "handler") or env.handler is None:
         log.warning("Handler not available, returning empty state")
         return state_dict
 
@@ -67,7 +63,7 @@ def extract_state_dict(env, scenario, env_idx=0):
     robot_cfg_dict = {robot.name: robot for robot in scenario.robots}
 
     # Extract object states
-    if hasattr(handler_states, 'objects'):
+    if hasattr(handler_states, "objects"):
         for obj_name, obj_state in handler_states.objects.items():
             pos = obj_state.root_state[env_idx, :3].cpu().numpy()  # [x, y, z]
             quat = obj_state.root_state[env_idx, 3:7].cpu().numpy()  # [w, x, y, z]
@@ -89,7 +85,7 @@ def extract_state_dict(env, scenario, env_idx=0):
             state_dict[obj_name] = state_entry
 
     # Extract robot states
-    if hasattr(handler_states, 'robots'):
+    if hasattr(handler_states, "robots"):
         for robot_name, robot_state in handler_states.robots.items():
             pos = robot_state.root_state[env_idx, :3].cpu().numpy()  # [x, y, z]
             quat = robot_state.root_state[env_idx, 3:7].cpu().numpy()  # [w, x, y, z]
@@ -129,7 +125,7 @@ def evaluate(
     obs_normalizer,
     num_episodes: int,
     device: torch.device,
-    scenario = None,
+    scenario=None,
     task_name: str = "eval",
     amp_enabled: bool = False,
     amp_device_type: str = "cpu",
@@ -240,7 +236,7 @@ def evaluate(
         if save_traj:
             # Get states from handler for trajectory recording
             handler_states = None
-            if hasattr(env, 'handler') and env.handler is not None:
+            if hasattr(env, "handler") and env.handler is not None:
                 handler_states = env.handler.get_states(mode="tensor")
 
             for i in range(num_eval_envs):
@@ -250,7 +246,11 @@ def evaluate(
                     robot_name = scenario.robots[0].name
                     joint_names = sorted(scenario.robots[0].actuators.keys())
 
-                    if handler_states is not None and hasattr(handler_states, 'robots') and robot_name in handler_states.robots:
+                    if (
+                        handler_states is not None
+                        and hasattr(handler_states, "robots")
+                        and robot_name in handler_states.robots
+                    ):
                         # Use handler states (preferred)
                         robot_state = handler_states.robots[robot_name]
                         joint_positions = robot_state.joint_pos[i].cpu().numpy()
@@ -309,12 +309,16 @@ def evaluate(
                         # Use env_id and episode number for filename
                         base_dir = os.path.dirname(video_path)
                         base_name = os.path.splitext(os.path.basename(video_path))[0]
-                        ext = os.path.splitext(video_path)[1] or '.mp4'
-                        ep_video_path = os.path.join(base_dir, f"{base_name}_env{i:02d}_ep{episodes_per_env[i].item():02d}{ext}")
+                        ext = os.path.splitext(video_path)[1] or ".mp4"
+                        ep_video_path = os.path.join(
+                            base_dir, f"{base_name}_env{i:02d}_ep{episodes_per_env[i].item():02d}{ext}"
+                        )
 
                         os.makedirs(base_dir, exist_ok=True)
                         iio.mimsave(ep_video_path, episode_frames[i], fps=30)
-                        log.info(f"Env {i} Episode {episodes_per_env[i].item()}: Saved video to {ep_video_path} (return: {current_returns[i].item():.2f})")
+                        log.info(
+                            f"Env {i} Episode {episodes_per_env[i].item()}: Saved video to {ep_video_path} (return: {current_returns[i].item():.2f})"
+                        )
 
                         # Clear frames for this env
                         episode_frames[i] = []
@@ -327,7 +331,9 @@ def evaluate(
                             "states": current_episode_states[i] if save_states else None,
                         }
                         all_episodes[i].append(episode_data)
-                        log.info(f"Env {i} Episode {episodes_per_env[i].item()}: Saved trajectory ({len(current_episode_actions[i])} steps, return: {current_returns[i].item():.2f})")
+                        log.info(
+                            f"Env {i} Episode {episodes_per_env[i].item()}: Saved trajectory ({len(current_episode_actions[i])} steps, return: {current_returns[i].item():.2f})"
+                        )
 
                         # Reset trajectory tracking for this env
                         current_episode_actions[i] = []
@@ -374,6 +380,7 @@ def evaluate(
     # Save single video if rendering all episodes together
     if render and not render_each_episode and frames and video_path:
         import imageio.v2 as iio
+
         os.makedirs(os.path.dirname(video_path), exist_ok=True)
         iio.mimsave(video_path, frames, fps=30)
         log.info(f"Saved evaluation video to {video_path}")
@@ -482,34 +489,49 @@ def _adjust_state_dict_for_model(checkpoint_state: dict, model: torch.nn.Module)
 
 
 def main():
-    parser = argparse.ArgumentParser(description='FastTD3 Evaluation')
-    parser.add_argument('--checkpoint', type=str, default='roboverse_data/models/walk_1400.pt',
-                       help='Path to checkpoint file')
-    parser.add_argument('--num_episodes', type=int, default=1,
-                       help='Number of episodes per environment (default: 1, each env saves one episode)')
+    parser = argparse.ArgumentParser(description="FastTD3 Evaluation")
+    parser.add_argument(
+        "--checkpoint", type=str, default="roboverse_data/models/walk_1400.pt", help="Path to checkpoint file"
+    )
+    parser.add_argument(
+        "--num_episodes",
+        type=int,
+        default=1,
+        help="Number of episodes per environment (default: 1, each env saves one episode)",
+    )
 
     # Rendering arguments
-    parser.add_argument('--render', type=int, default=1,
-                       help='Render mode: 0=no render, 1=render each episode separately (default), 2=single combined video')
-    parser.add_argument('--video_path', type=str, default='output/eval_rollout.mp4',
-                       help='Path to save video (base name for multiple videos)')
+    parser.add_argument(
+        "--render",
+        type=int,
+        default=1,
+        help="Render mode: 0=no render, 1=render each episode separately (default), 2=single combined video",
+    )
+    parser.add_argument(
+        "--video_path",
+        type=str,
+        default="output/eval_rollout.mp4",
+        help="Path to save video (base name for multiple videos)",
+    )
 
-    parser.add_argument('--device_rank', type=int, default=0,
-                       help='GPU device rank')
-    parser.add_argument('--num_envs', type=int, default=None,
-                       help='Number of parallel environments (default: from checkpoint config)')
-    parser.add_argument('--headless', action='store_true',
-                       help='Run in headless mode')
+    parser.add_argument("--device_rank", type=int, default=0, help="GPU device rank")
+    parser.add_argument(
+        "--num_envs", type=int, default=None, help="Number of parallel environments (default: from checkpoint config)"
+    )
+    parser.add_argument("--headless", action="store_true", help="Run in headless mode")
 
     # Trajectory saving arguments (default: enabled)
-    parser.add_argument('--save_traj', type=int, default=1,
-                       help='Save trajectories: 0=no, 1=yes (default)')
-    parser.add_argument('--save_states', type=int, default=1,
-                       help='Save full states: 0=no (actions only), 1=yes (default)')
-    parser.add_argument('--save_every_n_steps', type=int, default=1,
-                       help='Save every N steps (1=save all, 2=save every other step, etc.)')
-    parser.add_argument('--traj_dir', type=str, default='eval_trajs',
-                       help='Directory to save trajectories')
+    parser.add_argument("--save_traj", type=int, default=1, help="Save trajectories: 0=no, 1=yes (default)")
+    parser.add_argument(
+        "--save_states", type=int, default=1, help="Save full states: 0=no (actions only), 1=yes (default)"
+    )
+    parser.add_argument(
+        "--save_every_n_steps",
+        type=int,
+        default=1,
+        help="Save every N steps (1=save all, 2=save every other step, etc.)",
+    )
+    parser.add_argument("--traj_dir", type=str, default="eval_trajs", help="Directory to save trajectories")
 
     args = parser.parse_args()
 
@@ -607,13 +629,7 @@ def main():
 
     # Setup AMP
     amp_enabled = config.get("amp", False) and torch.cuda.is_available()
-    amp_device_type = (
-        "cuda"
-        if torch.cuda.is_available()
-        else "mps"
-        if torch.backends.mps.is_available()
-        else "cpu"
-    )
+    amp_device_type = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
     amp_dtype = torch.bfloat16 if config.get("amp_dtype") == "bf16" else torch.float16
 
     # Run evaluation

--- a/roboverse_learn/rl/fast_td3/evaluate_lift.py
+++ b/roboverse_learn/rl/fast_td3/evaluate_lift.py
@@ -6,11 +6,10 @@ Loops until collecting target number of successful trajectories (default: 100).
 
 from __future__ import annotations
 
-import os
-import sys
 import argparse
+import os
 import pickle
-from typing import Any
+import sys
 
 os.environ["TORCHDYNAMO_INLINE_INBUILT_NN_MODULES"] = "1"
 os.environ["OMP_NUM_THREADS"] = "1"
@@ -30,16 +29,16 @@ try:
 except ImportError:
     pass
 
-import torch
-import numpy as np
-from loguru import logger as log
-from torch.amp import autocast
 from datetime import datetime
 
-from roboverse_learn.rl.fast_td3.fttd3_module import Actor, EmpiricalNormalization
-from metasim.scenario.cameras import PinholeCameraCfg
+import numpy as np
+import torch
+from loguru import logger as log
+from torch.amp import autocast
+
 from metasim.task.registry import get_task_class
 from metasim.utils.demo_util import save_traj_file
+from roboverse_learn.rl.fast_td3.fttd3_module import Actor, EmpiricalNormalization
 
 
 def extract_state_dict(env, scenario, env_idx=0):
@@ -56,7 +55,7 @@ def extract_state_dict(env, scenario, env_idx=0):
     state_dict = {}
 
     # Get states from handler (returns TensorState object)
-    if not hasattr(env, 'handler') or env.handler is None:
+    if not hasattr(env, "handler") or env.handler is None:
         log.warning("Handler not available, returning empty state")
         return state_dict
 
@@ -70,7 +69,7 @@ def extract_state_dict(env, scenario, env_idx=0):
     robot_cfg_dict = {robot.name: robot for robot in scenario.robots}
 
     # Extract object states
-    if hasattr(handler_states, 'objects'):
+    if hasattr(handler_states, "objects"):
         for obj_name, obj_state in handler_states.objects.items():
             pos = obj_state.root_state[env_idx, :3].cpu().numpy()  # [x, y, z]
             quat = obj_state.root_state[env_idx, 3:7].cpu().numpy()  # [w, x, y, z]
@@ -92,7 +91,7 @@ def extract_state_dict(env, scenario, env_idx=0):
             state_dict[obj_name] = state_entry
 
     # Extract robot states
-    if hasattr(handler_states, 'robots'):
+    if hasattr(handler_states, "robots"):
         for robot_name, robot_state in handler_states.robots.items():
             pos = robot_state.root_state[env_idx, :3].cpu().numpy()  # [x, y, z]
             quat = robot_state.root_state[env_idx, 3:7].cpu().numpy()  # [w, x, y, z]
@@ -215,7 +214,7 @@ def evaluate_lift_collection(
         dones = terminated | time_out
 
         handler_states = None
-        if hasattr(env, 'handler') and env.handler is not None:
+        if hasattr(env, "handler") and env.handler is not None:
             handler_states = env.handler.get_states(mode="tensor")
 
         for i in range(num_eval_envs):
@@ -228,7 +227,7 @@ def evaluate_lift_collection(
             robot_name = scenario.robots[0].name
             joint_names = sorted(scenario.robots[0].actuators.keys())
 
-            if handler_states is not None and hasattr(handler_states, 'robots') and robot_name in handler_states.robots:
+            if handler_states is not None and hasattr(handler_states, "robots") and robot_name in handler_states.robots:
                 robot_state = handler_states.robots[robot_name]
                 joint_positions = robot_state.joint_pos[i].cpu().numpy()
             else:
@@ -333,10 +332,11 @@ def evaluate_lift_collection(
             obs = next_obs
 
     # Treat each active env as an attempted episode, and count it as successful if it already
-    active_envs = (~done_masks).sum().item() if 'done_masks' in locals() else 0
+    active_envs = (~done_masks).sum().item() if "done_masks" in locals() else 0
     successes_in_active = sum(
-        1 for i in range(num_eval_envs)
-        if 'done_masks' in locals() and not done_masks[i] and success_in_episode.get(i, False)
+        1
+        for i in range(num_eval_envs)
+        if "done_masks" in locals() and not done_masks[i] and success_in_episode.get(i, False)
     )
     attempted_episodes = episodes_completed + active_envs
     total_successful_episodes = successful_episodes_count + successes_in_active
@@ -380,25 +380,31 @@ def evaluate_lift_collection(
 
 
 def main():
-    parser = argparse.ArgumentParser(description='FastTD3 lift trajectory collection evaluation')
-    parser.add_argument('--checkpoint', type=str, default='models/pick_place.approach_grasp_simple_1210000.pt',
-                       help='Checkpoint file path')
-    parser.add_argument('--target_count', type=int, default=100,
-                       help='Target number of successful trajectories to collect (default: 100)')
+    parser = argparse.ArgumentParser(description="FastTD3 lift trajectory collection evaluation")
+    parser.add_argument(
+        "--checkpoint",
+        type=str,
+        default="models/pick_place.approach_grasp_simple_1210000.pt",
+        help="Checkpoint file path",
+    )
+    parser.add_argument(
+        "--target_count",
+        type=int,
+        default=100,
+        help="Target number of successful trajectories to collect (default: 100)",
+    )
 
-    parser.add_argument('--device_rank', type=int, default=0,
-                       help='GPU device rank')
-    parser.add_argument('--num_envs', type=int, default=None,
-                       help='Number of parallel environments (default: from checkpoint config)')
-    parser.add_argument('--headless', action='store_true',
-                       help='Run in headless mode')
+    parser.add_argument("--device_rank", type=int, default=0, help="GPU device rank")
+    parser.add_argument(
+        "--num_envs", type=int, default=None, help="Number of parallel environments (default: from checkpoint config)"
+    )
+    parser.add_argument("--headless", action="store_true", help="Run in headless mode")
 
-    parser.add_argument('--traj_dir', type=str, default='eval_trajs',
-                       help='Trajectory save directory')
-    parser.add_argument('--state_dir', type=str, default='eval_states',
-                       help='State save directory')
-    parser.add_argument('--lift_stable_frames', type=int, default=10,
-                       help='Number of frames lift must be maintained (default: 10)')
+    parser.add_argument("--traj_dir", type=str, default="eval_trajs", help="Trajectory save directory")
+    parser.add_argument("--state_dir", type=str, default="eval_states", help="State save directory")
+    parser.add_argument(
+        "--lift_stable_frames", type=int, default=10, help="Number of frames lift must be maintained (default: 10)"
+    )
 
     args = parser.parse_args()
 
@@ -452,13 +458,7 @@ def main():
         obs_normalizer.load_state_dict(checkpoint["obs_normalizer_state"])
 
     amp_enabled = config.get("amp", False) and torch.cuda.is_available()
-    amp_device_type = (
-        "cuda"
-        if torch.cuda.is_available()
-        else "mps"
-        if torch.backends.mps.is_available()
-        else "cpu"
-    )
+    amp_device_type = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
     amp_dtype = torch.bfloat16 if config.get("amp_dtype") == "bf16" else torch.float16
 
     log.info("Starting lift trajectory collection...")

--- a/roboverse_learn/rl/fast_td3/replay_lift_states.py
+++ b/roboverse_learn/rl/fast_td3/replay_lift_states.py
@@ -5,10 +5,10 @@ Continuously replays saved lift states for visualization.
 
 from __future__ import annotations
 
-import os
-import sys
 import argparse
+import os
 import pickle
+import sys
 import time
 
 os.environ["TORCHDYNAMO_INLINE_INBUILT_NN_MODULES"] = "1"
@@ -29,14 +29,13 @@ try:
 except ImportError:
     pass
 
-import torch
-import numpy as np
-from loguru import logger as log
 import imageio.v2 as iio
+import numpy as np
+import torch
+from loguru import logger as log
 
 from metasim.scenario.cameras import PinholeCameraCfg
 from metasim.task.registry import get_task_class
-from roboverse_pack.tasks.pick_place.track_banana import convert_state_dict_to_initial_state
 
 
 def load_states_from_pkl(pkl_path: str):
@@ -96,34 +95,27 @@ def convert_state_to_dict_format(state_dict: dict, device: torch.device, robot_n
 
 
 def main():
-    parser = argparse.ArgumentParser(description='Replay Lift States')
-    parser.add_argument('--state_file', type=str,
-                       default='eval_states/pick_place.approach_grasp_simple_franka_lift_states_101states_20251122_180651.pkl',
-                       help='State file path (pkl format)')
-    parser.add_argument('--task', type=str, default='pick_place.track',
-                       help='Task name')
-    parser.add_argument('--sim', type=str, default='isaacsim',
-                       help='Simulator type')
-    parser.add_argument('--num_envs', type=int, default=1,
-                       help='Number of environments')
-    parser.add_argument('--headless', action='store_true',
-                       help='Run in headless mode')
-    parser.add_argument('--render', action='store_true', default=True,
-                       help='Enable rendering')
-    parser.add_argument('--save_video', action='store_true',
-                       help='Save video')
-    parser.add_argument('--video_path', type=str, default='replay_output/replay.mp4',
-                       help='Video output path')
-    parser.add_argument('--loop', action='store_true', default=True,
-                       help='Loop replay')
-    parser.add_argument('--max_loops', type=int, default=None,
-                       help='Max loop count (None for infinite)')
-    parser.add_argument('--fps', type=int, default=30,
-                       help='Video FPS')
-    parser.add_argument('--delay', type=float, default=0.0,
-                       help='Delay between frames (seconds)')
-    parser.add_argument('--disable_dr', action='store_true', default=True,
-                       help='Disable domain randomization (default: True)')
+    parser = argparse.ArgumentParser(description="Replay Lift States")
+    parser.add_argument(
+        "--state_file",
+        type=str,
+        default="eval_states/pick_place.approach_grasp_simple_franka_lift_states_101states_20251122_180651.pkl",
+        help="State file path (pkl format)",
+    )
+    parser.add_argument("--task", type=str, default="pick_place.track", help="Task name")
+    parser.add_argument("--sim", type=str, default="isaacsim", help="Simulator type")
+    parser.add_argument("--num_envs", type=int, default=1, help="Number of environments")
+    parser.add_argument("--headless", action="store_true", help="Run in headless mode")
+    parser.add_argument("--render", action="store_true", default=True, help="Enable rendering")
+    parser.add_argument("--save_video", action="store_true", help="Save video")
+    parser.add_argument("--video_path", type=str, default="replay_output/replay.mp4", help="Video output path")
+    parser.add_argument("--loop", action="store_true", default=True, help="Loop replay")
+    parser.add_argument("--max_loops", type=int, default=None, help="Max loop count (None for infinite)")
+    parser.add_argument("--fps", type=int, default=30, help="Video FPS")
+    parser.add_argument("--delay", type=float, default=0.0, help="Delay between frames (seconds)")
+    parser.add_argument(
+        "--disable_dr", action="store_true", default=True, help="Disable domain randomization (default: True)"
+    )
 
     args = parser.parse_args()
 
@@ -187,9 +179,9 @@ def main():
                 break
 
             loop_count += 1
-            log.info(f"\n{'='*60}")
+            log.info(f"\n{'=' * 60}")
             log.info(f"Loop {loop_count}")
-            log.info(f"{'='*60}")
+            log.info(f"{'=' * 60}")
 
             for state_idx, state_dict in enumerate(states_list):
                 nested_state = convert_state_to_dict_format(state_dict, device, robot_name=robot_name)
@@ -217,14 +209,14 @@ def main():
                         if len(gripper_joint_names) >= 2:
                             gripper_angles = [
                                 joint_positions[joint_names.index(gripper_joint_names[0])],
-                                joint_positions[joint_names.index(gripper_joint_names[1])]
+                                joint_positions[joint_names.index(gripper_joint_names[1])],
                             ]
                         else:
                             gripper_angles = joint_positions[:2].tolist()
 
                         if state_idx == 0 or state_idx % 10 == 0 or state_idx == len(states_list) - 1:
                             log.info(
-                                f"[State {state_idx:3d}/{len(states_list)-1}] "
+                                f"[State {state_idx:3d}/{len(states_list) - 1}] "
                                 f"Distance: {gripper_box_dist:.4f}m | "
                                 f"Gripper: [{gripper_angles[0]:.4f}, {gripper_angles[1]:.4f}]"
                             )

--- a/roboverse_learn/rl/rsl_rl/env_wrapper.py
+++ b/roboverse_learn/rl/rsl_rl/env_wrapper.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
-from typing import Union
+
 import torch
 from tensordict import TensorDict
+
 from roboverse_pack.tasks.humanoid.base import AgentTask
 
 
@@ -34,7 +35,7 @@ class RslRlEnvWrapper:
         dones = torch.logical_or(terminated, truncated)
 
         # Merge info into extras
-        extras = {**getattr(self.env, 'extras', {}), **info}
+        extras = {**getattr(self.env, "extras", {}), **info}
 
         # move time out information to the extras dict
         # this is only needed for infinite horizon tasks
@@ -88,7 +89,4 @@ class RslRlEnvWrapper:
         All RoboVerse RL environments provide
         obs_buf and priv_obs_buf properties, so we simply wrap them.
         """
-        return TensorDict(
-            policy=self.env.obs_buf,
-            critic=self.env.priv_obs_buf
-        )
+        return TensorDict(policy=self.env.obs_buf, critic=self.env.priv_obs_buf)

--- a/roboverse_learn/rl/rsl_rl/eval.py
+++ b/roboverse_learn/rl/rsl_rl/eval.py
@@ -9,18 +9,20 @@ try:
 except ImportError:
     pass
 
+import datetime
+
 import numpy as np
 import rootutils
 import torch
 import tyro
-import datetime
 from loguru import logger as log
 
 rootutils.setup_root(__file__, pythonpath=True)
 
+from metasim.task.registry import get_task_class
 from roboverse_learn.rl.configs.rsl_rl.ppo import RslRlPPOConfig
 from roboverse_learn.rl.rsl_rl.env_wrapper import RslRlEnvWrapper
-from metasim.task.registry import get_task_class
+
 
 def get_log_dir(exp_name: str, task_name: str, now=None) -> str:
     """Get the log directory (aligned with ppo.py saving logic)."""
@@ -48,16 +50,13 @@ def get_load_path(load_root: str, checkpoint: int | str = None) -> str:
     log.info(f"Loading checkpoint {checkpoint} from {load_root}")
     return load_path
 
+
 def make_roboverse_env(args: RslRlPPOConfig):
     """Create RoboVerse task environment"""
     task_cls = get_task_class(args.task)
 
     scenario = task_cls.scenario.update(
-        robots=[args.robot],
-        simulator=args.sim,
-        num_envs=args.num_envs,
-        headless=args.headless,
-        cameras=[]
+        robots=[args.robot], simulator=args.sim, num_envs=args.num_envs, headless=args.headless, cameras=[]
     )
     if args.sim == "newton":
         if args.newton_use_mujoco_contacts is None:
@@ -115,7 +114,6 @@ def evaluate(args: RslRlPPOConfig):
     wrapped_env = RslRlEnvWrapper(env, train_cfg=args.train_cfg)
 
     # Get observations from environment (needed for resolve_obs_groups)
-    from rsl_rl.utils import resolve_obs_groups
     from rsl_rl.modules import ActorCritic
 
     obs = wrapped_env.get_observations()
@@ -136,8 +134,8 @@ def evaluate(args: RslRlPPOConfig):
         init_noise_std=policy_cfg.init_noise_std,
     ).to(device)
 
-    state_dict = checkpoint['model_state_dict']
-    state_dict = {k: v for k, v in state_dict.items() if 'critic' not in k}
+    state_dict = checkpoint["model_state_dict"]
+    state_dict = {k: v for k, v in state_dict.items() if "critic" not in k}
     # Load the model weights
     actor_critic.load_state_dict(state_dict, strict=False)
     actor_critic.to(device)
@@ -164,7 +162,9 @@ def evaluate(args: RslRlPPOConfig):
         actions = policy(obs)
         obs, _, _, _ = wrapped_env.step(actions)
         if (i + 1) % 100 == 0:
-            print(f"Step {i + 1}/1000000 | Simulation time: {(i + 1) * env.step_dt:.2f}s | Elapsed time: {time.time() - t0:.2f}s")
+            print(
+                f"Step {i + 1}/1000000 | Simulation time: {(i + 1) * env.step_dt:.2f}s | Elapsed time: {time.time() - t0:.2f}s"
+            )
     print("Evaluation complete!")
 
 

--- a/roboverse_learn/rl/rsl_rl/eval_tracking.py
+++ b/roboverse_learn/rl/rsl_rl/eval_tracking.py
@@ -8,20 +8,20 @@ try:
 except ImportError:
     pass
 
+import datetime
+
 import numpy as np
 import rootutils
 import torch
 import tyro
-import datetime
 from loguru import logger as log
 from rsl_rl.runners import OnPolicyRunner
 
 rootutils.setup_root(__file__, pythonpath=True)
 
+from metasim.task.registry import get_task_class
 from roboverse_learn.rl.configs.rsl_rl.ppo_tracking import RslRlPPOTrackingConfig
 from roboverse_learn.rl.rsl_rl.env_wrapper import RslRlEnvWrapper
-from metasim.task.registry import get_task_class
-
 
 torch.backends.cuda.matmul.allow_tf32 = True
 torch.backends.cudnn.allow_tf32 = True
@@ -60,11 +60,7 @@ def make_roboverse_env(args: RslRlPPOTrackingConfig):
     task_cls = get_task_class(args.task)
 
     scenario = task_cls.scenario.update(
-        robots=[args.robot],
-        simulator=args.sim,
-        num_envs=args.num_envs,
-        headless=args.headless,
-        cameras=[]
+        robots=[args.robot], simulator=args.sim, num_envs=args.num_envs, headless=args.headless, cameras=[]
     )
     device = torch.device(args.device if torch.cuda.is_available() and args.cuda else "cpu")
 
@@ -103,7 +99,9 @@ def evaluate(args: RslRlPPOTrackingConfig):
 
         # checkpoint = torch.load(checkpoint_path, map_location=device)
     else:
-        raise ValueError("Please provide either --wandb-path (WandB run path / model file path) or --resume (timestamp / log dir) for evaluation.")
+        raise ValueError(
+            "Please provide either --wandb-path (WandB run path / model file path) or --resume (timestamp / log dir) for evaluation."
+        )
 
     # Create environment
     print(f"Creating environment: {args.task} with {args.num_envs} environments")
@@ -114,12 +112,7 @@ def evaluate(args: RslRlPPOTrackingConfig):
     # Create environment wrapper
     env_wrapper = RslRlEnvWrapper(env, train_cfg=args.train_cfg)
 
-    runner = OnPolicyRunner(
-        env=env_wrapper,
-        train_cfg=args.train_cfg,
-        log_dir=None,
-        device=device
-    )
+    runner = OnPolicyRunner(env=env_wrapper, train_cfg=args.train_cfg, log_dir=None, device=device)
     runner.load(checkpoint_path)
     policy = runner.get_inference_policy(device=device)
 

--- a/roboverse_learn/rl/rsl_rl/ppo.py
+++ b/roboverse_learn/rl/rsl_rl/ppo.py
@@ -16,9 +16,9 @@ from rsl_rl.runners import OnPolicyRunner
 
 rootutils.setup_root(__file__, pythonpath=True)
 
+from metasim.task.registry import _discover_task_modules, get_task_class
 from roboverse_learn.rl.configs.rsl_rl.ppo import RslRlPPOConfig
 from roboverse_learn.rl.rsl_rl.env_wrapper import RslRlEnvWrapper
-from metasim.task.registry import _discover_task_modules, get_task_class
 
 
 def make_roboverse_env(args: RslRlPPOConfig):
@@ -35,11 +35,7 @@ def make_roboverse_env(args: RslRlPPOConfig):
     # Load environment configuration from task
 
     scenario = task_cls.scenario.update(
-        robots=[args.robot],
-        simulator=args.sim,
-        num_envs=args.num_envs,
-        headless=args.headless,
-        cameras=[]
+        robots=[args.robot], simulator=args.sim, num_envs=args.num_envs, headless=args.headless, cameras=[]
     )
     if args.sim == "newton":
         if args.newton_use_mujoco_contacts is None:
@@ -67,12 +63,9 @@ def train(args: RslRlPPOConfig):
     # Initialize WandB
     if args.use_wandb:
         import wandb
+
         wandb.init(
-            project=args.wandb_project,
-            entity=args.wandb_entity,
-            config=vars(args),
-            name=args.exp_name,
-            save_code=True
+            project=args.wandb_project, entity=args.wandb_entity, config=vars(args), name=args.exp_name, save_code=True
         )
 
     # Create environment and wrapper
@@ -85,21 +78,12 @@ def train(args: RslRlPPOConfig):
     # Create environment wrapper
     env_wrapper = RslRlEnvWrapper(env, train_cfg=train_cfg)
 
-
-    runner = OnPolicyRunner(
-        env=env_wrapper,
-        train_cfg=train_cfg,
-        log_dir=args.model_dir,
-        device=device
-    )
+    runner = OnPolicyRunner(env=env_wrapper, train_cfg=train_cfg, log_dir=args.model_dir, device=device)
 
     # Train
     print(f"Training RSL-RL PPO on {args.task} with {args.num_envs} environments")
     print(f"Model directory: {args.model_dir}")
-    runner.learn(
-        num_learning_iterations=args.max_iterations,
-        init_at_random_ep_len=True
-    )
+    runner.learn(num_learning_iterations=args.max_iterations, init_at_random_ep_len=True)
 
     # Export policy. Newer rsl_rl uses ``torch.distributions.Normal`` inside
     # ``GaussianDistribution``, which TorchScript cannot script. Fall back to a

--- a/roboverse_learn/rl/rsl_rl/ppo_tracking.py
+++ b/roboverse_learn/rl/rsl_rl/ppo_tracking.py
@@ -16,10 +16,9 @@ from rsl_rl.runners import OnPolicyRunner
 
 rootutils.setup_root(__file__, pythonpath=True)
 
+from metasim.task.registry import get_task_class
 from roboverse_learn.rl.configs.rsl_rl.ppo_tracking import RslRlPPOTrackingConfig
 from roboverse_learn.rl.rsl_rl.env_wrapper import RslRlEnvWrapper
-from metasim.task.registry import get_task_class
-
 
 torch.backends.cuda.matmul.allow_tf32 = True
 torch.backends.cudnn.allow_tf32 = True
@@ -32,11 +31,7 @@ def make_roboverse_env(args: RslRlPPOTrackingConfig):
 
     # Load environment configuration from task
     scenario = task_cls.scenario.update(
-        robots=[args.robot],
-        simulator=args.sim,
-        num_envs=args.num_envs,
-        headless=args.headless,
-        cameras=[]
+        robots=[args.robot], simulator=args.sim, num_envs=args.num_envs, headless=args.headless, cameras=[]
     )
     device = torch.device(args.device if torch.cuda.is_available() and args.cuda else "cpu")
 
@@ -60,12 +55,9 @@ def train(args: RslRlPPOTrackingConfig):
     # Initialize WandB
     if args.use_wandb:
         import wandb
+
         wandb.init(
-            project=args.wandb_project,
-            entity=args.wandb_entity,
-            config=vars(args),
-            name=args.exp_name,
-            save_code=True
+            project=args.wandb_project, entity=args.wandb_entity, config=vars(args), name=args.exp_name, save_code=True
         )
         # use artifact for training
         if args.registry_name:
@@ -81,20 +73,12 @@ def train(args: RslRlPPOTrackingConfig):
     # Create environment wrapper
     env_wrapper = RslRlEnvWrapper(env, train_cfg=train_cfg)
 
-    runner = OnPolicyRunner(
-        env=env_wrapper,
-        train_cfg=train_cfg,
-        log_dir=args.model_dir,
-        device=device
-    )
+    runner = OnPolicyRunner(env=env_wrapper, train_cfg=train_cfg, log_dir=args.model_dir, device=device)
 
     # Train
     print(f"Training RSL-RL PPO on {args.task} with {args.num_envs} environments")
     print(f"Model directory: {args.model_dir}")
-    runner.learn(
-        num_learning_iterations=args.max_iterations,
-        init_at_random_ep_len=True
-    )
+    runner.learn(num_learning_iterations=args.max_iterations, init_at_random_ep_len=True)
 
     # Export policy
     print("Exporting policy...")

--- a/roboverse_learn/vla/OpenVLA/vla_eval.py
+++ b/roboverse_learn/vla/OpenVLA/vla_eval.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+from __future__ import annotations
+
 import argparse
 import json
 import os

--- a/roboverse_learn/vla/OpenVLA/vla_eval.py
+++ b/roboverse_learn/vla/OpenVLA/vla_eval.py
@@ -6,27 +6,29 @@ import sys
 import time
 from collections import deque
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 
 import numpy as np
 import torch
 from PIL import Image
-from transformers import AutoModelForVision2Seq, AutoProcessor
 from scipy.spatial.transform import Rotation
+from transformers import AutoModelForVision2Seq, AutoProcessor
+
 sys.path.append(str(Path(__file__).parent.parent.parent))
 
-import metasim
 from gymnasium import make_vec
 
+import metasim
+
 metasim.register_gym_envs()
-from metasim.utils import configclass
+from metasim.randomization import DomainRandomizationManager, DRConfig
 from metasim.scenario.cameras import PinholeCameraCfg
 from metasim.scenario.lights import DiskLightCfg, SphereLightCfg
-from metasim.utils.obs_utils import ObsSaver
+from metasim.utils import configclass
 from metasim.utils.demo_util import get_traj
+from metasim.utils.obs_utils import ObsSaver
 from metasim.utils.setup_util import get_robot
-from metasim.randomization import DomainRandomizationManager, DRConfig
-from roboverse_learn.il.configs.base_config import BasePolicyCfg, ActionCfg, ObsCfg, EndEffectorCfg
+from roboverse_learn.il.configs.base_config import ActionCfg, BasePolicyCfg, EndEffectorCfg, ObsCfg
 
 
 @configclass
@@ -86,13 +88,17 @@ class OpenVLARunner:
         self.DATA_STAT = json.load(open(stats_path)) if os.path.exists(stats_path) else {}
 
         self.processor = AutoProcessor.from_pretrained(self.model_path, trust_remote_code=True)
-        self.model = AutoModelForVision2Seq.from_pretrained(
-            self.model_path,
-            torch_dtype=torch.bfloat16,
-            low_cpu_mem_usage=True,
-            trust_remote_code=True,
-            attn_implementation="flash_attention_2",
-        ).to(self.device).eval()
+        self.model = (
+            AutoModelForVision2Seq.from_pretrained(
+                self.model_path,
+                torch_dtype=torch.bfloat16,
+                low_cpu_mem_usage=True,
+                trust_remote_code=True,
+                attn_implementation="flash_attention_2",
+            )
+            .to(self.device)
+            .eval()
+        )
 
         # Important: give norm stats to the model; unnorm_key used in predict_action
         self.model.norm_stats = self.DATA_STAT
@@ -102,6 +108,7 @@ class OpenVLARunner:
     # ---------------- IK ----------------
     def _setup_ik(self):
         from metasim.utils.ik_solver import setup_ik_solver
+
         self.robot_cfg = self.scenario.robots[0]
         self.ik_solver = setup_ik_solver(self.robot_cfg, self.solver)
 
@@ -129,14 +136,16 @@ class OpenVLARunner:
             instruction = self.env.task_env.task_desc
         else:
             # Generate instruction from task name
-            task_desc = self.task_name.replace('_', ' ')
+            task_desc = self.task_name.replace("_", " ")
             instruction = task_desc[0].upper() + task_desc[1:]
 
         # Process inputs manually for OpenVLAForActionPrediction
         prompt = f"In: What action should the robot take to {instruction}?\nOut:"
         inputs = self.processor(text=prompt, images=image, return_tensors="pt")
-        inputs = {k: v.to(self.device, dtype=torch.bfloat16 if v.dtype == torch.float32 else v.dtype)
-                 for k, v in inputs.items()}
+        inputs = {
+            k: v.to(self.device, dtype=torch.bfloat16 if v.dtype == torch.float32 else v.dtype)
+            for k, v in inputs.items()
+        }
 
         # Use the model's predict_action method with input_ids
         with torch.no_grad():
@@ -144,7 +153,7 @@ class OpenVLARunner:
                 input_ids=inputs["input_ids"],
                 pixel_values=inputs["pixel_values"],
                 unnorm_key="bridge_orig",
-                do_sample=False
+                do_sample=False,
             )
 
         print(f"VLA model output (denormalized): pos={action[:3]}, rot={action[3:6]}, gripper={action[6]}")
@@ -172,8 +181,8 @@ class OpenVLARunner:
     def ee_control_actions(self, obs) -> list[dict]:
         """Δ-pose (local) -> target EE pose -> cuRobo IK -> joint targets."""
         # 1) VLA action
-        with torch.no_grad():                     # only VLA forward is no-grad
-            action = self.predict_action(obs)     # (B,7)
+        with torch.no_grad():  # only VLA forward is no-grad
+            action = self.predict_action(obs)  # (B,7)
         num_envs = action.shape[0]
 
         # 2) Robot state (TensorState -> tensors)
@@ -184,8 +193,16 @@ class OpenVLARunner:
         inverse_reorder_idx = [reorder_idx.index(i) for i in range(len(reorder_idx))]
         joint_pos_raw = rs.joint_pos if isinstance(rs.joint_pos, torch.Tensor) else torch.tensor(rs.joint_pos)
         curr_robot_q = joint_pos_raw[:, inverse_reorder_idx].to(self.device).float()
-        robot_ee_state = (rs.body_state if isinstance(rs.body_state, torch.Tensor) else torch.tensor(rs.body_state)).to(self.device).float()
-        robot_root_state = (rs.root_state if isinstance(rs.root_state, torch.Tensor) else torch.tensor(rs.root_state)).to(self.device).float()
+        robot_ee_state = (
+            (rs.body_state if isinstance(rs.body_state, torch.Tensor) else torch.tensor(rs.body_state))
+            .to(self.device)
+            .float()
+        )
+        robot_root_state = (
+            (rs.root_state if isinstance(rs.root_state, torch.Tensor) else torch.tensor(rs.root_state))
+            .to(self.device)
+            .float()
+        )
 
         if self.ee_body_idx is None:
             self.ee_body_idx = rs.body_names.index(self.ee_body_name)
@@ -218,7 +235,7 @@ class OpenVLARunner:
 
         # Convert euler angles to quaternion using scipy
         ee_rot_delta_np = ee_rot_delta.cpu().numpy()
-        ee_quat_delta_rot = Rotation.from_euler('XYZ', ee_rot_delta_np)
+        ee_quat_delta_rot = Rotation.from_euler("XYZ", ee_rot_delta_np)
         ee_quat_delta = self.quat_from_scipy(ee_quat_delta_rot.as_quat(), self.device)
 
         gripper_open = action[:num_envs, -1]
@@ -237,10 +254,13 @@ class OpenVLARunner:
 
         # 5) Gripper control
         from metasim.utils.ik_solver import process_gripper_command
+
         gripper_widths = process_gripper_command(gripper_open, self.robot_cfg, self.device)
 
         # Compose robot command
-        actions = self.ik_solver.compose_joint_action(q_solution, gripper_widths, current_q=curr_robot_q, return_dict=True)
+        actions = self.ik_solver.compose_joint_action(
+            q_solution, gripper_widths, current_q=curr_robot_q, return_dict=True
+        )
         return actions
 
     def reset(self):
@@ -269,6 +289,7 @@ def evaluate_episode(
     # Reset environment
     if randomization_manager is not None and init_states is not None:
         from roboverse_learn.il.act.act_eval_runner import ensure_clean_state
+
         # Use task_env.reset() directly to pass states parameter
         obs, info = env.task_env.reset(states=[init_states[demo_idx]])
         ensure_clean_state(env.task_env.handler, expected_state=None)
@@ -316,13 +337,20 @@ def evaluate_episode(
 
 def main():
     parser = argparse.ArgumentParser(description="OpenVLA Evaluation (EE control + IK)")
-    parser.add_argument("--model_path", type=str, default="openvla_runs/openvla-7b+roboverse_dataset+b16+lr-0.0005+lora-r32+dropout-0.0")
+    parser.add_argument(
+        "--model_path", type=str, default="openvla_runs/openvla-7b+roboverse_dataset+b16+lr-0.0005+lora-r32+dropout-0.0"
+    )
     parser.add_argument("--task", type=str, default="pick_butter")
     parser.add_argument("--robot", type=str, default="franka")
-    parser.add_argument("--sim", type=str, default="mujoco",
-                        choices=["isaacgym", "isaacsim", "isaaclab", "genesis", "pybullet", "sapien2", "sapien3", "mujoco", "mjx"])
-    parser.add_argument("--solver", type=str, default="pyroki", choices=["curobo", "pyroki"],
-                        help="IK solver to use: curobo or pyroki")
+    parser.add_argument(
+        "--sim",
+        type=str,
+        default="mujoco",
+        choices=["isaacgym", "isaacsim", "isaaclab", "genesis", "pybullet", "sapien2", "sapien3", "mujoco", "mjx"],
+    )
+    parser.add_argument(
+        "--solver", type=str, default="pyroki", choices=["curobo", "pyroki"], help="IK solver to use: curobo or pyroki"
+    )
     parser.add_argument("--num_envs", type=int, default=1)
     parser.add_argument("--num_episodes", type=int, default=1)
     parser.add_argument("--max_steps", type=int, default=250)
@@ -336,23 +364,22 @@ def main():
         type=int,
         default=0,
         choices=[0, 1, 2, 3],
-        help="Randomization level: 0=None, 1=Scene+Material, 2=+Light, 3=+Camera"
+        help="Randomization level: 0=None, 1=Scene+Material, 2=+Light, 3=+Camera",
     )
     parser.add_argument(
         "--scene_mode",
         type=int,
         default=0,
         choices=[0, 1, 2, 3],
-        help="Scene mode: 0=Manual, 1=USD Table, 2=USD Scene, 3=Full USD"
+        help="Scene mode: 0=Manual, 1=USD Table, 2=USD Scene, 3=Full USD",
     )
     parser.add_argument(
         "--randomization_seed",
         type=int,
         default=None,
-        help="Seed for reproducible randomization. If None, uses random seed"
+        help="Seed for reproducible randomization. If None, uses random seed",
     )
     args = parser.parse_args()
-
 
     if args.device.startswith("cuda") and not torch.cuda.is_available():
         print("CUDA not available, switching to CPU")
@@ -456,6 +483,7 @@ def main():
     randomization_manager = None
     if args.level > 0:
         from dataclasses import dataclass as dc
+
         @dc
         class SimpleRenderCfg:
             mode: str = render_mode
@@ -469,9 +497,11 @@ def main():
             scenario=env.scenario,
             handler=env.task_env.handler,
             init_states=init_states,
-            render_cfg=SimpleRenderCfg(mode=render_mode)
+            render_cfg=SimpleRenderCfg(mode=render_mode),
         )
-        print(f"Domain Randomization enabled: level={args.level}, scene_mode={args.scene_mode}, seed={args.randomization_seed}")
+        print(
+            f"Domain Randomization enabled: level={args.level}, scene_mode={args.scene_mode}, seed={args.randomization_seed}"
+        )
 
     start_time = time.time()
     eval_stats = {"total_episodes": 0, "total_successes": 0, "total_rewards": [], "episode_results": []}
@@ -484,10 +514,14 @@ def main():
         demo_idx = ep % len(init_states) if randomization_manager is not None else 0
 
         ep_res = evaluate_episode(
-            env, runner, args.max_steps, ep + 1, args.output_dir,
+            env,
+            runner,
+            args.max_steps,
+            ep + 1,
+            args.output_dir,
             randomization_manager=randomization_manager,
             demo_idx=demo_idx,
-            init_states=init_states if randomization_manager is not None else None
+            init_states=init_states if randomization_manager is not None else None,
         )
 
         eval_stats["total_episodes"] += 1
@@ -520,12 +554,17 @@ def main():
         ts = time.strftime("%Y%m%d_%H%M%S")
         out_path = os.path.join(args.output_dir, f"openvla_eval_{args.task}_{ts}.json")
         with open(out_path, "w", encoding="utf-8") as f:
-            json.dump({
-                "config": vars(args),
-                "eval_stats": eval_stats,
-                "timestamp": ts,
-                "dr_config": {"level": args.level, "scene_mode": args.scene_mode, "seed": args.randomization_seed}
-            }, f, indent=2, ensure_ascii=False)
+            json.dump(
+                {
+                    "config": vars(args),
+                    "eval_stats": eval_stats,
+                    "timestamp": ts,
+                    "dr_config": {"level": args.level, "scene_mode": args.scene_mode, "seed": args.randomization_seed},
+                },
+                f,
+                indent=2,
+                ensure_ascii=False,
+            )
 
     try:
         env.close()

--- a/roboverse_learn/vla/SmolVLA/convert_roboverse_to_lerobot.py
+++ b/roboverse_learn/vla/SmolVLA/convert_roboverse_to_lerobot.py
@@ -39,9 +39,7 @@ import tyro
 try:
     from lerobot.datasets.lerobot_dataset import HF_LEROBOT_HOME, LeRobotDataset
 except ImportError as exc:
-    raise ImportError(
-        "Install `lerobot` before running this script (e.g. `pip install lerobot`)."
-    ) from exc
+    raise ImportError("Install `lerobot` before running this script (e.g. `pip install lerobot`).") from exc
 
 
 @dataclass
@@ -80,9 +78,7 @@ def _first_frame_shape(video_path: Path) -> tuple[int, int, int]:
     try:
         import imageio.v3 as iio
     except ImportError as exc:
-        raise ImportError(
-            "Install `imageio` and `imageio-ffmpeg` to decode RoboVerse videos."
-        ) from exc
+        raise ImportError("Install `imageio` and `imageio-ffmpeg` to decode RoboVerse videos.") from exc
     frame = iio.imread(video_path, index=0)
     return tuple(frame.shape)
 
@@ -92,9 +88,7 @@ def _frame_iter(video_path: Path):
     try:
         import imageio.v3 as iio
     except ImportError as exc:
-        raise ImportError(
-            "Install `imageio` and `imageio-ffmpeg` to decode RoboVerse videos."
-        ) from exc
+        raise ImportError("Install `imageio` and `imageio-ffmpeg` to decode RoboVerse videos.") from exc
     return iio.imiter(video_path, plugin="FFMPEG")
 
 
@@ -117,7 +111,7 @@ def convert(args: Args) -> None:
     action_dim = len(first_meta[args.action_key][0])
     frame_shape = _first_frame_shape(episode_dirs[0] / args.video_name)
 
-    print(f"Dataset configuration:")
+    print("Dataset configuration:")
     print(f"  State dimension: {state_dim}")
     print(f"  Action dimension: {action_dim}")
     print(f"  Frame shape: {frame_shape}")
@@ -128,9 +122,7 @@ def convert(args: Args) -> None:
             print(f"Removing existing dataset at {output_dir}")
             shutil.rmtree(output_dir)
         else:
-            raise FileExistsError(
-                f"Dataset already exists at {output_dir}. Pass --overwrite to replace it."
-            )
+            raise FileExistsError(f"Dataset already exists at {output_dir}. Pass --overwrite to replace it.")
 
     dataset = LeRobotDataset.create(
         repo_id=args.repo_id,
@@ -206,13 +198,13 @@ def convert(args: Args) -> None:
         if (episode_idx + 1) % 10 == 0:
             print(f"Progress: {written} episodes written, {skipped} skipped")
 
-    print(f"\n{'='*60}")
-    print(f"Conversion complete!")
+    print(f"\n{'=' * 60}")
+    print("Conversion complete!")
     print(f"  Total episodes processed: {len(episode_dirs)}")
     print(f"  Successfully written: {written}")
     print(f"  Skipped: {skipped}")
     print(f"  Output: {output_dir}")
-    print(f"{'='*60}")
+    print(f"{'=' * 60}")
 
     if written == 0:
         raise RuntimeError("No episodes were converted; check dataset integrity.")

--- a/roboverse_learn/vla/SmolVLA/roboverse_smolvla_policy.py
+++ b/roboverse_learn/vla/SmolVLA/roboverse_smolvla_policy.py
@@ -6,15 +6,15 @@ to SmolVLA's expected format within the LeRobot training pipeline.
 """
 
 import dataclasses
-from typing import Dict, Any
+from typing import Any, Dict
 
 import torch
 import torch.nn as nn
 
 __all__ = [
+    "RoboVerseSmolVLAConfig",
     "RoboVerseSmolVLAInputs",
     "RoboVerseSmolVLAOutputs",
-    "RoboVerseSmolVLAConfig",
     "create_roboverse_transforms",
     "get_roboverse_data_config",
 ]
@@ -68,10 +68,7 @@ class RoboVerseSmolVLAInputs(nn.Module):
             # Resize if needed
             if image.shape[-2:] != self.image_size:
                 image = torch.nn.functional.interpolate(
-                    image,
-                    size=self.image_size,
-                    mode='bilinear',
-                    align_corners=False
+                    image, size=self.image_size, mode="bilinear", align_corners=False
                 )
 
             output["image"] = image
@@ -164,14 +161,9 @@ def create_roboverse_transforms(config: RoboVerseSmolVLAConfig = None):
     if config is None:
         config = RoboVerseSmolVLAConfig()
 
-    input_transform = RoboVerseSmolVLAInputs(
-        image_size=config.image_size,
-        normalize_image=config.normalize_image
-    )
+    input_transform = RoboVerseSmolVLAInputs(image_size=config.image_size, normalize_image=config.normalize_image)
 
-    output_transform = RoboVerseSmolVLAOutputs(
-        use_first_action=config.use_first_action
-    )
+    output_transform = RoboVerseSmolVLAOutputs(use_first_action=config.use_first_action)
 
     return input_transform, output_transform
 

--- a/roboverse_learn/vla/SmolVLA/smolvla_eval.py
+++ b/roboverse_learn/vla/SmolVLA/smolvla_eval.py
@@ -7,13 +7,13 @@ This script evaluates a fine-tuned SmolVLA model on RoboVerse tasks.
 
 import argparse
 import json
+import multiprocessing
 import os
 import sys
 import time
-import multiprocessing
 from collections import deque
 from pathlib import Path
-from typing import Dict, Any
+from typing import Any, Dict
 
 import numpy as np
 import torch
@@ -22,23 +22,25 @@ from PIL import Image
 # Add parent directories to path
 sys.path.append(str(Path(__file__).parent.parent.parent.parent))
 
-import metasim
 import gymnasium as gym
 
+import metasim
+
 metasim.register_gym_envs()
-from metasim.utils import configclass
+from metasim.randomization import DomainRandomizationManager, DRConfig
 from metasim.scenario.cameras import PinholeCameraCfg
 from metasim.scenario.lights import DiskLightCfg, SphereLightCfg
-from metasim.utils.obs_utils import ObsSaver
+from metasim.utils import configclass
 from metasim.utils.demo_util import get_traj
+from metasim.utils.obs_utils import ObsSaver
 from metasim.utils.setup_util import get_robot
-from metasim.randomization import DomainRandomizationManager, DRConfig
-from roboverse_learn.il.configs.base_config import BasePolicyCfg, ActionCfg, ObsCfg, EndEffectorCfg
+from roboverse_learn.il.configs.base_config import ActionCfg, BasePolicyCfg, EndEffectorCfg, ObsCfg
 
 
 @configclass
 class SmolVLAPolicyCfg(BasePolicyCfg):
     """Configuration for SmolVLA policy."""
+
     name: str = "SmolVLAPolicy"
     action_config: ActionCfg = ActionCfg(
         action_type="ee",
@@ -76,10 +78,10 @@ class SmolVLARunner:
         # Get the base environment for accessing handler
         # GymEnvWrapper has a task_env attribute which contains the handler
         env_unwrapped = env
-        while hasattr(env_unwrapped, 'unwrapped') and env_unwrapped != env_unwrapped.unwrapped:
+        while hasattr(env_unwrapped, "unwrapped") and env_unwrapped != env_unwrapped.unwrapped:
             env_unwrapped = env_unwrapped.unwrapped
         # Access handler through task_env if it exists
-        if hasattr(env_unwrapped, 'task_env'):
+        if hasattr(env_unwrapped, "task_env"):
             self.env_base = env_unwrapped.task_env
         else:
             self.env_base = env_unwrapped
@@ -101,19 +103,25 @@ class SmolVLARunner:
 
         try:
             from lerobot.policies.smolvla.modeling_smolvla import SmolVLAPolicy
+
             self.model = SmolVLAPolicy.from_pretrained(checkpoint_path)
             self.model = self.model.to(self.device).eval()
             self.use_lerobot = True
         except Exception as e:
             try:
                 from transformers import AutoModel, AutoProcessor
+
                 self.processor = AutoProcessor.from_pretrained(checkpoint_path, trust_remote_code=True)
-                self.model = AutoModel.from_pretrained(
-                    checkpoint_path,
-                    torch_dtype=torch.bfloat16,
-                    low_cpu_mem_usage=True,
-                    trust_remote_code=True,
-                ).to(self.device).eval()
+                self.model = (
+                    AutoModel.from_pretrained(
+                        checkpoint_path,
+                        torch_dtype=torch.bfloat16,
+                        low_cpu_mem_usage=True,
+                        trust_remote_code=True,
+                    )
+                    .to(self.device)
+                    .eval()
+                )
                 self.use_lerobot = False
             except Exception as e2:
                 raise RuntimeError(f"Failed to load SmolVLA model from {checkpoint_path}: {e2}")
@@ -127,6 +135,7 @@ class SmolVLARunner:
     def _setup_ik(self):
         """Setup IK solver for end-effector control."""
         from metasim.utils.ik_solver import setup_ik_solver
+
         self.robot_cfg = self.scenario.robots[0]
         self.ik_solver = setup_ik_solver(self.robot_cfg, self.solver)
 
@@ -157,15 +166,15 @@ class SmolVLARunner:
         image = Image.fromarray(rgb_data.detach().cpu().numpy())
 
         # Get task description (unwrap to access task_env)
-        task_env = getattr(self.env, 'unwrapped', self.env)
-        if hasattr(task_env, 'task_env'):
+        task_env = getattr(self.env, "unwrapped", self.env)
+        if hasattr(task_env, "task_env"):
             task_env = task_env.task_env
         instruction = getattr(task_env, "task_desc", self.task_name)
 
         if self.use_lerobot:
             # Prepare input batch for LeRobot model
-            from torchvision.transforms import ToTensor
             import torch
+            from torchvision.transforms import ToTensor
 
             # Convert image to tensor and add batch dimension
             image_tensor = ToTensor()(image).unsqueeze(0).to(self.device)
@@ -184,10 +193,7 @@ class SmolVLARunner:
 
             # Tokenize instruction
             tokenized = self.model.model.vlm_with_expert.processor.tokenizer(
-                instruction,
-                return_tensors="pt",
-                padding=True,
-                truncation=True
+                instruction, return_tensors="pt", padding=True, truncation=True
             )
 
             batch = {
@@ -201,10 +207,12 @@ class SmolVLARunner:
         else:
             prompt = f"What action should the robot take to {instruction}?"
             inputs = self.processor(text=prompt, images=image, return_tensors="pt")
-            inputs = {k: v.to(self.device, dtype=torch.bfloat16 if v.dtype == torch.float32 else v.dtype)
-                     for k, v in inputs.items()}
+            inputs = {
+                k: v.to(self.device, dtype=torch.bfloat16 if v.dtype == torch.float32 else v.dtype)
+                for k, v in inputs.items()
+            }
             outputs = self.model(**inputs)
-            action = outputs.action if hasattr(outputs, 'action') else outputs[0]
+            action = outputs.action if hasattr(outputs, "action") else outputs[0]
 
         # Convert to tensor if needed
         if not isinstance(action, torch.Tensor):
@@ -241,8 +249,16 @@ class SmolVLARunner:
         joint_pos_raw = rs.joint_pos if isinstance(rs.joint_pos, torch.Tensor) else torch.tensor(rs.joint_pos)
         curr_robot_q = joint_pos_raw[:, inverse_reorder_idx].to(self.device).float()
 
-        robot_ee_state = (rs.body_state if isinstance(rs.body_state, torch.Tensor) else torch.tensor(rs.body_state)).to(self.device).float()
-        robot_root_state = (rs.root_state if isinstance(rs.root_state, torch.Tensor) else torch.tensor(rs.root_state)).to(self.device).float()
+        robot_ee_state = (
+            (rs.body_state if isinstance(rs.body_state, torch.Tensor) else torch.tensor(rs.body_state))
+            .to(self.device)
+            .float()
+        )
+        robot_root_state = (
+            (rs.root_state if isinstance(rs.root_state, torch.Tensor) else torch.tensor(rs.root_state))
+            .to(self.device)
+            .float()
+        )
 
         # Get end-effector pose
         if self.ee_body_idx is None:
@@ -262,9 +278,7 @@ class SmolVLARunner:
         gripper_open = action[:num_envs, 6]
 
         # Convert rotation delta to quaternion
-        ee_quat_delta = transforms.matrix_to_quaternion(
-            transforms.euler_angles_to_matrix(ee_rot_delta, "XYZ")
-        )
+        ee_quat_delta = transforms.matrix_to_quaternion(transforms.euler_angles_to_matrix(ee_rot_delta, "XYZ"))
 
         # Compute target pose
         ee_pos_target = curr_ee_pos_local + ee_pos_delta
@@ -275,6 +289,7 @@ class SmolVLARunner:
 
         # Process gripper command
         from metasim.utils.ik_solver import process_gripper_command
+
         gripper_widths = process_gripper_command(gripper_open, self.robot_cfg, self.device)
 
         # Compose final action
@@ -314,9 +329,9 @@ def evaluate_episode(
 
         # Access task_env through wrapper
         env_unwrapped = env
-        while hasattr(env_unwrapped, 'unwrapped') and env_unwrapped != env_unwrapped.unwrapped:
+        while hasattr(env_unwrapped, "unwrapped") and env_unwrapped != env_unwrapped.unwrapped:
             env_unwrapped = env_unwrapped.unwrapped
-        task_env = env_unwrapped.task_env if hasattr(env_unwrapped, 'task_env') else env_unwrapped
+        task_env = env_unwrapped.task_env if hasattr(env_unwrapped, "task_env") else env_unwrapped
 
         # Reset to specific state
         obs, info = task_env.reset(states=[init_states[demo_idx]], env_ids=[0])
@@ -327,20 +342,15 @@ def evaluate_episode(
         # Update gym wrapper state to avoid "ResetNeeded" error
         wrapper = env
         while wrapper is not env_unwrapped:
-            if hasattr(wrapper, '_has_reset'):
+            if hasattr(wrapper, "_has_reset"):
                 wrapper._has_reset = True
-            if hasattr(wrapper, '_episode_steps'):
+            if hasattr(wrapper, "_episode_steps"):
                 wrapper._episode_steps[0] = 0
-            wrapper = wrapper.unwrapped if hasattr(wrapper, 'unwrapped') else wrapper.env
+            wrapper = wrapper.unwrapped if hasattr(wrapper, "unwrapped") else wrapper.env
     else:
         obs, info = env.reset()
 
-    stats = {
-        "steps": 0,
-        "success": False,
-        "total_reward": 0.0,
-        "start_time": time.time()
-    }
+    stats = {"steps": 0, "success": False, "total_reward": 0.0, "start_time": time.time()}
     runner.reset()
 
     # Initialize video saver
@@ -415,20 +425,20 @@ def main():
         type=int,
         default=0,
         choices=[0, 1, 2, 3],
-        help="Randomization level: 0=None, 1=Scene+Material, 2=+Light, 3=+Camera"
+        help="Randomization level: 0=None, 1=Scene+Material, 2=+Light, 3=+Camera",
     )
     parser.add_argument(
         "--scene_mode",
         type=int,
         default=0,
         choices=[0, 1, 2, 3],
-        help="Scene mode: 0=Manual, 1=USD Table, 2=USD Scene, 3=Full USD"
+        help="Scene mode: 0=Manual, 1=USD Table, 2=USD Scene, 3=Full USD",
     )
     parser.add_argument(
         "--randomization_seed",
         type=int,
         default=None,
-        help="Seed for reproducible randomization. If None, uses random seed"
+        help="Seed for reproducible randomization. If None, uses random seed",
     )
     args = parser.parse_args()
 
@@ -516,9 +526,9 @@ def main():
 
     # Access the actual task environment through wrapper
     env_unwrapped = env
-    while hasattr(env_unwrapped, 'unwrapped') and env_unwrapped != env_unwrapped.unwrapped:
+    while hasattr(env_unwrapped, "unwrapped") and env_unwrapped != env_unwrapped.unwrapped:
         env_unwrapped = env_unwrapped.unwrapped
-    task_env = env_unwrapped.task_env if hasattr(env_unwrapped, 'task_env') else env_unwrapped
+    task_env = env_unwrapped.task_env if hasattr(env_unwrapped, "task_env") else env_unwrapped
 
     # Load trajectories for domain randomization
     traj_filepath = task_env.traj_filepath
@@ -529,6 +539,7 @@ def main():
     randomization_manager = None
     if args.level > 0:
         from dataclasses import dataclass as dc
+
         @dc
         class SimpleRenderCfg:
             mode: str = render_mode
@@ -542,9 +553,11 @@ def main():
             scenario=env.unwrapped.scenario,
             handler=task_env.handler,
             init_states=init_states,
-            render_cfg=SimpleRenderCfg(mode=render_mode)
+            render_cfg=SimpleRenderCfg(mode=render_mode),
         )
-        print(f"Domain Randomization enabled: level={args.level}, scene_mode={args.scene_mode}, seed={args.randomization_seed}")
+        print(
+            f"Domain Randomization enabled: level={args.level}, scene_mode={args.scene_mode}, seed={args.randomization_seed}"
+        )
 
     # Create runner
     runner = SmolVLARunner(
@@ -560,12 +573,7 @@ def main():
 
     # Run evaluation
     start_time = time.time()
-    eval_stats = {
-        "total_episodes": 0,
-        "total_successes": 0,
-        "total_rewards": [],
-        "episode_results": []
-    }
+    eval_stats = {"total_episodes": 0, "total_successes": 0, "total_rewards": [], "episode_results": []}
 
     for ep in range(args.num_episodes):
         print(f"\n{'=' * 50}")
@@ -575,10 +583,14 @@ def main():
         demo_idx = ep % len(init_states) if randomization_manager is not None else 0
 
         ep_res = evaluate_episode(
-            env, runner, args.max_steps, ep + 1, args.output_dir,
+            env,
+            runner,
+            args.max_steps,
+            ep + 1,
+            args.output_dir,
             randomization_manager=randomization_manager,
             demo_idx=demo_idx,
-            init_states=init_states if randomization_manager is not None else None
+            init_states=init_states if randomization_manager is not None else None,
         )
 
         eval_stats["total_episodes"] += 1
@@ -611,12 +623,16 @@ def main():
     ts = time.strftime("%Y%m%d_%H%M%S")
     result_path = os.path.join(args.output_dir, f"smolvla_eval_{args.task}_{ts}.json")
     with open(result_path, "w") as f:
-        json.dump({
-            "config": vars(args),
-            "eval_stats": eval_stats,
-            "timestamp": ts,
-            "dr_config": {"level": args.level, "scene_mode": args.scene_mode, "seed": args.randomization_seed}
-        }, f, indent=2)
+        json.dump(
+            {
+                "config": vars(args),
+                "eval_stats": eval_stats,
+                "timestamp": ts,
+                "dr_config": {"level": args.level, "scene_mode": args.scene_mode, "seed": args.randomization_seed},
+            },
+            f,
+            indent=2,
+        )
     print(f"\nResults saved to: {result_path}")
 
     # Cleanup

--- a/roboverse_learn/vla/SmolVLA/smolvla_eval.py
+++ b/roboverse_learn/vla/SmolVLA/smolvla_eval.py
@@ -124,7 +124,7 @@ class SmolVLARunner:
                 )
                 self.use_lerobot = False
             except Exception as e2:
-                raise RuntimeError(f"Failed to load SmolVLA model from {checkpoint_path}: {e2}")
+                raise RuntimeError(f"Failed to load SmolVLA model from {checkpoint_path}: {e2}") from e2
 
         # Load dataset statistics if available
         stats_path = os.path.join(self.model_path, "dataset_statistics.json")

--- a/roboverse_learn/vla/pi0/config_snippet.py
+++ b/roboverse_learn/vla/pi0/config_snippet.py
@@ -5,10 +5,10 @@ import dataclasses
 import pathlib
 from typing import override
 
+from openpi.policies import roboverse_policy
 from openpi.training import config as _config
 from openpi.training import model as _model
 from openpi.training import transforms as _transforms
-from openpi.policies import roboverse_policy
 
 
 @dataclasses.dataclass(frozen=True)
@@ -18,20 +18,16 @@ class LeRobotRoboVerseDataConfig(_config.DataConfigFactory):
     extra_delta_transform: bool = True
 
     @override
-    def create(
-        self, assets_dirs: pathlib.Path, model_config: _model.BaseModelConfig
-    ) -> _config.DataConfig:
+    def create(self, assets_dirs: pathlib.Path, model_config: _model.BaseModelConfig) -> _config.DataConfig:
         repack_transform = _transforms.Group(
             inputs=[
-                _transforms.RepackTransform(
-                    {
-                        "observation/image": "image",
-                        # "observation/wrist_image": "wrist_image",  # RoboVerse has a single view now
-                        "observation/state": "state",
-                        "actions": "actions",
-                        "prompt": "prompt",
-                    }
-                )
+                _transforms.RepackTransform({
+                    "observation/image": "image",
+                    # "observation/wrist_image": "wrist_image",  # RoboVerse has a single view now
+                    "observation/state": "state",
+                    "actions": "actions",
+                    "prompt": "prompt",
+                })
             ]
         )
 

--- a/roboverse_learn/vla/pi0/convert_roboverse_to_lerobot.py
+++ b/roboverse_learn/vla/pi0/convert_roboverse_to_lerobot.py
@@ -37,9 +37,7 @@ import tyro
 try:
     from lerobot.common.datasets.lerobot_dataset import HF_LEROBOT_HOME, LeRobotDataset
 except ImportError as exc:  # pragma: no cover - optional dependency
-    raise ImportError(
-        "Install `lerobot` before running this script (e.g. `uv pip install lerobot`)."
-    ) from exc
+    raise ImportError("Install `lerobot` before running this script (e.g. `uv pip install lerobot`).") from exc
 
 
 @dataclass
@@ -75,9 +73,7 @@ def _first_frame_shape(video_path: Path) -> tuple[int, int, int]:
     try:
         import imageio.v3 as iio
     except ImportError as exc:  # pragma: no cover - optional dependency
-        raise ImportError(
-            "Install `imageio` and `imageio-ffmpeg` to decode RoboVerse videos."
-        ) from exc
+        raise ImportError("Install `imageio` and `imageio-ffmpeg` to decode RoboVerse videos.") from exc
     frame = iio.imread(video_path, index=0)
     return tuple(frame.shape)
 
@@ -86,9 +82,7 @@ def _frame_iter(video_path: Path):
     try:
         import imageio.v3 as iio
     except ImportError as exc:  # pragma: no cover - optional dependency
-        raise ImportError(
-            "Install `imageio` and `imageio-ffmpeg` to decode RoboVerse videos."
-        ) from exc
+        raise ImportError("Install `imageio` and `imageio-ffmpeg` to decode RoboVerse videos.") from exc
     return iio.imiter(video_path, plugin="FFMPEG")
 
 
@@ -113,9 +107,7 @@ def convert(args: Args) -> None:
         if args.overwrite:
             shutil.rmtree(output_dir)
         else:
-            raise FileExistsError(
-                f"Dataset already exists at {output_dir}. Pass --overwrite to replace it."
-            )
+            raise FileExistsError(f"Dataset already exists at {output_dir}. Pass --overwrite to replace it.")
 
     dataset = LeRobotDataset.create(
         repo_id=args.repo_id,
@@ -160,14 +152,12 @@ def convert(args: Args) -> None:
             if frame_idx >= total:
                 break
             np_frame = np.asarray(frame, dtype=np.uint8)
-            dataset.add_frame(
-                {
-                    "image": np_frame,
-                    "state": states[frame_idx],
-                    "actions": actions[frame_idx],
-                    "task": prompt,
-                }
-            )
+            dataset.add_frame({
+                "image": np_frame,
+                "state": states[frame_idx],
+                "actions": actions[frame_idx],
+                "task": prompt,
+            })
             frame_count += 1
 
         if frame_count == 0:

--- a/roboverse_learn/vla/pi0/pi_eval.py
+++ b/roboverse_learn/vla/pi0/pi_eval.py
@@ -10,25 +10,24 @@ from typing import Any, Dict
 
 import numpy as np
 import torch
-from PIL import Image
 
 sys.path.append(str(Path(__file__).resolve().parents[2]))
 
-import metasim
 from gymnasium import make_vec
+
+import metasim
 from metasim.scenario.cameras import PinholeCameraCfg
 
 metasim.register_gym_envs()
-from metasim.scenario.lights import DiskLightCfg, SphereLightCfg
-from metasim.utils import configclass
-from metasim.utils.obs_utils import ObsSaver
-from metasim.utils.ik_solver import process_gripper_command, setup_ik_solver
-from metasim.utils.demo_util import get_traj
-from metasim.utils.setup_util import get_robot
-from metasim.randomization import DomainRandomizationManager, DRConfig
-
 from openpi_client import image_tools, websocket_client_policy
 
+from metasim.randomization import DomainRandomizationManager, DRConfig
+from metasim.scenario.lights import DiskLightCfg, SphereLightCfg
+from metasim.utils import configclass
+from metasim.utils.demo_util import get_traj
+from metasim.utils.ik_solver import process_gripper_command, setup_ik_solver
+from metasim.utils.obs_utils import ObsSaver
+from metasim.utils.setup_util import get_robot
 from roboverse_learn.il.configs.base_config import ActionCfg, BasePolicyCfg, ObsCfg
 
 
@@ -142,22 +141,13 @@ class PiPolicyRunner:
         joint_target = torch.cat([arm_target, gripper_widths], dim=-1)
 
         joint_names = list(self.robot_cfg.joint_limits.keys())
-        assert len(joint_names) == joint_target.shape[1], \
+        assert len(joint_names) == joint_target.shape[1], (
             f"Joint count mismatch: {len(joint_names)} names vs {joint_target.shape[1]} targets"
-        dof_pos_target = {
-            joint_name: float(joint_target[0, i].item())
-            for i, joint_name in enumerate(joint_names)
-        }
+        )
+        dof_pos_target = {joint_name: float(joint_target[0, i].item()) for i, joint_name in enumerate(joint_names)}
 
-        actions = [
-            {
-                self.robot_name: {
-                    "dof_pos_target": dof_pos_target
-                }
-            }
-        ]
+        actions = [{self.robot_name: {"dof_pos_target": dof_pos_target}}]
         return actions
-
 
     def _request_action_chunk(self, policy_obs: Dict[str, Any]) -> None:
         response = self.client.infer(policy_obs)
@@ -173,11 +163,7 @@ class PiPolicyRunner:
     def infer_action(self, obs) -> list[dict]:
         current_q = self._extract_robot_state(obs)
 
-        if (
-            self.cached_actions is None
-            or self.cache_remaining <= 0
-            or self.cache_index >= len(self.cached_actions)
-        ):
+        if self.cached_actions is None or self.cache_remaining <= 0 or self.cache_index >= len(self.cached_actions):
             policy_obs = self._build_policy_observation(obs)
             self._request_action_chunk(policy_obs)
 
@@ -220,6 +206,7 @@ def evaluate_episode(
     # Reset environment
     if randomization_manager is not None and init_states is not None:
         from roboverse_learn.il.act.act_eval_runner import ensure_clean_state
+
         # Use task_env.reset() directly to pass states parameter
         obs, info = env.task_env.reset(states=[init_states[demo_idx]])
         ensure_clean_state(env.task_env.handler, expected_state=init_states[demo_idx])
@@ -269,43 +256,60 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Evaluate π policies via websocket server")
     parser.add_argument("--task", type=str, default="pick_butter")
     parser.add_argument("--robot", type=str, default="franka")
-    parser.add_argument("--sim", type=str, default="mujoco",
-                        choices=["isaacgym", "isaacsim", "isaaclab", "genesis", "pybullet", "sapien2", "sapien3", "mujoco", "mjx"])
+    parser.add_argument(
+        "--sim",
+        type=str,
+        default="mujoco",
+        choices=["isaacgym", "isaacsim", "isaaclab", "genesis", "pybullet", "sapien2", "sapien3", "mujoco", "mjx"],
+    )
     parser.add_argument("--policy-host", type=str, default="localhost")
     parser.add_argument("--policy-port", type=int, default=8000)
     parser.add_argument("--num_envs", type=int, default=1)
     parser.add_argument("--num_episodes", type=int, default=1)
     parser.add_argument("--max_steps", type=int, default=250)
     parser.add_argument("--device", type=str, default="cuda" if torch.cuda.is_available() else "cpu")
-    parser.add_argument("--solver", type=str, default="pyroki", choices=["curobo", "pyroki"],
-                        help="IK backend used for composing joint commands")
+    parser.add_argument(
+        "--solver",
+        type=str,
+        default="pyroki",
+        choices=["curobo", "pyroki"],
+        help="IK backend used for composing joint commands",
+    )
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--output-dir", type=str, default="./pi_eval_output")
     parser.add_argument("--image-size", type=int, default=224)
-    parser.add_argument("--gripper-threshold", type=float, default=0.02,
-                        help="Threshold on finger joint values to treat the gripper as open")
-    parser.add_argument("--actions-per-call", type=int, default=0,
-                        help="Number of cached actions to use before requesting a new chunk (0 = consume entire chunk)")
+    parser.add_argument(
+        "--gripper-threshold",
+        type=float,
+        default=0.02,
+        help="Threshold on finger joint values to treat the gripper as open",
+    )
+    parser.add_argument(
+        "--actions-per-call",
+        type=int,
+        default=0,
+        help="Number of cached actions to use before requesting a new chunk (0 = consume entire chunk)",
+    )
     # Domain Randomization options
     parser.add_argument(
         "--level",
         type=int,
         default=0,
         choices=[0, 1, 2, 3],
-        help="Randomization level: 0=None, 1=Scene+Material, 2=+Light, 3=+Camera"
+        help="Randomization level: 0=None, 1=Scene+Material, 2=+Light, 3=+Camera",
     )
     parser.add_argument(
         "--scene_mode",
         type=int,
         default=0,
         choices=[0, 1, 2, 3],
-        help="Scene mode: 0=Manual, 1=USD Table, 2=USD Scene, 3=Full USD"
+        help="Scene mode: 0=Manual, 1=USD Table, 2=USD Scene, 3=Full USD",
     )
     parser.add_argument(
         "--randomization_seed",
         type=int,
         default=None,
-        help="Seed for reproducible randomization. If None, uses random seed"
+        help="Seed for reproducible randomization. If None, uses random seed",
     )
     return parser.parse_args()
 
@@ -414,6 +418,7 @@ def main() -> bool:
     randomization_manager = None
     if args.level > 0:
         from dataclasses import dataclass as dc
+
         @dc
         class SimpleRenderCfg:
             mode: str = render_mode
@@ -427,9 +432,11 @@ def main() -> bool:
             scenario=env.scenario,
             handler=env.task_env.handler,
             init_states=init_states,
-            render_cfg=SimpleRenderCfg(mode=render_mode)
+            render_cfg=SimpleRenderCfg(mode=render_mode),
         )
-        print(f"Domain Randomization enabled: level={args.level}, scene_mode={args.scene_mode}, seed={args.randomization_seed}")
+        print(
+            f"Domain Randomization enabled: level={args.level}, scene_mode={args.scene_mode}, seed={args.randomization_seed}"
+        )
 
     start_time = time.time()
     aggregate = {
@@ -447,10 +454,14 @@ def main() -> bool:
         demo_idx = ep % len(init_states) if randomization_manager is not None else 0
 
         result = evaluate_episode(
-            env, runner, args.max_steps, ep + 1, args.output_dir,
+            env,
+            runner,
+            args.max_steps,
+            ep + 1,
+            args.output_dir,
             randomization_manager=randomization_manager,
             demo_idx=demo_idx,
-            init_states=init_states if randomization_manager is not None else None
+            init_states=init_states if randomization_manager is not None else None,
         )
 
         aggregate["total_episodes"] += 1
@@ -482,12 +493,16 @@ def main() -> bool:
     ts = time.strftime("%Y%m%d_%H%M%S")
     report_path = os.path.join(args.output_dir, f"pi_eval_{args.task}_{ts}.json")
     with open(report_path, "w", encoding="utf-8") as f:
-        json.dump({
-            "config": vars(args),
-            "stats": aggregate,
-            "timestamp": ts,
-            "dr_config": {"level": args.level, "scene_mode": args.scene_mode, "seed": args.randomization_seed}
-        }, f, indent=2)
+        json.dump(
+            {
+                "config": vars(args),
+                "stats": aggregate,
+                "timestamp": ts,
+                "dr_config": {"level": args.level, "scene_mode": args.scene_mode, "seed": args.randomization_seed},
+            },
+            f,
+            indent=2,
+        )
     print(f"Saved results to {report_path}")
 
     try:

--- a/roboverse_learn/vla/pi0/roboverse_policy.py
+++ b/roboverse_learn/vla/pi0/roboverse_policy.py
@@ -2,7 +2,6 @@ import dataclasses
 
 import einops
 import numpy as np
-
 from openpi import transforms
 from openpi.models import model as _model
 

--- a/roboverse_learn/vla/pi0/train_config_snippet.py
+++ b/roboverse_learn/vla/pi0/train_config_snippet.py
@@ -1,11 +1,10 @@
 # Training configuration snippet to add to openpi/src/openpi/training/config.py
 # This file is used by train_pi0.sh to automatically register training configs
 
+from openpi.policies import pi0_config
 from openpi.training import config as _config
 from openpi.training import optimizer as _optimizer
 from openpi.training import weight_loaders
-from openpi.policies import pi0_config
-
 
 # π₀.₅ with LoRA configuration
 TrainConfig(
@@ -29,9 +28,7 @@ TrainConfig(
         decay_lr=5e-5,
     ),
     optimizer=_optimizer.AdamW(clip_gradient_norm=1.0),
-    weight_loader=weight_loaders.CheckpointWeightLoader(
-        "gs://openpi-assets/checkpoints/pi05_base/params"
-    ),
+    weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi05_base/params"),
     num_train_steps=30_000,
     freeze_filter=pi0_config.Pi0Config(
         paligemma_variant="gemma_2b_lora",
@@ -62,9 +59,7 @@ TrainConfig(
         decay_lr=5e-5,
     ),
     optimizer=_optimizer.AdamW(clip_gradient_norm=1.0),
-    weight_loader=weight_loaders.CheckpointWeightLoader(
-        "gs://openpi-assets/checkpoints/pi0_base/params"
-    ),
+    weight_loader=weight_loaders.CheckpointWeightLoader("gs://openpi-assets/checkpoints/pi0_base/params"),
     num_train_steps=30_000,
     freeze_filter=pi0_config.Pi0Config(
         paligemma_variant="gemma_2b_lora",

--- a/roboverse_learn/vla/rlds_utils/roboverse/roboverse.py
+++ b/roboverse_learn/vla/rlds_utils/roboverse/roboverse.py
@@ -1,9 +1,9 @@
-from typing import Iterator, Tuple, Any
-import os
 import json
+import os
+from typing import Any, Iterator, Tuple
+
 import imageio.v2 as iio
 import numpy as np
-import tensorflow as tf
 import tensorflow_datasets as tfds
 import tensorflow_hub as hub
 
@@ -25,50 +25,40 @@ class BridgeOrig(tfds.core.GeneratorBasedBuilder):
     def _info(self) -> tfds.core.DatasetInfo:
         """Dataset metadata (features)."""
         return self.dataset_info_from_configs(
-            features=tfds.features.FeaturesDict(
-                {
-                    "steps": tfds.features.Dataset(
-                        {
-                            "observation": tfds.features.FeaturesDict(
-                                {
-                                    "image_0": tfds.features.Image(
-                                        shape=(256, 256, 3), dtype=np.uint8, doc="RGB image (H,W,3)."
-                                    ),
-                                    "image_1": tfds.features.Image(
-                                        shape=(256, 256, 3), dtype=np.uint8, doc="Secondary RGB image (H,W,3)."
-                                    ),
-                                    "state": tfds.features.Tensor(
-                                        shape=(7,), dtype=np.float32, doc="Full state (6 dims EEF + 1 dim gripper)."
-                                    ),
-                                    "EEF_state": tfds.features.Tensor(
-                                        shape=(6,), dtype=np.float32, doc="End-effector state (6 dims: xyz + rpy)."
-                                    ),
-                                    "gripper_state": tfds.features.Tensor(
-                                        shape=(1,), dtype=np.float32, doc="Gripper state (1 dim)."
-                                    ),
-                                }
-                            ),
-                            "action": tfds.features.Tensor(
-                                shape=(7,), dtype=np.float32, doc="Delta action (next_state - current_state) (7 dims)."
-                            ),
-                            "discount": tfds.features.Scalar(dtype=np.float32),
-                            "reward": tfds.features.Scalar(dtype=np.float32),
-                            "is_first": tfds.features.Scalar(dtype=np.bool_),
-                            "is_last": tfds.features.Scalar(dtype=np.bool_),
-                            "is_terminal": tfds.features.Scalar(dtype=np.bool_),
-                            "language_instruction": tfds.features.Text(),
-                            "language_embedding": tfds.features.Tensor(shape=(512,), dtype=np.float32),
-                        }
+            features=tfds.features.FeaturesDict({
+                "steps": tfds.features.Dataset({
+                    "observation": tfds.features.FeaturesDict({
+                        "image_0": tfds.features.Image(shape=(256, 256, 3), dtype=np.uint8, doc="RGB image (H,W,3)."),
+                        "image_1": tfds.features.Image(
+                            shape=(256, 256, 3), dtype=np.uint8, doc="Secondary RGB image (H,W,3)."
+                        ),
+                        "state": tfds.features.Tensor(
+                            shape=(7,), dtype=np.float32, doc="Full state (6 dims EEF + 1 dim gripper)."
+                        ),
+                        "EEF_state": tfds.features.Tensor(
+                            shape=(6,), dtype=np.float32, doc="End-effector state (6 dims: xyz + rpy)."
+                        ),
+                        "gripper_state": tfds.features.Tensor(
+                            shape=(1,), dtype=np.float32, doc="Gripper state (1 dim)."
+                        ),
+                    }),
+                    "action": tfds.features.Tensor(
+                        shape=(7,), dtype=np.float32, doc="Delta action (next_state - current_state) (7 dims)."
                     ),
-                    "episode_metadata": tfds.features.FeaturesDict(
-                        {
-                            "file_path": tfds.features.Text(),
-                            "depth_min": tfds.features.Tensor(shape=(None,), dtype=np.float32),
-                            "depth_max": tfds.features.Tensor(shape=(None,), dtype=np.float32),
-                        }
-                    ),
-                }
-            )
+                    "discount": tfds.features.Scalar(dtype=np.float32),
+                    "reward": tfds.features.Scalar(dtype=np.float32),
+                    "is_first": tfds.features.Scalar(dtype=np.bool_),
+                    "is_last": tfds.features.Scalar(dtype=np.bool_),
+                    "is_terminal": tfds.features.Scalar(dtype=np.bool_),
+                    "language_instruction": tfds.features.Text(),
+                    "language_embedding": tfds.features.Tensor(shape=(512,), dtype=np.float32),
+                }),
+                "episode_metadata": tfds.features.FeaturesDict({
+                    "file_path": tfds.features.Text(),
+                    "depth_min": tfds.features.Tensor(shape=(None,), dtype=np.float32),
+                    "depth_max": tfds.features.Tensor(shape=(None,), dtype=np.float32),
+                }),
+            })
         )
 
     def _split_generators(self, dl_manager: tfds.download.DownloadManager):
@@ -132,7 +122,7 @@ class BridgeOrig(tfds.core.GeneratorBasedBuilder):
             if not os.path.isfile(meta_file):
                 return None
 
-            with open(meta_file, "r") as f:
+            with open(meta_file) as f:
                 meta = json.load(f)
 
             # get keys (support both names)

--- a/roboverse_learn/vla/rlds_utils/test_dataset_transform.py
+++ b/roboverse_learn/vla/rlds_utils/test_dataset_transform.py
@@ -1,51 +1,37 @@
 import argparse
 import importlib
-import tqdm
-import numpy as np
 import os
-os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'  # suppress debug warning messages
-import tensorflow as tf
-import tensorflow_datasets as tfds
 
+import numpy as np
+import tqdm
+
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # suppress debug warning messages
+import tensorflow_datasets as tfds
 from example_transform.transform import transform_step
 
 parser = argparse.ArgumentParser()
-parser.add_argument('dataset_name', help='name of the dataset to visualize')
+parser.add_argument("dataset_name", help="name of the dataset to visualize")
 args = parser.parse_args()
 
 
 TARGET_SPEC = {
-    'observation': {
-        'image': {'shape': (128, 128, 3),
-                  'dtype': np.uint8,
-                  'range': (0, 255)}
+    "observation": {"image": {"shape": (128, 128, 3), "dtype": np.uint8, "range": (0, 255)}},
+    "action": {
+        "shape": (7,),
+        "dtype": np.float32,
+        "range": [
+            (-1, -1, -1, -2 * np.pi, -2 * np.pi, -2 * np.pi, -1, 0),
+            (+1, +1, +1, +2 * np.pi, +2 * np.pi, +2 * np.pi, +1, 1),
+        ],
     },
-    'action': {'shape': (7,),
-               'dtype': np.float32,
-               'range': [(-1, -1, -1, -2*np.pi, -2*np.pi, -2*np.pi, -1, 0),
-                         (+1, +1, +1, +2*np.pi, +2*np.pi, +2*np.pi, +1, 1)]},
-    'discount': {'shape': (),
-                 'dtype': np.float32,
-                 'range': (0, 1)},
-    'reward': {'shape': (),
-               'dtype': np.float32,
-               'range': (0, 1)},
-    'is_first': {'shape': (),
-                 'dtype': np.bool_,
-                 'range': None},
-    'is_last': {'shape': (),
-                'dtype': np.bool_,
-                'range': None},
-    'is_terminal': {'shape': (),
-                    'dtype': np.bool_,
-                    'range': None},
-    'language_instruction': {'shape': (),
-                             'dtype': str,
-                             'range': None},
-    'language_embedding': {'shape': (512,),
-                           'dtype': np.float32,
-                           'range': None},
-    }
+    "discount": {"shape": (), "dtype": np.float32, "range": (0, 1)},
+    "reward": {"shape": (), "dtype": np.float32, "range": (0, 1)},
+    "is_first": {"shape": (), "dtype": np.bool_, "range": None},
+    "is_last": {"shape": (), "dtype": np.bool_, "range": None},
+    "is_terminal": {"shape": (), "dtype": np.bool_, "range": None},
+    "language_instruction": {"shape": (), "dtype": str, "range": None},
+    "language_embedding": {"shape": (512,), "dtype": np.float32, "range": None},
+}
 
 
 def check_elements(target, values):
@@ -54,36 +40,39 @@ def check_elements(target, values):
         if isinstance(values[elem], dict):
             check_elements(target[elem], values[elem])
         else:
-            if target[elem]['shape']:
-                if tuple(values[elem].shape) != target[elem]['shape']:
+            if target[elem]["shape"]:
+                if tuple(values[elem].shape) != target[elem]["shape"]:
                     raise ValueError(
-                        f"Shape of {elem} should be {target[elem]['shape']} but is {tuple(values[elem].shape)}")
-            if not isinstance(values[elem], bytes) and values[elem].dtype != target[elem]['dtype']:
+                        f"Shape of {elem} should be {target[elem]['shape']} but is {tuple(values[elem].shape)}"
+                    )
+            if not isinstance(values[elem], bytes) and values[elem].dtype != target[elem]["dtype"]:
                 raise ValueError(f"Dtype of {elem} should be {target[elem]['dtype']} but is {values[elem].dtype}")
-            if target[elem]['range'] is not None:
-                if isinstance(target[elem]['range'], list):
-                    for vmin, vmax, val in zip(target[elem]['range'][0],
-                                               target[elem]['range'][1],
-                                               values[elem]):
+            if target[elem]["range"] is not None:
+                if isinstance(target[elem]["range"], list):
+                    for vmin, vmax, val in zip(target[elem]["range"][0], target[elem]["range"][1], values[elem]):
                         if not (val >= vmin and val <= vmax):
                             raise ValueError(
-                                f"{elem} is out of range. Should be in {target[elem]['range']} but is {values[elem]}.")
+                                f"{elem} is out of range. Should be in {target[elem]['range']} but is {values[elem]}."
+                            )
                 else:
-                    if not (np.all(values[elem] >= target[elem]['range'][0])
-                            and np.all(values[elem] <= target[elem]['range'][1])):
+                    if not (
+                        np.all(values[elem] >= target[elem]["range"][0])
+                        and np.all(values[elem] <= target[elem]["range"][1])
+                    ):
                         raise ValueError(
-                            f"{elem} is out of range. Should be in {target[elem]['range']} but is {values[elem]}.")
+                            f"{elem} is out of range. Should be in {target[elem]['range']} but is {values[elem]}."
+                        )
 
 
 # create TF dataset
 dataset_name = args.dataset_name
 print(f"Visualizing data from dataset: {dataset_name}")
 module = importlib.import_module(dataset_name)
-ds = tfds.load(dataset_name, split='train')
+ds = tfds.load(dataset_name, split="train")
 ds = ds.shuffle(100)
 
 for episode in tqdm.tqdm(ds.take(50)):
-    steps = tfds.as_numpy(episode['steps'])
+    steps = tfds.as_numpy(episode["steps"])
     for step in steps:
         transformed_step = transform_step(step)
         check_elements(TARGET_SPEC, transformed_step)

--- a/roboverse_learn/vla/rlds_utils/visualize_dataset.py
+++ b/roboverse_learn/vla/rlds_utils/visualize_dataset.py
@@ -1,14 +1,14 @@
 import argparse
-import tqdm
 import importlib
 import os
 
-os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # suppress debug warning messages
-import tensorflow_datasets as tfds
-import numpy as np
-import matplotlib.pyplot as plt
-import wandb
+import tqdm
 
+os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"  # suppress debug warning messages
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow_datasets as tfds
+import wandb
 
 WANDB_ENTITY = "wbjsamuel"
 WANDB_PROJECT = "vis_rlds"


### PR DESCRIPTION
Stacked on #820; retarget to main once that merges.

`roboverse_learn` was in ruff's `extend-exclude`, so the lint job never parsed its ~26k lines (architecture review, self-correction item). This PR:

- removes the exclusion; applies the 97 safe auto-fixes (unused imports, import order, f-strings, quoted annotations, `__all__` order) and `ruff format` (69 files);
- hand-fixes: `super(__class__, self)` ×3, nested `max` ×2, `warnings.warn` stacklevel, `type(x) == y` comparison, `np.sqrt(2)` as a default argument, and an undefined name `lighten` in `pymunk_override.__all__` (would have raised on `from … import *`);
- per-file-ignores for `roboverse_learn/**`: `FA100 UP006 UP045 E731 B006 RUF013 F811` (505 findings at inclusion time; documented as debt in `pyproject.toml`, remove a code when its findings are fixed); `F821` only for `vla/pi0/train_config_snippet.py`, which is a paste-in snippet for an openpi config, not an importable module.

Behaviour: none intended. `pytest tests/` result unchanged (see CI). Unused-import removals were checked against the deliberate ordered imports (`isaacgym` before torch): none touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw