### PR TITLE
chore(release): PyPI-installable extras, py310 target, version-header alignment, release dry-run job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,3 +88,39 @@ jobs:
           # nothing in tests/ renders on MuJoCo, and the suite is identical locally with this value.
           MUJOCO_GL: disable
         run: python -m pytest tests/ -rs
+
+  release-dry-run:
+    # What release.yml will do on the next tag, run on every PR so a broken build or a git-URL
+    # dependency (which PyPI rejects) is caught before the tag exists.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip build twine tomli
+      - name: No git-URL dependencies in either [project] table
+        run: |
+          python - <<'PY'
+          import tomli, sys
+          bad = []
+          for path in ("pyproject.toml", "packages/metasim/pyproject.toml"):
+              proj = tomli.load(open(path, "rb"))["project"]
+              deps = list(proj.get("dependencies", [])) + [d for ds in proj.get("optional-dependencies", {}).values() for d in ds]
+              bad += [f"{path}: {d}" for d in deps if "@ git+" in d or "://" in d]
+          if bad:
+              print("::error::PyPI rejects direct URL dependencies:\n" + "\n".join(bad)); sys.exit(1)
+          print("no direct-URL dependencies")
+          PY
+      - name: Versions agree
+        run: |
+          python - <<'PY'
+          import tomli, sys
+          a = tomli.load(open("pyproject.toml", "rb"))["project"]["version"]
+          b = tomli.load(open("packages/metasim/pyproject.toml", "rb"))["project"]["version"]
+          print("roboverse-py", a, "roboverse-metasim", b)
+          sys.exit(0 if a == b else 1)
+          PY
+      - run: python -m build --outdir dist packages/metasim && python -m build --outdir dist .
+      - run: python -m twine check --strict dist/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ release.
 ## [Unreleased]
 
 ### Changed
+- Packaging hygiene: `requires-python = ">=3.10,<3.13"` and ruff `target-version = "py310"` in both packages (old-style typing rewritten by ruff where safe); the CHANGELOG release header is `[1.0.0b0]`, matching the `pyproject` version `release.yml` checks; a `release-dry-run` CI job builds both distributions on every PR, runs `twine check --strict`, and fails on direct-URL dependencies (PyPI rejects them) or mismatched package versions.
 - MetaSim now lives in this repository under `packages/metasim` (imported with `git subtree`, history preserved) and is released in lockstep as `roboverse-metasim`; `roboverse-py` depends on `roboverse-metasim>=1.0.0b0,<1.1` instead of a git `@main` URL. Install with `pip install -e "packages/metasim[mujoco]" -e ".[mujoco]"` (MetaSim first). CI runs MetaSim's simulator-free suite on 3.10/3.11 alongside the RoboVerse suite; `changelog.yml` guards one CHANGELOG per package; `release.yml` builds and publishes both from one tag.
 
 ### Fixed
@@ -64,7 +65,7 @@ release.
 
 - `hydra-core` pinned to 1.3.4 in the dp / vita / fm IL policy requirements (Dependabot: `hydra.utils.instantiate` code execution with untrusted configs in <=1.3.3).
 
-## [1.0.0-beta] - 2026-05-31
+## [1.0.0b0] - 2026-05-31
 
 The headline of this release is **cross-platform parity is now testable and
 load-bearing**. Every shipped `RobotCfg`, every contracted handler method,
@@ -149,4 +150,4 @@ flagged `default_joint_positions` mismatches before they trip in CI.
 ---
 
 [Unreleased]: https://github.com/RoboVerseOrg/RoboVerse/compare/v1.0.0-beta...HEAD
-[1.0.0-beta]: https://github.com/RoboVerseOrg/RoboVerse/compare/v1.0.0-alpha...v1.0.0-beta
+[1.0.0b0]: https://github.com/RoboVerseOrg/RoboVerse/compare/v1.0.0-alpha...v1.0.0-beta

--- a/generation/load_asset.py
+++ b/generation/load_asset.py
@@ -66,7 +66,7 @@ def cvt_embodiedgen_asset_to_anysim(
     asset_paths = dict()
 
     with asset_converter:
-        for urdf_file, target_dir in zip(urdf_files, target_dirs):
+        for urdf_file, target_dir in zip(urdf_files, target_dirs, strict=False):
             filename = os.path.basename(urdf_file).replace(".urdf", "")
             if target_type == AssetType.MJCF:
                 target_file = f"{target_dir}/{filename}.xml"

--- a/get_started/9_maniskill_two_robot_stack_cube.py
+++ b/get_started/9_maniskill_two_robot_stack_cube.py
@@ -154,7 +154,7 @@ def _agent_slice(traj, articulation: str, agent_name: str) -> dict:
             agent_name: {
                 "pos": art[i, :3].tolist(),
                 "rot": art[i, _POSE_QUAT_SLICE].tolist(),  # wxyz
-                "dof_pos": dict(zip(PANDA_JOINTS, qpos.tolist())),
+                "dof_pos": dict(zip(PANDA_JOINTS, qpos.tolist(), strict=False)),
             }
         }
         for name, rows in objs.items():
@@ -164,7 +164,10 @@ def _agent_slice(traj, articulation: str, agent_name: str) -> dict:
     states = [frame_state(i) for i in range(n_frames)]
     # Action target at step t is the next recorded joint pose (state replay's
     # action-space twin); the loader merges these into per-step {robot: action}.
-    actions = [{"dof_pos_target": dict(zip(PANDA_JOINTS, art[i, _QPOS_SLICE].tolist()))} for i in range(1, n_frames)]
+    actions = [
+        {"dof_pos_target": dict(zip(PANDA_JOINTS, art[i, _QPOS_SLICE].tolist(), strict=False))}
+        for i in range(1, n_frames)
+    ]
     return {"init_state": states[0], "actions": actions, "states": states}
 
 

--- a/get_started/dexhands/1_diff_dex_hand.py
+++ b/get_started/dexhands/1_diff_dex_hand.py
@@ -147,7 +147,7 @@ def main():
         actions = []
         for i_env in range(num_envs):
             # Start with actuated joints
-            dof_targets = dict(zip(j_names_actuated, q_actuated[i_env].tolist()))
+            dof_targets = dict(zip(j_names_actuated, q_actuated[i_env].tolist(), strict=False))
 
             # Calculate passive joint targets based on mimic relationships
             # This is needed for ALL simulators to ensure consistency
@@ -173,7 +173,7 @@ def main():
 
         # Log joint positions (only actuated joints)
         log.info("Target joint positions (actuated only):")
-        for i, (name, value) in enumerate(zip(j_names_actuated[:3], q_actuated[0][:3].tolist())):
+        for i, (name, value) in enumerate(zip(j_names_actuated[:3], q_actuated[0][:3].tolist(), strict=False)):
             log.info(f"  {name}: {value:.3f}")
         log.info("  ... (showing first 3 actuated joints)")
 

--- a/get_started/obj_layout/object_layout_task.py
+++ b/get_started/obj_layout/object_layout_task.py
@@ -67,7 +67,7 @@ def save_poses_to_file(obs, scenario, filename="saved_poses.py"):
                     joint_names = sorted(obj_cfg.actuators.keys())
                     joint_positions = obj_state.joint_pos[0].cpu().numpy()
                     f.write('            "dof_pos": {\n')
-                    for name, pos in zip(joint_names, joint_positions):
+                    for name, pos in zip(joint_names, joint_positions, strict=False):
                         f.write(f'                "{name}": {pos:.6f},\n')
                     f.write("            },\n")
 
@@ -91,7 +91,7 @@ def save_poses_to_file(obs, scenario, filename="saved_poses.py"):
                 joint_names = sorted(robot_cfg.actuators.keys())
                 joint_positions = robot_state.joint_pos[0].cpu().numpy()
                 f.write('            "dof_pos": {\n')
-                for name, pos in zip(joint_names, joint_positions):
+                for name, pos in zip(joint_names, joint_positions, strict=False):
                     f.write(f'                "{name}": {pos:.6f},\n')
                 f.write("            },\n")
 
@@ -367,7 +367,9 @@ def obs_to_state_dict(obs, scenario):
             if obj_cfg and hasattr(obj_cfg, "actuators") and obj_cfg.actuators:
                 joint_names = sorted(obj_cfg.actuators.keys())
                 joint_positions = obj_state.joint_pos[0]
-                obj_entry["dof_pos"] = {name: pos.item() for name, pos in zip(joint_names, joint_positions)}
+                obj_entry["dof_pos"] = {
+                    name: pos.item() for name, pos in zip(joint_names, joint_positions, strict=False)
+                }
 
         state_dict["objects"][obj_name] = obj_entry
 
@@ -386,7 +388,7 @@ def obs_to_state_dict(obs, scenario):
         if robot_cfg and robot_cfg.actuators:
             joint_names = sorted(robot_cfg.actuators.keys())
             joint_positions = robot_state.joint_pos[0]
-            robot_entry["dof_pos"] = {name: pos.item() for name, pos in zip(joint_names, joint_positions)}
+            robot_entry["dof_pos"] = {name: pos.item() for name, pos in zip(joint_names, joint_positions, strict=False)}
 
         state_dict["robots"][robot_name] = robot_entry
 
@@ -640,7 +642,9 @@ if __name__ == "__main__":
                 joint_positions = robot_state.joint_pos[0]
 
                 env_action[robot.name] = {
-                    "dof_pos_target": {name: pos.item() for name, pos in zip(joint_names, joint_positions)}
+                    "dof_pos_target": {
+                        name: pos.item() for name, pos in zip(joint_names, joint_positions, strict=False)
+                    }
                 }
             actions.append(env_action)
 

--- a/get_started/rl/fast_td3/1_fttd3.py
+++ b/get_started/rl/fast_td3/1_fttd3.py
@@ -498,7 +498,7 @@ def main() -> None:
                     if global_step % cfg("policy_frequency") == 0:
                         logs_dict = update_pol(data, logs_dict)
 
-                for param, target_param in zip(qnet.parameters(), qnet_target.parameters()):
+                for param, target_param in zip(qnet.parameters(), qnet_target.parameters(), strict=False):
                     target_param.data.copy_(cfg("tau") * param.data + (1 - cfg("tau")) * target_param.data)
 
             if torch.cuda.is_available():

--- a/packages/metasim/CHANGELOG.md
+++ b/packages/metasim/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Extras are PyPI-installable: `newton>=1.5,<2` (PyPI wheel; the 1.5/1.6 shims are in `_newton_compat`) and `sapien2` → `mani-skill2==0.5.3` replace git URLs; `robo-splatter` (git-only) moves to `requirements/robosplatter.txt`; `[tool.uv] conflicts` marks the isaacsim / isaacsim211 / mjx / isaacgym extras mutually exclusive; `requires-python = ">=3.10,<3.13"`.
 - Moved into the RoboVerse monorepo as `packages/metasim`; version aligned to `1.0.0b0` (lockstep with `roboverse-py`). The standalone `RoboVerseOrg/MetaSim` repository becomes a read-only mirror for one release cycle.
 
 - **Task registry is lazy.** `get_task_class(name)` resolves the name through a static AST index of

--- a/packages/metasim/metasim/queries/contact_force.py
+++ b/packages/metasim/metasim/queries/contact_force.py
@@ -177,7 +177,7 @@ class ContactForces(BaseQueryType):
                     body_count = 0
                 continue
             body_names = [model.body_key[idx] for idx in body_ids]
-            sorted_pairs = sorted(zip(body_names, body_ids), key=lambda pair: pair[0])
+            sorted_pairs = sorted(zip(body_names, body_ids, strict=False), key=lambda pair: pair[0])
             sorted_body_ids = [idx for _, idx in sorted_pairs]
             if body_count is None:
                 body_count = len(sorted_body_ids)

--- a/packages/metasim/metasim/randomization/presets/material_presets.py
+++ b/packages/metasim/metasim/randomization/presets/material_presets.py
@@ -8,10 +8,10 @@ https://huggingface.co/datasets/RoboVerseOrg/roboverse_data/tree/main/materials.
 from __future__ import annotations
 
 import warnings
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
-from typing import Callable, Iterable, Sequence
 
 try:
     from huggingface_hub import HfApi, hf_hub_download

--- a/packages/metasim/metasim/sim/blender/offline.py
+++ b/packages/metasim/metasim/sim/blender/offline.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import copy
+from collections.abc import Iterable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterable
 
 import imageio.v3 as iio
 

--- a/packages/metasim/metasim/sim/mjx/mjx_helper.py
+++ b/packages/metasim/metasim/sim/mjx/mjx_helper.py
@@ -249,11 +249,11 @@ def sorted_joint_info(model, prefix: str):
         panda_joint1 → panda_joint2 → panda_joint_finger1
     """
     names, ids = _names_ids_mjx(model, "joint")
-    matches = [(n, i) for n, i in zip(names, ids) if n.startswith(prefix)]
+    matches = [(n, i) for n, i in zip(names, ids, strict=False) if n.startswith(prefix)]
     if not matches:
         raise ValueError(f"No joints begin with '{prefix}'")
     matches.sort(key=lambda t: t[0])  # alpha order by full name
-    _, j_ids = zip(*matches)
+    _, j_ids = zip(*matches, strict=False)
     qadr = model.jnt_qposadr[list(j_ids)]
     vadr = model.jnt_dofadr[list(j_ids)]
     return jnp.asarray(qadr), jnp.asarray(vadr)
@@ -262,7 +262,7 @@ def sorted_joint_info(model, prefix: str):
 def sorted_actuator_ids(model, prefix: str):
     """Return **sorted** actuator IDs whose name begins with `prefix`."""
     names, ids = _names_ids_mjx(model, "actuator")
-    sel = [(n, i) for n, i in zip(names, ids) if n.startswith(prefix)]
+    sel = [(n, i) for n, i in zip(names, ids, strict=False) if n.startswith(prefix)]
     sel.sort(key=lambda t: t[0])
     return [i for _, i in sel]
 
@@ -284,7 +284,7 @@ def sorted_body_ids(model, prefix: str):
         panda_link0  → panda_link3 → panda_left_finger
     """
     names, ids = _names_ids_mjx(model, "body")
-    filt = [(n, i) for n, i in zip(names, ids) if n.startswith(prefix) and n != prefix]
+    filt = [(n, i) for n, i in zip(names, ids, strict=False) if n.startswith(prefix) and n != prefix]
     filt.sort(key=lambda t: t[0])
     body_ids = [i for _, i in filt]
     local_names = [n.split("/")[-1] for n, _ in filt]

--- a/packages/metasim/metasim/sim/newton/newton.py
+++ b/packages/metasim/metasim/sim/newton/newton.py
@@ -871,7 +871,7 @@ class NewtonHandler(BaseSimHandler):
                 body_ids = self._get_body_indices(env_id, name)
                 if body_ids:
                     body_names = [self._model.body_key[idx] for idx in body_ids]
-                    sorted_pairs = sorted(zip(body_names, body_ids), key=lambda pair: pair[0])
+                    sorted_pairs = sorted(zip(body_names, body_ids, strict=False), key=lambda pair: pair[0])
                     sorted_body_ids = [idx for _, idx in sorted_pairs]
                 else:
                     sorted_body_ids = []
@@ -1781,7 +1781,7 @@ class NewtonHandler(BaseSimHandler):
                 body_ids = self._get_body_indices(env_id, robot_name)
                 if body_ids:
                     body_names = [self._model.body_key[idx] for idx in body_ids]
-                    sorted_pairs = sorted(zip(body_names, body_ids), key=lambda pair: pair[0])
+                    sorted_pairs = sorted(zip(body_names, body_ids, strict=False), key=lambda pair: pair[0])
                     sorted_body_ids = [idx for _, idx in sorted_pairs]
                 else:
                     sorted_body_ids = []
@@ -1830,7 +1830,7 @@ class NewtonHandler(BaseSimHandler):
                 if body_q is not None:
                     if body_ids:
                         body_names = [self._model.body_key[idx] for idx in body_ids]
-                        sorted_pairs = sorted(zip(body_names, body_ids), key=lambda pair: pair[0])
+                        sorted_pairs = sorted(zip(body_names, body_ids, strict=False), key=lambda pair: pair[0])
                         sorted_body_ids = [idx for _, idx in sorted_pairs]
                     else:
                         sorted_body_ids = []

--- a/packages/metasim/metasim/sim/parallel.py
+++ b/packages/metasim/metasim/sim/parallel.py
@@ -131,7 +131,7 @@ def ParallelSimWrapper(base_cls: type[BaseSimHandler]) -> type[BaseSimHandler]:
             self.error_queue = ctx.Queue()
 
             # Initialize workers
-            self.remotes, self.work_remotes = zip(*[ctx.Pipe() for _ in range(self.num_envs)])
+            self.remotes, self.work_remotes = zip(*[ctx.Pipe() for _ in range(self.num_envs)], strict=False)
             self.processes = []
             for rank in range(self.num_envs):
                 work_remote = self.work_remotes[rank]

--- a/packages/metasim/metasim/task/base.py
+++ b/packages/metasim/metasim/task/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import gymnasium as gym
 import numpy as np

--- a/packages/metasim/metasim/task/gym_registration.py
+++ b/packages/metasim/metasim/task/gym_registration.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 import gymnasium as gym
 import numpy as np

--- a/packages/metasim/metasim/task/rl_task.py
+++ b/packages/metasim/metasim/task/rl_task.py
@@ -245,7 +245,7 @@ class RLTaskEnv(BaseTaskEnv):
         total_reward = None
         if len(self.reward_functions) == 0:
             return torch.zeros(self.num_envs, dtype=torch.float32, device=self.device)
-        for reward_func, weight in zip(self.reward_functions, self.reward_weights):
+        for reward_func, weight in zip(self.reward_functions, self.reward_weights, strict=False):
             val = reward_func(env_states)
             if total_reward is None:
                 total_reward = torch.zeros_like(val)

--- a/packages/metasim/metasim/test/conftest.py
+++ b/packages/metasim/metasim/test/conftest.py
@@ -16,7 +16,7 @@ need any simulator or handler.
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
 
 import pytest
 from loguru import logger as log

--- a/packages/metasim/metasim/test/sim/test_state_modes.py
+++ b/packages/metasim/metasim/test/sim/test_state_modes.py
@@ -263,7 +263,7 @@ def test_set_states_get_states_round_trip(handler):
     # the quaternion or apply small numerical massaging in set_states.
     got_pos = franka_post["pos"]
     pos_list = got_pos.tolist() if hasattr(got_pos, "tolist") else list(got_pos)
-    for i, (a, b) in enumerate(zip(pos_list, target_pos)):
+    for i, (a, b) in enumerate(zip(pos_list, target_pos, strict=False)):
         assert abs(a - b) < 1e-3, (
             f"root pos round-trip failed on {handler.scenario.simulator} component {i}: set={b:.4f}, got={a:.4f}"
         )

--- a/packages/metasim/metasim/test/test_contract_api_general.py
+++ b/packages/metasim/metasim/test/test_contract_api_general.py
@@ -97,7 +97,7 @@ def test_pyproject_builds_metasim_distribution_only():
     assert project["name"] == "roboverse-metasim"  # PyPI name; `metasim` is an unrelated project there
     assert project["description"] == "MetaSim: A unified simulation framework for robotics"
     assert project["license"] == {"file": "LICENSE"}
-    assert project["requires-python"] == ">=3.8"
+    assert project["requires-python"] == ">=3.10,<3.13"
 
     package_find = pyproject["tool"]["setuptools"]["packages"]["find"]
     assert package_find["include"] == ["metasim", "metasim.*"]

--- a/packages/metasim/metasim/test/utils/test_color_util.py
+++ b/packages/metasim/metasim/test/utils/test_color_util.py
@@ -20,7 +20,7 @@ def test_hsv_to_rgb_matches_colorsys(h, s, v):
     got = hsv_to_rgb(h, s, v)
     assert got is not None, f"hsv_to_rgb returned None for h={h}"
     expected = colorsys.hsv_to_rgb(h / 360.0, s, v)
-    assert max(abs(a - b) for a, b in zip(got, expected)) < 1e-6
+    assert max(abs(a - b) for a, b in zip(got, expected, strict=False)) < 1e-6
 
 
 @pytest.mark.general

--- a/packages/metasim/metasim/test/utils/test_gs_util.py
+++ b/packages/metasim/metasim/test/utils/test_gs_util.py
@@ -22,11 +22,11 @@ def test_quaternion_multiply_identity():
 
     # Identity * q should equal q
     result1 = quaternion_multiply(identity, q)
-    assert all(abs(a - b) < 1e-4 for a, b in zip(result1, q))
+    assert all(abs(a - b) < 1e-4 for a, b in zip(result1, q, strict=False))
 
     # q * identity should equal q
     result2 = quaternion_multiply(q, identity)
-    assert all(abs(a - b) < 1e-4 for a, b in zip(result2, q))
+    assert all(abs(a - b) < 1e-4 for a, b in zip(result2, q, strict=False))
 
 
 @pytest.mark.general
@@ -72,7 +72,7 @@ def test_quaternion_multiply_commutativity():
     result2 = quaternion_multiply(q2, q1)
 
     # Results should be different (quaternion multiplication is non-commutative)
-    assert not all(abs(a - b) < 1e-4 for a, b in zip(result1, result2))
+    assert not all(abs(a - b) < 1e-4 for a, b in zip(result1, result2, strict=False))
 
 
 @pytest.mark.general
@@ -99,7 +99,7 @@ def test_quaternion_multiply_zero_rotation():
     result = quaternion_multiply(identity, identity)
 
     # Should remain identity
-    assert all(abs(a - b) < 1e-6 for a, b in zip(result, identity))
+    assert all(abs(a - b) < 1e-6 for a, b in zip(result, identity, strict=False))
 
 
 @pytest.mark.general
@@ -115,7 +115,7 @@ def test_quaternion_multiply_180deg():
     identity = [0.0, 0.0, 0.0, 1.0]
     neg_identity = [0.0, 0.0, 0.0, -1.0]
 
-    matches_identity = all(abs(a - b) < 1e-4 for a, b in zip(result, identity))
-    matches_neg_identity = all(abs(a - b) < 1e-4 for a, b in zip(result, neg_identity))
+    matches_identity = all(abs(a - b) < 1e-4 for a, b in zip(result, identity, strict=False))
+    matches_neg_identity = all(abs(a - b) < 1e-4 for a, b in zip(result, neg_identity, strict=False))
 
     assert matches_identity or matches_neg_identity

--- a/packages/metasim/metasim/types.py
+++ b/packages/metasim/metasim/types.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Literal, Tuple, TypedDict, Union
+from typing import Any, Literal, Tuple, TypedDict, Union
 
 try:
     from typing import Annotated
 except ImportError:
-    from typing_extensions import Annotated
+    from typing import Annotated
 
 import numpy as np
 import torch
@@ -16,14 +16,14 @@ import torch
 from metasim.utils.math import convert_camera_frame_orientation_convention
 
 ## Basic types
-Dof = Dict[str, float]
+Dof = dict[str, float]
 
 
 @dataclass(frozen=True)
 class ShapeSpec:
     """Machine-readable shape metadata for tensor annotations."""
 
-    dims: Tuple[Union[str, int], ...]  # noqa: UP006, UP007 — kept typing-style to match the runtime Union aliases below
+    dims: Tuple[Union[str, int], ...]  # noqa: UP006 — kept typing-style to match the runtime Union aliases below
 
 
 RootStateTensor = Annotated[torch.Tensor, ShapeSpec(("num_envs", 13))]
@@ -46,8 +46,8 @@ class RobotAction(TypedDict, total=False):
     dof_effort_target: Dof | None
 
 
-Action = Dict[str, RobotAction]
-ActionBatch = List[Action]
+Action = dict[str, RobotAction]
+ActionBatch = list[Action]
 ActionInput = Union[ActionBatch, torch.Tensor]
 CompatActionInput = Union[ActionInput, np.ndarray]
 
@@ -83,7 +83,7 @@ class DictEnvState(TypedDict):
     extras: dict[str, Any]  # States of Extra information
 
 
-DictStateBatch = List[DictEnvState]
+DictStateBatch = list[DictEnvState]
 StateMode = Literal["tensor", "dict"]
 
 
@@ -418,9 +418,9 @@ InfoValue = Union[
     Obs,
     np.ndarray,
     InfoScalar,
-    List["InfoValue"],
-    Tuple["InfoValue", ...],
-    Dict[str, "InfoValue"],
+    list["InfoValue"],
+    tuple["InfoValue", ...],
+    dict[str, "InfoValue"],
 ]
-Info = Dict[str, InfoValue]
+Info = dict[str, InfoValue]
 Termination = torch.BoolTensor

--- a/packages/metasim/metasim/utils/demo_util/demo_util.py
+++ b/packages/metasim/metasim/utils/demo_util/demo_util.py
@@ -98,12 +98,12 @@ def _get_traj_multiagent(
 
     log.info(f"Reading multi-agent trajectory for {len(robots)} agents: {names}")
     per_agent = [get_traj(traj_filepath, robot, handler=handler, v2_as_v3=True) for robot in robots]
-    init_list, action_list, state_list = zip(*per_agent)
+    init_list, action_list, state_list = zip(*per_agent, strict=False)
 
     demo_counts = [len(init) for init in init_list]
     if len(set(demo_counts)) > 1:
         log.warning(
-            f"Multi-agent agents have differing demo counts {dict(zip(names, demo_counts))}; "
+            f"Multi-agent agents have differing demo counts {dict(zip(names, demo_counts, strict=False))}; "
             f"merging the {min(demo_counts)} demo(s) common to all agents."
         )
     return (

--- a/packages/metasim/metasim/utils/ik_solver.py
+++ b/packages/metasim/metasim/utils/ik_solver.py
@@ -122,7 +122,7 @@ class IKSolver:
             return [
                 {
                     self.robot_cfg.name: {
-                        "dof_pos_target": dict(zip(joint_names_dict_order, q_full_dict_order[i].tolist()))
+                        "dof_pos_target": dict(zip(joint_names_dict_order, q_full_dict_order[i].tolist(), strict=False))
                     }
                 }
                 for i in range(q_full_dict_order.shape[0])

--- a/packages/metasim/metasim/utils/math.py
+++ b/packages/metasim/metasim/utils/math.py
@@ -409,7 +409,7 @@ def matrix_from_euler(euler_angles: torch.Tensor, convention: str) -> torch.Tens
     for letter in convention:
         if letter not in ("X", "Y", "Z"):
             raise ValueError(f"Invalid letter {letter} in convention string.")
-    matrices = [_axis_angle_rotation(c, e) for c, e in zip(convention, torch.unbind(euler_angles, -1))]
+    matrices = [_axis_angle_rotation(c, e) for c, e in zip(convention, torch.unbind(euler_angles, -1), strict=False)]
     # return functools.reduce(torch.matmul, matrices)
     return torch.matmul(torch.matmul(matrices[0], matrices[1]), matrices[2])
 

--- a/packages/metasim/metasim/utils/rerun/rerun_util.py
+++ b/packages/metasim/metasim/utils/rerun/rerun_util.py
@@ -985,7 +985,7 @@ class RerunVisualizer:
         elif visual_type == "box":
             size = visual_info.get("size", [1, 1, 1])
             # Apply global scale to box size
-            scaled_size = [s * gs for s, gs in zip(size, global_scale)]
+            scaled_size = [s * gs for s, gs in zip(size, global_scale, strict=False)]
 
             # Use Mesh3D for solid rendering
             if TRIMESH_AVAILABLE:

--- a/packages/metasim/metasim/utils/terrain_utils.py
+++ b/packages/metasim/metasim/utils/terrain_utils.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Sequence
 
 import numpy as np
 from scipy.interpolate import RegularGridInterpolator

--- a/packages/metasim/metasim/utils/viser/viser_util.py
+++ b/packages/metasim/metasim/utils/viser/viser_util.py
@@ -446,7 +446,9 @@ class ViserVisualizer:
                         self._initial_configs[name] = dof_pos.copy()
                     else:
                         # Convert list to dict using joint names
-                        self._initial_configs[name] = {jn: val for jn, val in zip(joint_names, dof_pos_list)}
+                        self._initial_configs[name] = {
+                            jn: val for jn, val in zip(joint_names, dof_pos_list, strict=False)
+                        }
                     logger.info(f"Stored initial config for robot {name}")
 
         # primitive item visualization
@@ -738,7 +740,7 @@ class ViserVisualizer:
         # Note: Preserve demo initial config if it already exists
         if not has_demo_initial_config:
             # Convert list to dict for consistency
-            self._initial_configs[robot_name] = {jn: val for jn, val in zip(joint_names, initial_config)}
+            self._initial_configs[robot_name] = {jn: val for jn, val in zip(joint_names, initial_config, strict=False)}
 
         # Set initial configuration and save current positions
         if urdf_handle:
@@ -780,7 +782,7 @@ class ViserVisualizer:
 
         # Update slider values - initial_config is a dict, need to extract values in order
         if isinstance(initial_config, dict):
-            for slider, joint_name in zip(sliders, joint_names):
+            for slider, joint_name in zip(sliders, joint_names, strict=False):
                 if joint_name in initial_config:
                     slider.value = initial_config[joint_name]
                     logger.debug(f"Reset {joint_name} to {initial_config[joint_name]}")
@@ -788,7 +790,7 @@ class ViserVisualizer:
                     logger.warning(f"Joint {joint_name} not found in initial config")
         else:
             # If it's a list (legacy support)
-            for slider, init_value in zip(sliders, initial_config):
+            for slider, init_value in zip(sliders, initial_config, strict=False):
                 slider.value = init_value
 
         # Clear saved positions so they don't override demo initial config on next setup

--- a/packages/metasim/pyproject.toml
+++ b/packages/metasim/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "roboverse-metasim"  # PyPI name; the import name stays `metasim` (`metasim` on PyPI is an unrelated project)
 version = "1.0.0b0"  # lockstep with roboverse-py (one tag releases both packages)
 description = "MetaSim: A unified simulation framework for robotics"
-requires-python = ">=3.8"
+requires-python = ">=3.10,<3.13"
 license = { file = "LICENSE" }
 dependencies = [
     "defusedxml",
@@ -53,7 +53,7 @@ isaacgym = [
 ]
 mujoco = ["mujoco", "dm-control"]
 mjx = ["torch==2.7.0", "mujoco-mjx>=3.2.7", "dm-control", "jax[cuda]==0.6.0"]
-sapien2 = ["mani-skill2 @ git+https://github.com/haosulab/ManiSkill.git@v0.5.3"]
+sapien2 = ["mani-skill2==0.5.3"]
 sapien3 = ["sapien>=3.0.0.b1"]
 pybullet = ["numpy<2", "pybullet"]
 genesis = [
@@ -71,21 +71,28 @@ superdex = [
     "trimesh",
     "pyrender",
 ]
-robosplatter = [
-   "robo-splatter @ git+https://github.com/HorizonRobotics/RoboSplatter.git@v0.1.2",
-   "setuptools==59.5.0"
-]
+# robo-splatter itself is git-only (PyPI forbids URL dependencies in published metadata):
+#   pip install -r packages/metasim/requirements/robosplatter.txt
+robosplatter = ["setuptools==59.5.0"]
 newton = [
     "warp-lang>=1.11.0",
     "mujoco>=3.3.7",
     "mujoco-warp>=0.0.1",
-    "newton @ git+https://github.com/newton-physics/newton.git",
+    "newton>=1.5,<2",  # 1.5/1.6 API shims live in metasim/sim/newton/_newton_compat.py
     "imgui-bundle",
     "pycollada",
 ]
 
 [tool.uv]
 index-strategy = "unsafe-best-match"
+# Simulator extras pin different torch / CUDA stacks; declare them mutually exclusive so a resolver
+# fails with a clear message instead of picking one silently (see docs: one environment per simulator).
+conflicts = [
+    [{ extra = "isaacsim" }, { extra = "isaacsim211" }],
+    [{ extra = "isaacsim" }, { extra = "mjx" }],
+    [{ extra = "isaacsim211" }, { extra = "mjx" }],
+    [{ extra = "isaacsim211" }, { extra = "isaacgym" }],
+]
 
 [tool.uv.pip]
 index-url = "https://download.pytorch.org/whl/cu128"
@@ -98,7 +105,7 @@ extra-index-url = [
 line-length = 120
 format.preview = true
 lint.preview = false
-target-version = "py38"
+target-version = "py310"
 lint.select = [
     "B",    # flake8: bugbear
     "E",    # pycodestyle
@@ -156,6 +163,8 @@ metasim = ["data/**/*"]
 
 [tool.ruff.lint.per-file-ignores]
 ## For unit test, allow no docstrings
+"metasim/types.py" = ["UP007", "UP035"]  # runtime Union/Tuple aliases, see the comment in the file
+"metasim/utils/gs_util.py" = ["UP035"]
 "metasim/test/**.py" = ["D"]
 ## For python files in docs, allow no docstrings
 "docs/**.py" = ["D"]

--- a/packages/metasim/requirements/robosplatter.txt
+++ b/packages/metasim/requirements/robosplatter.txt
@@ -1,0 +1,4 @@
+# Gaussian-splatting background rendering: not on PyPI, so it cannot be an extra of a published
+# wheel. Install after `pip install roboverse-metasim[robosplatter]`:
+#   pip install -r packages/metasim/requirements/robosplatter.txt
+robo-splatter @ git+https://github.com/HorizonRobotics/RoboSplatter.git@v0.1.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "roboverse-py"
 version = "1.0.0b0"
 description = "RoboVerse content, learning, and examples built on MetaSim"
-requires-python = ">=3.10"
+requires-python = ">=3.10,<3.13"
 license = { file = "LICENSE" }
 dependencies = [
     "roboverse-metasim>=1.0.0b0,<1.1",
@@ -109,7 +109,7 @@ extra-index-url = [
 line-length = 120
 format.preview = true
 lint.preview = false
-target-version = "py38"
+target-version = "py310"
 lint.select = [
     "B",    # flake8: bugbear
     "E",    # pycodestyle
@@ -189,6 +189,8 @@ roboverse_pack = [
 "roboverse_pack/tasks/maniskill/utils/**.py" = ["T20", "D"]
 ## For get_started scripts, allow no docstrings
 "get_started/**.py" = ["D"]
+"generation/enums.py" = ["UP035"]
+"roboverse_pack/tasks/humanoid/base/types.py" = ["UP007"]
 ## For special tasks, allow no docstrings
 "roboverse_pack/tasks/maniskill/{pick_single_egad,pick_single_ycb,peg_insertion_side}.py" = ["D"]
 "roboverse_pack/tasks/open6dor/task/**.py" = ["D"]

--- a/roboverse_pack/benchmark/spec.py
+++ b/roboverse_pack/benchmark/spec.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Mapping
 
 
 @dataclass(frozen=True)

--- a/roboverse_pack/blender/randomize.py
+++ b/roboverse_pack/blender/randomize.py
@@ -65,7 +65,7 @@ def sample_pose_box(
 ) -> tuple[tuple[float, float, float], tuple[float, float, float, float]]:
     """Return (pos, quat_wxyz) — rotation is yaw-only about world +Z."""
     rng = rng or random
-    pos = tuple(rng.uniform(lo, hi) for lo, hi in zip(cfg.xyz_min, cfg.xyz_max))
+    pos = tuple(rng.uniform(lo, hi) for lo, hi in zip(cfg.xyz_min, cfg.xyz_max, strict=False))
     yaw = rng.uniform(*cfg.yaw_range)
     half = yaw * 0.5
     quat = (math.cos(half), 0.0, 0.0, math.sin(half))

--- a/roboverse_pack/robots/g1_tracking.py
+++ b/roboverse_pack/robots/g1_tracking.py
@@ -262,9 +262,9 @@ class G1TrackingCfg(RobotCfg):
         # resolve regex to avoid compatibility issues with RoboVerse APIs
         joint_names = list(self.joint_limits.keys())
         _, name_list, value_list = resolve_matching_names_values(actuators, joint_names)
-        self.actuators = {k: v for k, v in zip(name_list, value_list)}
+        self.actuators = {k: v for k, v in zip(name_list, value_list, strict=False)}
         _, name_list, value_list = resolve_matching_names_values(action_scale, joint_names)
-        self.action_scale = {k: v for k, v in zip(name_list, value_list)}
+        self.action_scale = {k: v for k, v in zip(name_list, value_list, strict=False)}
 
         # Chain to the base __post_init__ so mjx_mjcf_path defaults to mjcf_path
         # (and scale/fix_base_link are normalised). Without this the MJX backend

--- a/roboverse_pack/tasks/beyondmimic/isaaclab/envs/tracking_rl_env.py
+++ b/roboverse_pack/tasks/beyondmimic/isaaclab/envs/tracking_rl_env.py
@@ -427,7 +427,7 @@ class TrackingRLEnv(TrackingBaseEnv, gym.Env):
             else:
                 self.single_observation_space[group_name] = gym.spaces.Dict({
                     term_name: gym.spaces.Box(low=-np.inf, high=np.inf, shape=term_dim)
-                    for term_name, term_dim in zip(group_term_names, group_dim)
+                    for term_name, term_dim in zip(group_term_names, group_dim, strict=False)
                 })
         # action space (unbounded since we don't impose any limits)
         action_dim = sum(self.action_manager.action_term_dim)

--- a/roboverse_pack/tasks/beyondmimic/metasim/configs/cfg_base.py
+++ b/roboverse_pack/tasks/beyondmimic/metasim/configs/cfg_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import MISSING
-from typing import Callable
 
 from metasim.utils import configclass
 

--- a/roboverse_pack/tasks/beyondmimic/metasim/configs/tracking_g1.py
+++ b/roboverse_pack/tasks/beyondmimic/metasim/configs/tracking_g1.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import MISSING
-from typing import Callable
 
 from metasim.utils import configclass
 from roboverse_pack.tasks.beyondmimic.metasim.configs.cfg_randomizers import MassRandomizer, MaterialRandomizer

--- a/roboverse_pack/tasks/beyondmimic/metasim/envs/base_legged_robot.py
+++ b/roboverse_pack/tasks/beyondmimic/metasim/envs/base_legged_robot.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from copy import deepcopy
 from dataclasses import asdict
-from typing import Any, Sequence
+from typing import Any
 
 import torch
 

--- a/roboverse_pack/tasks/beyondmimic/metasim/mdp/commands.py
+++ b/roboverse_pack/tasks/beyondmimic/metasim/mdp/commands.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import math
 import os
+from collections.abc import Sequence
 from dataclasses import MISSING
-from typing import TYPE_CHECKING, Sequence
+from typing import TYPE_CHECKING
 
 import numpy as np
 import torch

--- a/roboverse_pack/tasks/beyondmimic/metasim/utils/string.py
+++ b/roboverse_pack/tasks/beyondmimic/metasim/utils/string.py
@@ -161,7 +161,7 @@ def resolve_matching_names(
     if not all(keys_match_found):
         # make this print nicely aligned for debugging
         msg = "\n"
-        for key, value in zip(keys, keys_match_found):
+        for key, value in zip(keys, keys_match_found, strict=False):
             msg += f"\t{key}: {value}\n"
         msg += f"Available strings: {list_of_strings}\n"
         # raise error
@@ -276,7 +276,7 @@ def resolve_matching_names_values(
     if not all(keys_match_found):
         # make this print nicely aligned for debugging
         msg = "\n"
-        for key, value in zip(data.keys(), keys_match_found):
+        for key, value in zip(data.keys(), keys_match_found, strict=False):
             msg += f"\t{key}: {value}\n"
         msg += f"Available strings: {list_of_strings}\n"
         # raise error

--- a/roboverse_pack/tasks/calvin/data_preparation/convert_dataset.py
+++ b/roboverse_pack/tasks/calvin/data_preparation/convert_dataset.py
@@ -31,7 +31,7 @@ if __name__ == "__main__":
     indices = list(range(indices[0], indices[1] + 1))
 
     annotations = np.load(f"{args.path}/lang_annotations/auto_lang_ann.npy", allow_pickle=True).item()
-    annotations = list(zip(annotations["info"]["indx"], annotations["language"]["ann"]))
+    annotations = list(zip(annotations["info"]["indx"], annotations["language"]["ann"], strict=False))
 
     idx = 0
     ann_idx = -1

--- a/roboverse_pack/tasks/calvin/data_preparation/load_dataset.py
+++ b/roboverse_pack/tasks/calvin/data_preparation/load_dataset.py
@@ -27,7 +27,7 @@ if __name__ == "__main__":
     indices = list(range(indices[0], indices[1] + 1))
 
     annotations = np.load(f"{args.path}/lang_annotations/auto_lang_ann.npy", allow_pickle=True).item()
-    annotations = list(zip(annotations["info"]["indx"], annotations["language"]["ann"]))
+    annotations = list(zip(annotations["info"]["indx"], annotations["language"]["ann"], strict=False))
 
     idx = 0
     ann_idx = -1

--- a/roboverse_pack/tasks/humanoid/cfg_base.py
+++ b/roboverse_pack/tasks/humanoid/cfg_base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import MISSING
-from typing import Callable
 
 from metasim.utils import configclass
 

--- a/roboverse_pack/tasks/mjlab/mdp/actions.py
+++ b/roboverse_pack/tasks/mjlab/mdp/actions.py
@@ -33,8 +33,8 @@ Two scenarios this enables:
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Iterable
 
 import torch
 

--- a/roboverse_pack/tasks/mjlab/mdp/events_dr.py
+++ b/roboverse_pack/tasks/mjlab/mdp/events_dr.py
@@ -47,7 +47,8 @@ Implementation notes:
 from __future__ import annotations
 
 import dataclasses
-from typing import Callable, NoReturn
+from collections.abc import Callable
+from typing import NoReturn
 
 import numpy as np
 import torch

--- a/roboverse_pack/tasks/mjlab/mdp/scene_entity.py
+++ b/roboverse_pack/tasks/mjlab/mdp/scene_entity.py
@@ -18,8 +18,8 @@ amortize the name-lookup cost across the training loop.
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Iterable
 
 import torch
 

--- a/roboverse_pack/tasks/mujoco_playground/handover.py
+++ b/roboverse_pack/tasks/mujoco_playground/handover.py
@@ -176,7 +176,9 @@ class HandOver(RLTaskEnv):
 
         # Calculate potential-based reward
         raw_rewards = self._calculate_raw_rewards(self.env_states)
-        potential = sum(w * r for w, r in zip(self.reward_weights, raw_rewards)) / sum(self.reward_weights)
+        potential = sum(w * r for w, r in zip(self.reward_weights, raw_rewards, strict=False)) / sum(
+            self.reward_weights
+        )
 
         # Reward progress (clip at zero to not penalize exploration)
         progress_reward = torch.maximum(potential - self._prev_potential, torch.zeros_like(potential))

--- a/roboverse_pack/tasks/simpler_env/_metasim/grasp_objects_task.py
+++ b/roboverse_pack/tasks/simpler_env/_metasim/grasp_objects_task.py
@@ -239,7 +239,7 @@ class SimplerMoveNearTask(_GoogleArenaTask):
         self.robot.set_qpos(INIT_QPOS)
         self.robot.set_qvel(np.zeros(self.robot.dof))
         z = SCENE_TABLE_HEIGHT + 0.5
-        for o, xy_i, q_i in zip(self.objs, xy, quat):
+        for o, xy_i, q_i in zip(self.objs, xy, quat, strict=False):
             o.set_pose(sapien.Pose(np.hstack([xy_i, z]), q_i))
         self._settle(0.5)
         for o in self.objs:

--- a/roboverse_pack/tasks/simpler_env/_metasim/put_on_task.py
+++ b/roboverse_pack/tasks/simpler_env/_metasim/put_on_task.py
@@ -209,7 +209,7 @@ class SimplerPutOnTask(SimplerMetaSimTask):
             self.sink.set_pose(sapien.Pose([-0.16, 0.13, 0.88], [1, 0, 0, 0]))
             self.sink.lock_motion()
         z = 0.87 + 0.5
-        for o, xy_i, q_i in zip(self.objs, xy, quat):
+        for o, xy_i, q_i in zip(self.objs, xy, quat, strict=False):
             o.set_pose(sapien.Pose(np.hstack([xy_i, z]), q_i))
             o.lock_motion(0, 0, 0, 1, 1, 0)
         self._settle(0.5)

--- a/roboverse_pack/tasks/simpler_env/_native/move_near.py
+++ b/roboverse_pack/tasks/simpler_env/_native/move_near.py
@@ -238,7 +238,7 @@ class NativeMoveNearEnv:
         self.robot.set_qpos(INIT_QPOS)
         self.robot.set_qvel(np.zeros(self.robot.dof))
         z = SCENE_TABLE_HEIGHT + 0.5
-        for o, xy_i, q_i in zip(self.objs, xy, quat):
+        for o, xy_i, q_i in zip(self.objs, xy, quat, strict=False):
             o.set_pose(sapien.Pose(np.hstack([xy_i, z]), q_i))
             o.lock_motion(0, 0, 0, 1, 1, 0)
         self._settle(0.5)

--- a/roboverse_pack/tasks/simpler_env/_native/put_on.py
+++ b/roboverse_pack/tasks/simpler_env/_native/put_on.py
@@ -94,7 +94,7 @@ def _carrot_cfg():
 
 def _stack_cfg():
     xy = []
-    for hx, hy in zip([0.05, 0.1], [0.05, 0.1]):
+    for hx, hy in zip([0.05, 0.1], [0.05, 0.1], strict=False):
         xy += _grid([-0.16, 0.0], hx, hy)
     return dict(
         src="baked_green_cube_3cm",
@@ -261,7 +261,7 @@ class NativePutOnEnv:
             self.sink.set_pose(sapien.Pose([-0.16, 0.13, 0.88], [1, 0, 0, 0]))
             self.sink.lock_motion()
         z = SCENE_TABLE_HEIGHT + 0.5
-        for o, xy_i, q_i in zip(self.objs, xy, quat):
+        for o, xy_i, q_i in zip(self.objs, xy, quat, strict=False):
             o.set_pose(sapien.Pose(np.hstack([xy_i, z]), q_i))
             o.lock_motion(0, 0, 0, 1, 1, 0)
         self._settle(0.5)

--- a/roboverse_pack/teleop/common.py
+++ b/roboverse_pack/teleop/common.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 """Packet and command validation for canonical teleoperation streams."""
 
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import Any, Mapping
+from typing import Any
 
 KNOWN_TELEOP_COMMANDS = frozenset({
     "capture_zero",

--- a/roboverse_pack/teleop/runtime.py
+++ b/roboverse_pack/teleop/runtime.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 import json
 import time
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Mapping, Protocol, Sequence
+from typing import Any, Protocol
 
 import numpy as np
 

--- a/roboverse_pack/utils/curriculum_utils.py
+++ b/roboverse_pack/utils/curriculum_utils.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Sequence
+from collections.abc import Sequence
 
 import torch
 

--- a/roboverse_pack/utils/humanoid_utils.py
+++ b/roboverse_pack/utils/humanoid_utils.py
@@ -4,8 +4,8 @@ import argparse
 import os
 import random
 import re
+from collections.abc import Callable
 from functools import lru_cache
-from typing import Callable
 
 import numpy as np
 import torch

--- a/scripts/advanced/collect_demo.py
+++ b/scripts/advanced/collect_demo.py
@@ -144,7 +144,7 @@ def get_actions(all_actions, env, demo_idxs: list[int], robot: RobotCfg):
     action_idxs = env._episode_steps
 
     actions = []
-    for env_id, (demo_idx, action_idx) in enumerate(zip(demo_idxs, action_idxs)):
+    for env_id, (demo_idx, action_idx) in enumerate(zip(demo_idxs, action_idxs, strict=False)):
         if action_idx < len(all_actions[demo_idx]):
             action = all_actions[demo_idx][action_idx]
         else:
@@ -157,7 +157,9 @@ def get_actions(all_actions, env, demo_idxs: list[int], robot: RobotCfg):
 
 def get_run_out(all_actions, env, demo_idxs: list[int]) -> list[bool]:
     action_idxs = env._episode_steps
-    run_out = [action_idx >= len(all_actions[demo_idx]) for demo_idx, action_idx in zip(demo_idxs, action_idxs)]
+    run_out = [
+        action_idx >= len(all_actions[demo_idx]) for demo_idx, action_idx in zip(demo_idxs, action_idxs, strict=False)
+    ]
     return run_out
 
 

--- a/scripts/advanced/motion_planning.py
+++ b/scripts/advanced/motion_planning.py
@@ -126,7 +126,7 @@ def main():
     q[:, -ee_n_dof:] = random_gripper_widths
 
     actions = [
-        {robot.name: {"dof_pos_target": dict(zip(robot.actuators.keys(), q[i_env].tolist()))}}
+        {robot.name: {"dof_pos_target": dict(zip(robot.actuators.keys(), q[i_env].tolist(), strict=False))}}
         for i_env in range(num_envs)
     ]
 

--- a/scripts/advanced/motion_planning_gapartnet.py
+++ b/scripts/advanced/motion_planning_gapartnet.py
@@ -129,7 +129,7 @@ def control_to_pose(
     q[:, -ee_n_dof:] = gripper_widths
 
     actions = [
-        {robot.name: {"dof_pos_target": dict(zip(robot.actuators.keys(), q[i_env].tolist()))}}
+        {robot.name: {"dof_pos_target": dict(zip(robot.actuators.keys(), q[i_env].tolist(), strict=False))}}
         for i_env in range(num_envs)
     ]
 

--- a/scripts/advanced/random_action.py
+++ b/scripts/advanced/random_action.py
@@ -147,7 +147,7 @@ def main():
             q[:, -ee_n_dof:] = random_gripper_widths
 
         actions = [
-            {robot.name: {"dof_pos_target": dict(zip(robot.actuators.keys(), q[i_env].tolist()))}}
+            {robot.name: {"dof_pos_target": dict(zip(robot.actuators.keys(), q[i_env].tolist(), strict=False))}}
             for i_env in range(num_envs)
         ]
         q_min = torch.min(torch.stack([q_min, q[0]], -1), -1)[0]

--- a/scripts/advanced/random_action_ee.py
+++ b/scripts/advanced/random_action_ee.py
@@ -124,7 +124,7 @@ def main():
         q[:, -ee_n_dof:] = random_gripper_widths
 
         actions = [
-            {robot.name: {"dof_pos_target": dict(zip(robot.actuators.keys(), q[i_env].tolist()))}}
+            {robot.name: {"dof_pos_target": dict(zip(robot.actuators.keys(), q[i_env].tolist(), strict=False))}}
             for i_env in range(num_envs)
         ]
         q_min = torch.min(torch.stack([q_min, q[0]], -1), -1)[0]

--- a/scripts/advanced/random_action_notik.py
+++ b/scripts/advanced/random_action_notik.py
@@ -84,7 +84,7 @@ def main():
         q = q.to("cuda:0")
 
         actions = [
-            {robot.name: {"dof_pos_target": dict(zip(robot.actuators.keys(), q[i_env].tolist()))}}
+            {robot.name: {"dof_pos_target": dict(zip(robot.actuators.keys(), q[i_env].tolist(), strict=False))}}
             for i_env in range(num_envs)
         ]
         q_min = torch.min(torch.stack([q_min, q[0]], -1), -1)[0]

--- a/scripts/advanced/retarget_demo.py
+++ b/scripts/advanced/retarget_demo.py
@@ -253,12 +253,14 @@ def single(src_path, tgt_path, src_robot, tgt_robot):
         demo = {"actions": [], "states": [], "init_state": {}}
         for i_step in range(episode_lengths[i_succ]):
             demo["actions"].append({
-                "dof_pos_target": dict(zip(tgt_robot_joint_names, tgt_robot_qpos[i_succ, i_step].tolist()))
+                "dof_pos_target": dict(
+                    zip(tgt_robot_joint_names, tgt_robot_qpos[i_succ, i_step].tolist(), strict=False)
+                )
             })
         demo["init_state"] = src_demos[i_succ]["init_state"]
         del demo["init_state"][src_robot_cfg.name]
         demo["init_state"][tgt_robot_cfg.name] = {
-            "dof_pos": dict(zip(tgt_robot_joint_names, tgt_robot_qpos[i_succ, 0].tolist())),
+            "dof_pos": dict(zip(tgt_robot_joint_names, tgt_robot_qpos[i_succ, 0].tolist(), strict=False)),
             "pos": robot_pos[i_succ].tolist(),
             "rot": robot_quat[i_succ].tolist(),
         }

--- a/scripts/advanced/train_ppo.py
+++ b/scripts/advanced/train_ppo.py
@@ -59,7 +59,9 @@ class MetaSimGymEnv(gym.Env):
 
         # Convert numpy actions to handler format
         ## TODO: action should support vectorized actions
-        action_dicts = [{"dof_pos_target": dict(zip(self.env.handler.robot.joint_limits.keys(), actions))}]
+        action_dicts = [
+            {"dof_pos_target": dict(zip(self.env.handler.robot.joint_limits.keys(), actions, strict=False))}
+        ]
 
         # Step the simulation
         obs, rewards, success, timeout, _ = self.env.step(action_dicts)

--- a/scripts/advanced/train_ppo_vec.py
+++ b/scripts/advanced/train_ppo_vec.py
@@ -69,7 +69,11 @@ class StableBaseline3VecEnv(VecEnv):
 
     def step_async(self, actions: np.ndarray) -> None:
         self.action_dicts = [
-            {args.robot: {"dof_pos_target": dict(zip(self.env.scenario.robots[0].joint_limits.keys(), action))}}
+            {
+                args.robot: {
+                    "dof_pos_target": dict(zip(self.env.scenario.robots[0].joint_limits.keys(), action, strict=False))
+                }
+            }
             for action in actions
         ]
 

--- a/scripts/conversion/print_usd_joint_names.py
+++ b/scripts/conversion/print_usd_joint_names.py
@@ -32,7 +32,7 @@ joint_limits = obj.root_physx_view.get_dof_limits().squeeze(0).tolist()
 # joint_qpos = obj.root_physx_view.get_dof_positions()
 # print(joint_qpos)
 # print(obj.root_physx_view.get_dof_position_targets())
-for joint_name, joint_limit in zip(obj.joint_names, joint_limits):
+for joint_name, joint_limit in zip(obj.joint_names, joint_limits, strict=False):
     print(f"{joint_name}: ({joint_limit[0]:.4f}, {joint_limit[1]:.4f})")
 
 print("=" * 100)

--- a/scripts/eval_liberoplus_policy_consistency.py
+++ b/scripts/eval_liberoplus_policy_consistency.py
@@ -102,7 +102,7 @@ def _obs_diff(obss_a, obss_b) -> float:
     if not obss_a:
         raise RuntimeError("empty rollout: no observations were compared")
     diff = 0.0
-    for i, (pa, pb) in enumerate(zip(obss_a, obss_b)):
+    for i, (pa, pb) in enumerate(zip(obss_a, obss_b, strict=False)):
         ka, kb = _state_keys(pa), _state_keys(pb)
         if ka != kb:
             raise RuntimeError(
@@ -175,10 +175,10 @@ def run(max_steps: int = 120) -> int:
         # passthrough rollout, then an independently-constructed native rollout.
         sp, op, rp, dp, fp = _rollout(pt.make_liberoplus_env(suite, tid, seed=0), init_state, actions, max_steps)
         sn, on, rn, dn, fn = _rollout(_native_env(suite, tid, seed=0), init_state, actions, max_steps)
-        ds = max(float(np.abs(np.asarray(a) - np.asarray(b)).max()) for a, b in zip(sp, sn))
+        ds = max(float(np.abs(np.asarray(a) - np.asarray(b)).max()) for a, b in zip(sp, sn, strict=False))
         do = _obs_diff(op, on)
-        dr = max(abs(x - y) for x, y in zip(rp, rn))
-        dd = all(x == y for x, y in zip(dp, dn))
+        dr = max(abs(x - y) for x, y in zip(rp, rn, strict=False))
+        dd = all(x == y for x, y in zip(dp, dn, strict=False))
         succ_match = fp[-1] == fn[-1]
         worst = max(worst, ds, do, dr)
         ok = ds == 0.0 and do == 0.0 and dr == 0.0 and dd and succ_match

--- a/scripts/gen_libero_sidebyside.py
+++ b/scripts/gen_libero_sidebyside.py
@@ -69,10 +69,10 @@ def run(suite, base, variant, frames, sz, out):
     transforms = {"id": lambda x: x, "v": lambda x: x[::-1], "h": lambda x: x[:, ::-1], "vh": lambda x: x[::-1, ::-1]}
     best = min(transforms, key=lambda k: np.abs(native[0].astype(int) - transforms[k](meta[0]).astype(int)).mean())
     meta = [transforms[best](m) for m in meta]
-    mae = float(np.mean([np.abs(n.astype(int) - m.astype(int)).mean() for n, m in zip(native, meta)]))
+    mae = float(np.mean([np.abs(n.astype(int) - m.astype(int)).mean() for n, m in zip(native, meta, strict=False)]))
     print(f"MetaSim orientation match = '{best}'; per-frame native-vs-MetaSim pixel MAE = {mae:.2f}/255")
 
-    sbs = [np.concatenate([n, m], axis=1) for n, m in zip(native, meta)]
+    sbs = [np.concatenate([n, m], axis=1) for n, m in zip(native, meta, strict=False)]
     os.makedirs(os.path.dirname(out), exist_ok=True)
     import imageio
 

--- a/scripts/migrate_liberoplus_metasim.py
+++ b/scripts/migrate_liberoplus_metasim.py
@@ -166,7 +166,8 @@ def run(suite: str, n_frames: int, engine_steps: int) -> int:
             meta_frames = list(kinematic_rollout(handler, cam, states, image_size=SZ))
             mae = float(
                 np.mean([
-                    np.abs(a.astype(np.float32) - b.astype(np.float32)).mean() for a, b in zip(ref_frames, meta_frames)
+                    np.abs(a.astype(np.float32) - b.astype(np.float32)).mean()
+                    for a, b in zip(ref_frames, meta_frames, strict=False)
                 ])
             )
 

--- a/scripts/parity_liberoplus_passthrough.py
+++ b/scripts/parity_liberoplus_passthrough.py
@@ -147,7 +147,7 @@ def _compare(traj_a: list[dict], traj_b: list[dict]) -> tuple[float, float, floa
         raise RuntimeError("empty rollout: nothing was compared, so this is not parity")
     dev_state = dev_img = dev_rew = 0.0
     done_match = True
-    for i, (sa, sb) in enumerate(zip(traj_a, traj_b)):
+    for i, (sa, sb) in enumerate(zip(traj_a, traj_b, strict=False)):
         ka, kb = set(sa["obs"]), set(sb["obs"])
         if ka != kb:
             raise RuntimeError(

--- a/scripts/parity_policy_simpler_env.py
+++ b/scripts/parity_policy_simpler_env.py
@@ -137,7 +137,7 @@ def _diff_frames(nat, wrp):
     fn, fw = nat["frames"], wrp["frames"]
     if len(fn) != len(fw):
         diffs.append(f"length {len(fn)} vs {len(fw)}")
-    for i, (a, b) in enumerate(zip(fn, fw)):
+    for i, (a, b) in enumerate(zip(fn, fw, strict=False)):
         for k in ("obs", "rew", "term", "trunc", "success", "instr"):
             if a[k] != b[k]:
                 diffs.append(f"step{i}.{k}: {a[k]} != {b[k]}")

--- a/scripts/parity_superdex_tracking.py
+++ b/scripts/parity_superdex_tracking.py
@@ -264,7 +264,7 @@ def compare(a_path: str, b_path: str, *, plot: str | None = None) -> None:
         for ax in axes.ravel()[len(names) :]:
             ax.set_visible(False)
         t = np.arange(len(a["targets"]))
-        for j, (ax, jn) in enumerate(zip(axes.ravel(), names)):
+        for j, (ax, jn) in enumerate(zip(axes.ravel(), names, strict=False)):
             ax.plot(t, a["targets"][:, j], "k--", lw=1, label="target")
             ax.plot(t, a["measured"][:, j], lw=1.4, label=str(a["sim"]))
             ax.plot(t, b["measured"][:, j], lw=1.4, label=str(b["sim"]))

--- a/scripts/policy/eval_bc_liberoplus.py
+++ b/scripts/policy/eval_bc_liberoplus.py
@@ -183,7 +183,7 @@ def run(ckpt, suite, base, episodes, max_steps, exec_horizon):
     en = _native_env(suite, tid, 0)
     _, _, tn = _rollout(en, inits[0], policy, p_mean, p_std, max_steps=60, exec_horizon=exec_horizon, record=True)
     en.close()
-    dev = max((float(np.abs(a - b).max()) for a, b in zip(tp, tn)), default=float("nan"))
+    dev = max((float(np.abs(a - b).max()) for a, b in zip(tp, tn, strict=False)), default=float("nan"))
     print(f"\npassthrough == native under the policy: state max|Δ| over {min(len(tp), len(tn))} steps = {dev:.2e}")
     print("(deterministic policy + deterministic env -> bitwise identical eval through the passthrough)")
     return 0

--- a/tests/test_liberoplus_passthrough.py
+++ b/tests/test_liberoplus_passthrough.py
@@ -155,7 +155,7 @@ def test_passthrough_bitwise_matches_native():
     nat_traj = record(nat)
     nat.close()
 
-    for t, ((po, pr, pd), (no, nr, nd)) in enumerate(zip(pt_traj, nat_traj)):
+    for t, ((po, pr, pd), (no, nr, nd)) in enumerate(zip(pt_traj, nat_traj, strict=False)):
         assert set(po) == set(no), f"step{t}: obs key mismatch"
         for k in po:
             if any(h in k.lower() for h in ("image", "rgb", "depth")):

--- a/tests/test_maniskill_demo_replay.py
+++ b/tests/test_maniskill_demo_replay.py
@@ -84,7 +84,7 @@ def test_action_replay_grasp_lift():
 
     delta = np.abs(nat_cube - np.asarray(our_cube)).max()
     assert delta < 1e-3, f"cube replay delta vs native through grasp+lift too large: {delta:.3e}"
-    assert sum(int(a == b) for a, b in zip(nat_grasp, our_grasp)) >= T - 2
+    assert sum(int(a == b) for a, b in zip(nat_grasp, our_grasp, strict=False)) >= T - 2
     assert nat_cube[-1][2] > 0.2 and np.asarray(our_cube)[-1][2] > 0.2  # both actually lifted
 
 

--- a/tests/test_maniskill_reward_grasp.py
+++ b/tests/test_maniskill_reward_grasp.py
@@ -223,6 +223,6 @@ def test_is_grasped_matches_native():
         ours.append(is_grasped(task.handler, "cube"))
     task.close()
 
-    agreement = sum(int(a == b) for a, b in zip(native, ours))
+    agreement = sum(int(a == b) for a, b in zip(native, ours, strict=False))
     assert agreement >= T - 1, f"is_grasped agreement {agreement}/{T} too low (native={native}, ours={ours})"
     assert any(ours), "expected the controlled grasp to register as grasped"

--- a/tests/test_openarm_wuji_mount.py
+++ b/tests/test_openarm_wuji_mount.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import os
 import struct
 import xml.etree.ElementTree as ET
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import pytest
 

--- a/tests/test_simpler_env_passthrough.py
+++ b/tests/test_simpler_env_passthrough.py
@@ -115,7 +115,7 @@ def test_passthrough_matches_native_bitwise():
     fw = rollout(wrapped, acts)
     wrapped.close()
 
-    for (on, rn, tn, un, sn), (ow, rw, tw, uw, sw) in zip(fn, fw):
+    for (on, rn, tn, un, sn), (ow, rw, tw, uw, sw) in zip(fn, fw, strict=False):
         assert set(on) == set(ow)
         for k in on:
             assert np.array_equal(on[k], ow[k]), f"obs mismatch at {k}"
@@ -232,5 +232,5 @@ def test_closed_loop_policy_parity_native_vs_passthrough():
     fw = rollout(wrapped)
 
     assert len(fn) == len(fw), f"trajectory length differs: {len(fn)} vs {len(fw)}"
-    for i, (a, b) in enumerate(zip(fn, fw)):
+    for i, (a, b) in enumerate(zip(fn, fw, strict=False)):
         assert a == b, f"closed-loop divergence at step {i}: {a} != {b}"

--- a/tests/test_task_reset_seed_contract.py
+++ b/tests/test_task_reset_seed_contract.py
@@ -203,7 +203,7 @@ def _reset_violations(fn: ast.FunctionDef) -> list[str]:
     # (3) any extra parameter must have a default (positional defaults bind to the tail).
     n_pos_defaults = len(a.defaults)
     required_positional = positional[: len(positional) - n_pos_defaults]
-    required_kwonly = [p.arg for p, d in zip(a.kwonlyargs, a.kw_defaults) if d is None]
+    required_kwonly = [p.arg for p, d in zip(a.kwonlyargs, a.kw_defaults, strict=False) if d is None]
     extra_required = [p for p in (*required_positional, *required_kwonly) if p not in _CONTRACT_PARAMS]
     if extra_required:
         bad.append(f"adds required parameter(s) {', '.join(extra_required)} (give them defaults)")

--- a/tools/maniskill_integration/maniskill_rollout.py
+++ b/tools/maniskill_integration/maniskill_rollout.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
 
 import numpy as np
 

--- a/tools/maniskill_integration/metasim_rollout.py
+++ b/tools/maniskill_integration/metasim_rollout.py
@@ -10,9 +10,9 @@ gap-analysis section.
 from __future__ import annotations
 
 import copy
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable
 
 import numpy as np
 

--- a/tools/maniskill_integration/render_demo_replay.py
+++ b/tools/maniskill_integration/render_demo_replay.py
@@ -108,7 +108,7 @@ def _robot_map(task, g):
     shipped_names = list(getattr(task, "robot_names", None) or [getattr(task, "robot_name", "panda")])
     if len(demo_keys) != len(shipped_names):
         raise RuntimeError(f"robot count mismatch: demo {demo_keys} vs shipped {shipped_names}")
-    return list(zip(demo_keys, shipped_names))
+    return list(zip(demo_keys, shipped_names, strict=False))
 
 
 def _shipped_rollout(task, g, goal_actor, scene_objs, record_state: bool, actor_remap=None, track: str | None = None):
@@ -376,7 +376,7 @@ def run(
     H = native_frames[0].shape[0]
     pad = np.zeros((H, 6, 3), np.uint8)
     comp, diffs = [], []
-    for nf, mf in zip(native_frames, shipped_frames):
+    for nf, mf in zip(native_frames, shipped_frames, strict=False):
         d = np.abs(nf.astype(np.int16) - mf.astype(np.int16))
         diffs.append(float(d.mean()))
         dvis = np.clip(d * 8, 0, 255).astype(np.uint8)

--- a/tools/maniskill_integration/render_parity.py
+++ b/tools/maniskill_integration/render_parity.py
@@ -169,7 +169,7 @@ def run(task_id: str, steps: int, seed: int, amp: float, out_path: Path, shipped
     H = native_frames[0].shape[0]
     pad = np.zeros((H, 6, 3), np.uint8)
     comp, diffs = [], []
-    for nf, mf in zip(native_frames, metasim_frames):
+    for nf, mf in zip(native_frames, metasim_frames, strict=False):
         d = np.abs(nf.astype(np.int16) - mf.astype(np.int16))
         diffs.append(float(d.mean()))
         dvis = np.clip(d * 8, 0, 255).astype(np.uint8)

--- a/tools/mjlab_integration/full_runner.py
+++ b/tools/mjlab_integration/full_runner.py
@@ -17,8 +17,8 @@ import json
 import os
 import sys
 import traceback
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 from . import inventory as inv
 from .diff import diff_rollouts

--- a/tools/mjlab_integration/metasim_rollout.py
+++ b/tools/mjlab_integration/metasim_rollout.py
@@ -20,8 +20,8 @@ from __future__ import annotations
 import glob
 import os
 import tempfile
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
 
 import mujoco
 import numpy as np

--- a/tools/mjlab_integration/policy_replay/extract_curves.py
+++ b/tools/mjlab_integration/policy_replay/extract_curves.py
@@ -68,7 +68,7 @@ def plot_run(run_dir: Path, task_name: str, out_png: Path, scalars: dict) -> dic
     def _plot(ax, candidates, title, ylabel, scale_y=False):
         for cand in candidates:
             if cand in scalars:
-                xs, ys = zip(*scalars[cand])
+                xs, ys = zip(*scalars[cand], strict=False)
                 ax.plot(xs, ys, lw=1.5, label=cand.split("/")[-1])
                 break
         ax.set_title(title, fontsize=11)
@@ -98,7 +98,7 @@ def plot_run(run_dir: Path, task_name: str, out_png: Path, scalars: dict) -> dic
     summary = {"task": task_name, "run_dir": str(run_dir)}
     for r in ("Train/mean_reward", "rollout/ep_rew_mean", "Train/Mean Reward"):
         if scalars.get(r):
-            xs, ys = zip(*scalars[r])
+            xs, ys = zip(*scalars[r], strict=False)
             summary["iter_final"] = int(xs[-1])
             summary["reward_final"] = float(ys[-1])
             summary["reward_max"] = float(np.max(ys))

--- a/tools/mjlab_integration/policy_replay/plot_metasim_curve.py
+++ b/tools/mjlab_integration/policy_replay/plot_metasim_curve.py
@@ -104,7 +104,7 @@ def main(argv=None) -> int:
     colors = ["steelblue", "darkorange", "green", "purple"]
 
     ax = axes[0, 0]
-    for (label, log), c in zip(logs, colors):
+    for (label, log), c in zip(logs, colors, strict=False):
         ax.plot(log["iters"], log["ep_r"], lw=1.5, color=c, label=label)
     ax.axhline(
         args.mjlab_reference, color="red", linestyle="--", lw=1, label=f"mjlab native ({args.mjlab_reference:.2f})"
@@ -117,7 +117,7 @@ def main(argv=None) -> int:
     ax.grid(alpha=0.3)
 
     ax = axes[0, 1]
-    for (label, log), c in zip(logs, colors):
+    for (label, log), c in zip(logs, colors, strict=False):
         # smooth step_r with rolling mean for readability
         x = log["iters"]
         y = log["step_r"]
@@ -132,7 +132,7 @@ def main(argv=None) -> int:
     ax.legend(fontsize=8)
 
     ax = axes[1, 0]
-    for (label, log), c in zip(logs, colors):
+    for (label, log), c in zip(logs, colors, strict=False):
         ax.plot(log["iters"], log["v"], lw=1.0, color=c, label=label)
     ax.set_title("Value loss")
     ax.set_xlabel("iteration")
@@ -142,7 +142,7 @@ def main(argv=None) -> int:
     ax.legend(fontsize=8)
 
     ax = axes[1, 1]
-    for (label, log), c in zip(logs, colors):
+    for (label, log), c in zip(logs, colors, strict=False):
         ax.plot(log["iters"], log["ent"], lw=1.0, color=c, label=label)
     ax.set_title("Entropy (action distribution)")
     ax.set_xlabel("iteration")

--- a/tools/mjlab_integration/raw_rollout.py
+++ b/tools/mjlab_integration/raw_rollout.py
@@ -10,9 +10,9 @@ evolution is the same.
 from __future__ import annotations
 
 import math
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
 
 import mujoco
 import numpy as np

--- a/tools/robosuite_integration/benchmark_replay.py
+++ b/tools/robosuite_integration/benchmark_replay.py
@@ -185,7 +185,7 @@ def render_qpos_replay_with_success(
         opt.sitegroup[g] = 0
 
     ref_frames, ms_frames, flags = [], [], []
-    for rq, mq in zip(ref_qpos, ms_qpos):
+    for rq, mq in zip(ref_qpos, ms_qpos, strict=False):
         env.sim.data.qpos[:nq] = rq[:nq]
         env.sim.data.qvel[:] = 0
         env.sim.forward()

--- a/tools/robosuite_integration/common.py
+++ b/tools/robosuite_integration/common.py
@@ -15,9 +15,9 @@ isolates the engine from robosuite's OSC controller.
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
 
 import numpy as np
 

--- a/tools/robosuite_integration/robosuite_rollout.py
+++ b/tools/robosuite_integration/robosuite_rollout.py
@@ -15,9 +15,9 @@ Two capture modes:
 from __future__ import annotations
 
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable
 
 import numpy as np
 

--- a/tools/robotwin_integration/dp_policy_server.py
+++ b/tools/robotwin_integration/dp_policy_server.py
@@ -128,7 +128,7 @@ class _DPInference:
         if not isinstance(cameras, dict):  # back-compat: a bare head_camera array
             cameras = {"head_camera": cameras}
         step = {}
-        for obs_key, cam_name in zip(self.cam_obs_keys, self.cam_names):
+        for obs_key, cam_name in zip(self.cam_obs_keys, self.cam_names, strict=False):
             rgb = cameras.get(cam_name, cameras.get("head_camera"))
             img = torch.from_numpy(np.ascontiguousarray(rgb)).to(self.device).float() / 255.0
             step[obs_key] = img.permute(2, 0, 1).unsqueeze(0)  # (1, 3, H, W)

--- a/tools/robotwin_integration/mesh_replay_robotwin.py
+++ b/tools/robotwin_integration/mesh_replay_robotwin.py
@@ -360,7 +360,7 @@ def _replay_one(bridge: dict, args) -> dict:
                 jn, cols, jtraj = artic_drive[rv]
                 if cols is not None:
                     q = jtraj[min(t, len(jtraj) - 1)]
-                    st["dof_pos"] = {j: (float(q[c]) if c is not None else 0.0) for j, c in zip(jn, cols)}
+                    st["dof_pos"] = {j: (float(q[c]) if c is not None else 0.0) for j, c in zip(jn, cols, strict=False)}
                 else:
                     st["dof_pos"] = {j: 0.0 for j in jn}
             out[rv] = st


### PR DESCRIPTION
Stacked on #820; retarget to main once that merges.

Release-chain items from the architecture review (the chain could not ship):

- **Direct-URL dependencies** — PyPI rejects them in published metadata. `newton` → `newton>=1.5,<2` (wheel on PyPI; our `_newton_compat` covers 1.5/1.6), `sapien2` → `mani-skill2==0.5.3` (on PyPI), `robo-splatter` (git-only) → `packages/metasim/requirements/robosplatter.txt`.
- **Version header** — CHANGELOG said `[1.0.0-beta]` while `pyproject` says `1.0.0b0`; `release.yml` extracts notes by the pyproject version, so the first real release would have shipped empty notes. Aligned.
- **Python matrix** — `requires-python = ">=3.10,<3.13"` in both packages (was `>=3.8` / `>=3.10`; CI is 3.10/3.11, SuperDex needs 3.12); ruff `target-version = "py310"` (was `py38`), with the resulting 142 findings fixed where safe (`zip(strict=…)`, PEP 604/585 spellings) and per-file-ignored for the four files that use `typing` aliases at runtime.
- **uv conflicts** — the isaacsim / isaacsim211 / mjx / isaacgym extras pin incompatible torch/CUDA stacks; declared mutually exclusive so resolvers fail with a message instead of picking one.
- **release-dry-run job** (tests.yml): builds both distributions, `twine check --strict`, fails on any direct-URL dependency or mismatched package versions — the release workflow's preconditions, checked on every PR.

Verified locally: MetaSim general 511 passed (contract test updated for the new `requires-python`), RoboVerse tests 493 passed, `ruff check` / `format --check` clean, no direct-URL deps, versions agree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw