### PR TITLE
feat(sim): backend version policy — declared ranges, doctor command, weekly latest-version CI, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+version: 2
+# Simulator backends release often and break APIs between minor versions. Dependabot opens one
+# grouped PR per package root per week; the backend-compat workflow decides whether the new
+# versions actually work before `tested` in metasim/sim/_versions.py is bumped.
+updates:
+  - package-ecosystem: pip
+    directory: /packages/metasim
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      simulators:
+        patterns: ["mujoco*", "newton", "warp-lang", "sapien", "pybullet", "genesis-world", "superdex-*", "jax*", "dm-control"]
+      python-deps:
+        patterns: ["*"]
+        exclude-patterns: ["mujoco*", "newton", "warp-lang", "sapien", "pybullet", "genesis-world", "superdex-*", "jax*", "dm-control"]
+    labels: ["dependencies", "no-changelog"]
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    groups:
+      python-deps:
+        patterns: ["*"]
+    labels: ["dependencies", "no-changelog"]
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    labels: ["dependencies", "no-changelog"]

--- a/.github/workflows/backend-compat.yml
+++ b/.github/workflows/backend-compat.yml
@@ -1,0 +1,69 @@
+name: backend-compat
+
+# Weekly: install the NEWEST release of each CPU-installable simulator backend (not the pinned
+# `tested` version) and run that backend's MetaSim suite plus `metasim doctor`. A red lane means
+# the next upgrade will break users; it opens (or updates) an issue with the failing versions so
+# the compat shim / `spec` / `tested` in metasim/sim/_versions.py get updated deliberately.
+# GPU-only backends (Isaac Sim / Isaac Gym / Newton with CUDA / MJX) are covered by the
+# merge-queue workflow on the GPU runner, not here.
+
+on:
+  schedule:
+    - cron: "17 6 * * 1"  # Mondays 06:17 UTC, after Dependabot has opened its PRs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  latest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - backend: mujoco
+            python: "3.11"
+            install: "mujoco dm-control"
+          - backend: pybullet
+            python: "3.11"
+            install: "pybullet"
+          - backend: superdex
+            python: "3.12"
+            install: "superdex-physics superdex-robotics pyrender trimesh"
+    name: ${{ matrix.backend }} @ latest (py${{ matrix.python }})
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install MetaSim, then the backend at its newest release
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
+          python -m pip install -e "packages/metasim[dev,examples]"
+          python -m pip install --upgrade ${{ matrix.install }}
+      - name: Report versions
+        id: doctor
+        run: |
+          python -m metasim doctor --backend ${{ matrix.backend }} | tee doctor.txt
+          echo "versions<<EOF" >> "$GITHUB_OUTPUT"; cat doctor.txt >> "$GITHUB_OUTPUT"; echo "EOF" >> "$GITHUB_OUTPUT"
+      - name: Backend suite
+        working-directory: packages/metasim
+        env:
+          MUJOCO_GL: disable
+          METASIM_SKIP_VERSION_CHECK: "1"  # the point is to run on versions outside `tested`
+        run: python -m pytest -k "${{ matrix.backend }}" -q -rs -p no:cacheprovider
+      - name: Open or update the tracking issue on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BACKEND: ${{ matrix.backend }}
+          VERSIONS: ${{ steps.doctor.outputs.versions }}
+        run: |
+          title="backend-compat: ${BACKEND} @ latest fails"
+          body=$(printf 'The weekly compatibility run of the **%s** backend against its newest release failed.\n\nRun: %s/%s/actions/runs/%s\n\n```\n%s\n```\n\nNext: fix or shim in `packages/metasim/metasim/sim/%s/`, then update `spec` / `tested` in `metasim/sim/_versions.py`.' "$BACKEND" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" "$VERSIONS" "$BACKEND")
+          existing=$(gh issue list --search "\"$title\" in:title" --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then gh issue comment "$existing" --body "$body"; else gh issue create --title "$title" --body "$body" --label backend-compat; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ release.
   import name `metasim` unchanged). The pin moves to a MetaSim tag with the next release.
 
 ### Added
+- `backend-compat.yml`: weekly workflow that installs the newest release of each CPU-installable simulator backend (MuJoCo, PyBullet, SuperDex), runs `metasim doctor` and the backend's suite, and opens a `backend-compat` issue on failure; `.github/dependabot.yml` groups simulator bumps into weekly PRs.
 - Third-party attribution: `NOTICE` and `THIRD_PARTY_NOTICES.md` index every vendored or adapted component (FastTD3, CleanRL, stable-baselines3, diffusion_policy, BeT/minGPT, ACT/DETR, Isaac Lab, RSL-RL, BeyondMimic, gsnet/pointnet2, MuJoCo mesh tools, …) with its license text in-tree; adapted files carry a header naming upstream, license, changes and the license path; `tests/test_attribution.py` fails the build when a header or an index row is missing; wheels ship `NOTICE`, the index and the vendored `LICENSE*` files (`setuptools>=77`, PEP 639 `license-files`).
 
 - `--sim superdex` in every MuJoCo-capable `get_started` tutorial and a `roboverse-py[superdex]`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -109,3 +109,22 @@ nothing outside `packages/metasim` may import a `metasim.sim.*` underscore name,
 The former standalone repository `RoboVerseOrg/MetaSim` is a read-only mirror of `packages/metasim`
 kept for one release cycle so `git+https://github.com/RoboVerseOrg/MetaSim.git` installs keep
 working; new work happens here.
+
+## 8. Simulator backend versions
+
+Simulator packages change their APIs between minor releases. The policy is declarative and checked:
+
+- `packages/metasim/metasim/sim/_versions.py` lists, per backend, the distributions it depends on,
+  the version range its code paths support (`spec`) and the exact version its test suite last
+  passed with (`tested`). `get_sim_handler_class` refuses a version outside `spec` (message names
+  the installed and supported versions; `METASIM_SKIP_VERSION_CHECK=1` downgrades it to a warning)
+  and warns once on an untested version inside it.
+- `python -m metasim doctor` prints the table for every backend (`--json` for scripts; exit 1 when
+  an installed backend is unsupported). Run it first when a simulator misbehaves; paste it in issues.
+- `backend-compat.yml` runs weekly (and on demand): it installs the **newest** release of each
+  CPU-installable backend, runs `metasim doctor` and that backend's suite, and opens/updates a
+  `backend-compat` issue on failure. GPU backends are covered by the merge-queue workflow.
+- Dependabot (`.github/dependabot.yml`) groups simulator bumps into one weekly PR per package root.
+- When a new simulator release passes: bump `tested`; when a range must widen or a shim is needed:
+  change `spec` and the compat module (`metasim/sim/<backend>/_*_compat.py`) in the same PR, with a
+  CHANGELOG line. Never widen `spec` without a passing run.

--- a/packages/metasim/AGENTS.md
+++ b/packages/metasim/AGENTS.md
@@ -46,6 +46,10 @@ For testing infrastructure details, also refer to:
 - For unsupported backends or unsupported code paths, prefer an explicit error over silent success.
 - Do not turn an explicit unsupported-operation failure into a silent no-op unless there is a strong reason.
 
+## Backend Versions
+
+- Every simulator dependency is declared in `metasim/sim/_versions.py` (supported range + last verified version). Touching a backend for a new simulator release means updating that table in the same PR; `python -m metasim doctor` shows the installed state. See `RELEASING.md` §8.
+
 ## Testing Rules For `metasim/test`
 
 ### Source Of Truth

--- a/packages/metasim/CHANGELOG.md
+++ b/packages/metasim/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tree is `ruff check` / `ruff format` clean at the pre-commit pin (0.14.5).
 
 ### Added
+- Backend version policy: `metasim/sim/_versions.py` declares, per backend, the supported version range and the last verified version of every simulator package; `get_sim_handler_class` refuses unsupported releases (`METASIM_SKIP_VERSION_CHECK=1` to override) and warns once on untested ones; `python -m metasim doctor [--json] [--backend X]` reports the table. `packaging` is a runtime dependency.
 - `BaseTaskEnv.supported_simulators`: a task class declares the backends it is known to run on; constructing it with another `scenario.simulator` raises `ValueError` before any handler is built. `None` (the default) keeps today's unchecked behaviour.
 
 - **SuperDex backend** (`metasim/sim/superdex/`, `simulator="superdex"`, extra `metasim[superdex]`,

--- a/packages/metasim/metasim/__main__.py
+++ b/packages/metasim/metasim/__main__.py
@@ -1,0 +1,66 @@
+"""``python -m metasim <command>``.
+
+* ``doctor`` — every simulator backend: installed package versions vs the supported range and the
+  last verified version (``metasim/sim/_versions.py``). Exit status 1 when an installed backend is
+  outside its supported range, so it can gate an environment in CI or a Dockerfile.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from metasim.constants import SimType
+from metasim.sim._versions import BACKEND_REQUIREMENTS, doctor, format_reports
+
+
+def _doctor(args: argparse.Namespace) -> int:
+    sims = [SimType(b) for b in args.backend] if args.backend else None
+    reports = doctor(sims)
+    if args.json:
+        payload = [
+            {
+                "backend": r.sim.value,
+                "installed": r.installed,
+                "requirements": [
+                    {
+                        "dist": s.requirement.dist,
+                        "installed": s.installed,
+                        "supported": s.requirement.spec,
+                        "tested": s.requirement.tested,
+                        "status": s.label,
+                    }
+                    for s in r.statuses
+                ],
+            }
+            for r in reports
+        ]
+        print(json.dumps(payload, indent=2))
+    else:
+        print(format_reports(reports))
+        bad = [r for r in reports if r.unsupported]
+        if bad:
+            print(f"\nUNSUPPORTED versions installed for: {', '.join(r.sim.value for r in bad)}", file=sys.stderr)
+    return 1 if any(r.unsupported for r in reports) else 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse ``argv`` and run the selected sub-command; returns the process exit status."""
+    parser = argparse.ArgumentParser(prog="python -m metasim")
+    sub = parser.add_subparsers(dest="command", required=True)
+    d = sub.add_parser("doctor", help="check installed simulator versions against the supported ranges")
+    d.add_argument(
+        "--backend",
+        action="append",
+        choices=[s.value for s in BACKEND_REQUIREMENTS],
+        help="limit to one backend (repeatable)",
+    )
+    d.add_argument("--json", action="store_true")
+    d.set_defaults(func=_doctor)
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/metasim/metasim/sim/_versions.py
+++ b/packages/metasim/metasim/sim/_versions.py
@@ -1,0 +1,205 @@
+"""Backend version policy: what each simulator backend requires, what it was last verified with.
+
+Simulator packages move fast and break APIs between minor releases (newton 1.2 → 1.5 → 1.6 each
+renamed core fields; MuJoCo changed its arena defaults; SuperDex is pre-1.0 in spirit). Instead of
+discovering that at the first ``AttributeError`` deep inside a handler, every backend declares:
+
+* ``spec`` — the version range the handler's code paths are written for. Outside it, creating the
+  handler raises :class:`BackendVersionError` (``METASIM_SKIP_VERSION_CHECK=1`` overrides).
+* ``tested`` — the exact version the backend's test suite last passed with. A different version
+  inside ``spec`` only warns once, so the log says "untested" before anything else goes wrong.
+
+``python -m metasim doctor`` prints the table for every backend; the weekly ``backend-compat``
+workflow installs the newest release of each CPU-installable backend and runs its suite, so
+``tested`` is bumped deliberately, not by accident.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as dist_version
+
+from loguru import logger as log
+from packaging.specifiers import SpecifierSet
+from packaging.version import InvalidVersion, Version
+
+from metasim.constants import SimType
+
+
+class BackendVersionError(RuntimeError):
+    """An installed simulator package is outside the range the backend supports."""
+
+
+@dataclass(frozen=True)
+class Requirement:
+    """One distribution a backend depends on."""
+
+    dist: str
+    spec: str
+    tested: str = ""
+    optional: bool = False
+    """Optional distributions (viewers, renderers) are reported but never block handler creation."""
+
+
+@dataclass
+class RequirementStatus:
+    """The installed state of one :class:`Requirement`."""
+
+    requirement: Requirement
+    installed: str | None
+    in_spec: bool | None  # None when not installed
+    is_tested: bool | None
+
+    @property
+    def label(self) -> str:
+        if self.installed is None:
+            return "missing" if not self.requirement.optional else "absent (optional)"
+        if not self.in_spec:
+            return "UNSUPPORTED"
+        return "ok" if self.is_tested or not self.requirement.tested else "untested"
+
+
+@dataclass
+class BackendVersionReport:
+    """Every requirement of one backend, with a verdict."""
+
+    sim: SimType
+    statuses: list[RequirementStatus] = field(default_factory=list)
+
+    @property
+    def installed(self) -> bool:
+        required = [s for s in self.statuses if not s.requirement.optional]
+        return bool(required) and all(s.installed is not None for s in required)
+
+    @property
+    def unsupported(self) -> list[RequirementStatus]:
+        return [
+            s for s in self.statuses if s.installed is not None and s.in_spec is False and not s.requirement.optional
+        ]
+
+    @property
+    def untested(self) -> list[RequirementStatus]:
+        return [
+            s
+            for s in self.statuses
+            if s.installed is not None and s.in_spec and s.requirement.tested and not s.is_tested
+        ]
+
+
+# Ranges are the versions the handler code paths target (see the compat modules under
+# metasim/sim/<backend>/); ``tested`` is the last version the backend suite passed with. Keep both
+# honest: widen ``spec`` only with a passing run, bump ``tested`` from the backend-compat workflow.
+BACKEND_REQUIREMENTS: dict[SimType, tuple[Requirement, ...]] = {
+    SimType.MUJOCO: (
+        Requirement("mujoco", ">=3.2,<3.14", tested="3.12.0"),
+        Requirement("dm-control", ">=1.0.20,<2", tested="1.0.45"),
+    ),
+    SimType.MJX: (
+        Requirement("mujoco", ">=3.2,<3.14", tested="3.12.0"),
+        Requirement("mujoco-mjx", ">=3.2.7,<3.14"),
+        Requirement("jax", ">=0.4.30,<0.8"),
+    ),
+    SimType.NEWTON: (
+        Requirement("newton", ">=1.5,<2", tested="1.6.0.dev0"),
+        Requirement("warp-lang", ">=1.11,<2", tested="1.17.0"),
+        Requirement("mujoco-warp", ">=0.0.1", tested="3.12.0"),
+        Requirement("mujoco", ">=3.3.7,<3.14", tested="3.12.0"),
+    ),
+    SimType.SUPERDEX: (
+        Requirement("superdex-physics", ">=1.0,<2", tested="1.0.0"),
+        Requirement("superdex-robotics", ">=1.0,<2", tested="1.0.0"),
+        Requirement("pyrender", ">=0.1.45", optional=True),
+    ),
+    SimType.SAPIEN3: (Requirement("sapien", ">=3.0.0b1,<4"),),
+    SimType.SAPIEN2: (Requirement("sapien", ">=2.2,<3"),),
+    SimType.PYBULLET: (Requirement("pybullet", ">=3.2,<4"),),
+    SimType.GENESIS: (Requirement("genesis-world", ">=0.2,<1"),),
+    SimType.ISAACSIM: (Requirement("isaacsim", ">=4.5,<5.1"),),
+    SimType.ISAACGYM: (Requirement("isaacgym", ">=1.0rc4"),),
+    SimType.BLENDER: (Requirement("bpy", ">=4.0,<5"),),
+}
+
+
+def _installed(dist: str) -> str | None:
+    try:
+        return dist_version(dist)
+    except PackageNotFoundError:
+        return None
+
+
+def _status(req: Requirement) -> RequirementStatus:
+    installed = _installed(req.dist)
+    if installed is None:
+        return RequirementStatus(req, None, None, None)
+    try:
+        in_spec = Version(installed) in SpecifierSet(req.spec, prereleases=True)
+    except InvalidVersion:
+        in_spec = False
+    is_tested = (installed == req.tested) if req.tested else None
+    return RequirementStatus(req, installed, in_spec, is_tested)
+
+
+def check_backend(sim: SimType) -> BackendVersionReport:
+    """Inspect the packages backing ``sim`` without importing them."""
+    return BackendVersionReport(sim, [_status(r) for r in BACKEND_REQUIREMENTS.get(sim, ())])
+
+
+_WARNED: set[SimType] = set()
+
+
+def enforce_backend_versions(sim: SimType) -> BackendVersionReport:
+    """Called before a handler class is imported: raise on an unsupported version, warn once on an
+    untested one. ``METASIM_SKIP_VERSION_CHECK=1`` turns the error into a warning.
+    """
+    report = check_backend(sim)
+    if report.unsupported:
+        lines = ", ".join(
+            f"{s.requirement.dist} {s.installed} (supported: {s.requirement.spec})" for s in report.unsupported
+        )
+        message = (
+            f"{sim.value}: installed simulator packages are outside the range this backend supports: {lines}. "
+            f"Install a supported version, or set METASIM_SKIP_VERSION_CHECK=1 to proceed at your own risk."
+        )
+        if os.environ.get("METASIM_SKIP_VERSION_CHECK") == "1":
+            log.warning(message)
+        else:
+            raise BackendVersionError(message)
+    if report.untested and sim not in _WARNED:
+        _WARNED.add(sim)
+        lines = ", ".join(
+            f"{s.requirement.dist} {s.installed} (last verified: {s.requirement.tested})" for s in report.untested
+        )
+        log.warning(
+            f"{sim.value}: running on a simulator version the test suite has not been run against: {lines}. "
+            f"`python -m metasim doctor` shows the full table; report breakage with these versions."
+        )
+    return report
+
+
+def doctor(sims: list[SimType] | None = None) -> list[BackendVersionReport]:
+    """Reports for every backend (or ``sims``)."""
+    return [check_backend(s) for s in (sims or list(BACKEND_REQUIREMENTS))]
+
+
+def format_reports(reports: list[BackendVersionReport]) -> str:
+    """A fixed-width table for terminals."""
+    rows = [("backend", "package", "installed", "supported", "last verified", "status")]
+    for rep in reports:
+        for st in rep.statuses:
+            rows.append((
+                rep.sim.value,
+                st.requirement.dist,
+                st.installed or "-",
+                st.requirement.spec,
+                st.requirement.tested or "-",
+                st.label,
+            ))
+    widths = [max(len(r[i]) for r in rows) for i in range(len(rows[0]))]
+    out = []
+    for i, r in enumerate(rows):
+        out.append("  ".join(c.ljust(w) for c, w in zip(r, widths, strict=True)).rstrip())
+        if i == 0:
+            out.append("  ".join("-" * w for w in widths))
+    return "\n".join(out)

--- a/packages/metasim/metasim/test/test_backend_versions_general.py
+++ b/packages/metasim/metasim/test/test_backend_versions_general.py
@@ -1,0 +1,69 @@
+"""Backend version policy (``metasim.sim._versions``): the gate refuses unsupported releases, warns
+once on untested ones, and ``python -m metasim doctor`` reports every backend."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+from metasim.constants import SimType
+from metasim.sim import _versions as v
+
+
+def _fake_installed(monkeypatch, table: dict[str, str | None]):
+    monkeypatch.setattr(v, "_installed", lambda dist: table.get(dist))
+
+
+@pytest.mark.general
+def test_unsupported_version_raises_with_both_versions_in_the_message(monkeypatch):
+    _fake_installed(monkeypatch, {"mujoco": "2.3.7", "dm-control": "1.0.45"})
+    monkeypatch.delenv("METASIM_SKIP_VERSION_CHECK", raising=False)
+    with pytest.raises(v.BackendVersionError, match=r"mujoco 2\.3\.7 \(supported: >=3\.2,<3\.14\)"):
+        v.enforce_backend_versions(SimType.MUJOCO)
+
+
+@pytest.mark.general
+def test_skip_env_downgrades_the_error_to_a_warning(monkeypatch):
+    _fake_installed(monkeypatch, {"mujoco": "2.3.7", "dm-control": "1.0.45"})
+    monkeypatch.setenv("METASIM_SKIP_VERSION_CHECK", "1")
+    report = v.enforce_backend_versions(SimType.MUJOCO)
+    assert report.unsupported and report.unsupported[0].requirement.dist == "mujoco"
+
+
+@pytest.mark.general
+def test_untested_version_inside_the_range_is_reported_not_refused(monkeypatch):
+    _fake_installed(monkeypatch, {"mujoco": "3.13.0", "dm-control": "1.0.45"})
+    monkeypatch.delenv("METASIM_SKIP_VERSION_CHECK", raising=False)
+    v._WARNED.clear()
+    report = v.enforce_backend_versions(SimType.MUJOCO)
+    assert not report.unsupported and [s.requirement.dist for s in report.untested] == ["mujoco"]
+    assert report.statuses[0].label == "untested"
+
+
+@pytest.mark.general
+def test_missing_backend_is_not_an_error(monkeypatch):
+    _fake_installed(monkeypatch, {})
+    report = v.enforce_backend_versions(SimType.SAPIEN3)
+    assert not report.installed and report.statuses[0].label == "missing"
+
+
+@pytest.mark.general
+def test_prereleases_count_as_inside_the_range(monkeypatch):
+    _fake_installed(
+        monkeypatch, {"newton": "1.6.0.dev0", "warp-lang": "1.17.0", "mujoco-warp": "3.12.0", "mujoco": "3.12.0"}
+    )
+    assert not v.check_backend(SimType.NEWTON).unsupported
+
+
+@pytest.mark.general
+def test_doctor_cli_runs_and_reports_every_backend():
+    out = subprocess.run(
+        [sys.executable, "-m", "metasim", "doctor", "--json"], capture_output=True, text=True, check=False
+    )
+    assert out.returncode in (0, 1), out.stderr[-500:]
+    import json
+
+    names = {row["backend"] for row in json.loads(out.stdout)}
+    assert {"mujoco", "newton", "superdex", "sapien3"} <= names

--- a/packages/metasim/metasim/test/test_contract_api_general.py
+++ b/packages/metasim/metasim/test/test_contract_api_general.py
@@ -131,6 +131,7 @@ def test_pyproject_runtime_dependencies_are_metasim_owned():
         "numpy",
         "numpy-quaternion",
         "opencv-python>=4.11,<4.12",
+        "packaging>=23",
         "pillow",
         "portalocker",
         "pyyaml",

--- a/packages/metasim/metasim/utils/setup_util.py
+++ b/packages/metasim/metasim/utils/setup_util.py
@@ -135,6 +135,11 @@ def get_sim_handler_class(sim: SimType):
     spec = SIM_BACKENDS.get(sim)
     if spec is None:
         raise ValueError(f"Invalid simulator type: {sim}")
+    # Version gate before the import: an unsupported simulator release fails here with the
+    # installed/supported versions in the message, not with an AttributeError inside the handler.
+    from metasim.sim._versions import enforce_backend_versions
+
+    enforce_backend_versions(sim)
     try:
         handler_cls = getattr(importlib.import_module(spec.module), spec.cls)
     except ImportError as e:

--- a/packages/metasim/pyproject.toml
+++ b/packages/metasim/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "numpy",
     "numpy-quaternion",
     "opencv-python>=4.11,<4.12",
+    "packaging>=23",
     "pillow",
     "portalocker",
     "pyyaml",
@@ -164,6 +165,7 @@ metasim = ["data/**/*"]
 
 [tool.ruff.lint.per-file-ignores]
 ## For unit test, allow no docstrings
+"metasim/__main__.py" = ["T20"]  # a CLI prints its report
 "metasim/types.py" = ["UP007", "UP035"]  # runtime Union/Tuple aliases, see the comment in the file
 "metasim/utils/gs_util.py" = ["UP035"]
 "metasim/test/**.py" = ["D"]


### PR DESCRIPTION
Simulator backends move fast and break APIs between minor releases (newton 1.2 → 1.5 → 1.6 each renamed core fields; we hit all three this week). This makes compatibility a declared, checked, routinely re-verified property instead of something discovered at the first `AttributeError`.

**1. Declared policy** — `packages/metasim/metasim/sim/_versions.py`: per backend, every simulator distribution with the version range its code paths support (`spec`) and the exact version its suite last passed with (`tested`). Initial values are what this box verified today (mujoco 3.12.0, dm-control 1.0.45, newton 1.6.0.dev0 / warp 1.17.0 / mujoco-warp 3.12.0, superdex 1.0.0); ranges for backends not installed here are the ones the handlers were written against.

**2. Gate + diagnosis** — `get_sim_handler_class` calls `enforce_backend_versions` before importing a handler: outside `spec` → `BackendVersionError` naming installed vs supported (`METASIM_SKIP_VERSION_CHECK=1` downgrades to a warning); inside `spec` but ≠ `tested` → one warning. `python -m metasim doctor [--json] [--backend X]` prints the whole table and exits 1 on an unsupported install — for issues, Dockerfiles, CI.

**3. Routine check** — `.github/workflows/backend-compat.yml` (weekly + manual): installs the **newest** release of MuJoCo, PyBullet and SuperDex (py3.12), runs `doctor` and `pytest -k <backend>`, and opens/updates a `backend-compat` issue with the versions on failure. GPU backends stay in the merge-queue workflow.

**4. Upgrades arrive as PRs** — `.github/dependabot.yml` groups simulator bumps into one weekly PR per package root (`no-changelog` label).

Docs: `RELEASING.md` §8 (when to bump `tested`, when to widen `spec`), MetaSim `AGENTS.md`. Tests: `test_backend_versions_general.py` (refuse / skip-env / untested / missing / prerelease / CLI). MetaSim general 528 passed, mujoco 56 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw