### PR TITLE
docs(tools): a README per integration

### DIFF
--- a/tools/libero_integration/README.md
+++ b/tools/libero_integration/README.md
@@ -1,0 +1,14 @@
+# LIBERO integration
+
+LIBERO / LIBERO+ tasks reproduced 1:1 in MetaSim (bitwise MuJoCo parity) and replayed without a
+robosuite dependency.
+
+| Module | Purpose |
+|---|---|
+| `vendor_native_libero.py`, `vendor_shared_assets.py`, `vendor_all_native.py` | copy the upstream LIBERO MJCF bundles and shared assets into `roboverse_pack/tasks/libero/native_bundles/` |
+| `gen_liberoplus.py` | generate the LIBERO+ task variants (`liberoplus_tasks.json`, `liberoplus_cheap_tasks.json`) |
+| `libero_replay.py`, `libero_success.py` | replay upstream demonstrations in MetaSim and evaluate the LIBERO success predicates |
+| `liberoplus_native_smoke.py`, `verify_liberoplus.py`, `sweep_all.py` | smoke / verification sweeps across the suite |
+
+Run from the repository root, e.g. `python -m tools.libero_integration.vendor_native_libero`.
+Requires the `roboverse_data` checkout; upstream LIBERO is only needed for vendoring.

--- a/tools/maniskill_integration/README.md
+++ b/tools/maniskill_integration/README.md
@@ -1,0 +1,14 @@
+# ManiSkill integration
+
+ManiSkill3 tasks brought into MetaSim on SAPIEN, with a parity harness that compares observations,
+rewards and rollouts against upstream.
+
+| Module | Purpose |
+|---|---|
+| `recipe.py`, `inventory.py` | the ManiSkill sim/control recipe (`sim_freq`, `control_freq`, decimation) and the task inventory used by `roboverse_pack/tasks/maniskill/_native` |
+| `parity_native.py`, `parity_multi_agent.py` | run a task on ManiSkill and on MetaSim from the same seed and report the per-step deltas |
+| `maniskill_rollout.py`, `metasim_rollout.py`, `replay_demo.py`, `render_demo_replay.py` | rollouts and demonstration replay on either side |
+| `render_compare.py`, `render_parity.py`, `render_passthrough.py`, `run_sweep.py` | rendered side-by-side galleries and sweeps |
+
+Run from the repository root, e.g. `python -m tools.maniskill_integration.parity_native --task pick_cube`.
+Requires `mani_skill` and `sapien` (extra `sapien3`) for the upstream side.

--- a/tools/mjlab_integration/README.md
+++ b/tools/mjlab_integration/README.md
@@ -1,0 +1,15 @@
+# mjlab integration
+
+mjlab (MuJoCo locomotion / manipulation tasks) reproduced in MetaSim as the `mjlab.*` task family,
+with rollout, reward and rendering comparisons against upstream.
+
+| Module | Purpose |
+|---|---|
+| `runner.py`, `full_runner.py` | run an mjlab task on MetaSim (and, with upstream installed, on mjlab) and compare |
+| `metasim_rollout.py`, `raw_rollout.py`, `stand_demo.py` | rollouts of the ported tasks; `g1_walk/` holds the G1 walking reference |
+| `reward_sweep.py`, `rewards.py`, `plot.py` | reward-term parity sweeps and plots |
+| `render.py`, `render_sweep.py` | rendered comparisons |
+| `diagnose_*.py`, `diff.py`, `dump_metasim_xml.py`, `inventory.py` | diagnostics for MJCF patching, geometry and attachment positions |
+
+Run from the repository root, e.g. `python -m tools.mjlab_integration.runner --task mjlab.cartpole_v2`.
+The mjlab assets are downloaded from Hugging Face on first use (`roboverse_pack/tasks/mjlab/_locator.py`).

--- a/tools/robosuite_integration/README.md
+++ b/tools/robosuite_integration/README.md
@@ -1,0 +1,13 @@
+# robosuite integration
+
+robosuite tasks reproduced in MetaSim with a robosuite-free replay path and a parity harness.
+
+| Module | Purpose |
+|---|---|
+| `vendor_assets.py`, `inventory.py`, `common.py` | vendor the upstream MJCF assets and enumerate tasks |
+| `robosuite_rollout.py`, `metasim_rollout.py`, `replay_parity.py`, `benchmark_replay.py` | rollouts on both sides and replay parity |
+| `verify_native.py`, `verify_native_controller.py`, `verify_robosuite_free.py` | verify the native task registration, the ported OSC controller and the robosuite-free path |
+| `coverage_sweep.py`, `runner.py`, `policies.py`, `render.py`, `plots.py`, `diff.py` | sweeps, scripted policies, rendering and reports |
+
+Run from the repository root, e.g. `python -m tools.robosuite_integration.verify_native`.
+Requires `robosuite` only for the upstream side of a parity run.

--- a/tools/robotwin_integration/README.md
+++ b/tools/robotwin_integration/README.md
@@ -1,0 +1,15 @@
+# RoboTwin integration
+
+RoboTwin (50 bimanual ALOHA tasks) brought into MetaSim on SAPIEN: demonstration conversion, replay,
+rendering and policy evaluation.
+
+| Module | Purpose |
+|---|---|
+| `migrate_assets.py`, `inventory.py` | migrate the RoboTwin assets into `roboverse_data` and enumerate tasks |
+| `robotwin_to_demo.py`, `collect_bridge.py`, `collect_demos_robust.sh` | convert / collect demonstrations |
+| `aloha_demo.py`, `aloha_render.py`, `mesh_replay_robotwin.py`, `native_render.py`, `sidebyside.py` | replay and rendered comparisons |
+| `parity_robotwin.py`, `coverage_sweep.py` | parity harness and coverage sweep |
+| `dp_policy_server.py`, `eval_robotwin_policy.py` | serve a diffusion policy and evaluate it on the ported tasks |
+
+Run from the repository root, e.g. `python -m tools.robotwin_integration.aloha_demo`.
+Requires `sapien` (extra `sapien3`); the RoboTwin checkout is only needed for migration.


### PR DESCRIPTION
The five `tools/*_integration/` packages (14 kLOC) had no README; each now states what it integrates, maps its modules to purposes, and gives the `python -m tools.<pkg>.<module>` entry point the docs already use. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw