### PR TITLE
test(superdex): mark the bbq_sauce spawn-height check as a known asset gap

### DIFF
--- a/packages/metasim/metasim/test/sim/test_init_pose.py
+++ b/packages/metasim/metasim/test/sim/test_init_pose.py
@@ -71,6 +71,12 @@ def test_init_pose(handler):
     assert_close(pos, torch.Tensor(handler.scenario.objects[1].default_position), atol=1e-3, message="sphere pos")
     assert_close(rot, torch.Tensor(handler.scenario.objects[1].default_orientation), atol=1e-3, message="sphere rot")
 
+    if handler.scenario.simulator == "superdex":
+        # bbq_sauce's URDF has a mesh-centred origin while the scenario height was authored for
+        # the MJCF (bottom-centred): on SuperDex the hull would spawn 10 cm inside the ground and
+        # the handler lifts it (see the SuperDex ground-clearance warning). The asset needs a
+        # consistent origin across formats; until then the spawn height differs by design.
+        pytest.xfail("bbq_sauce URDF/MJCF origin mismatch: SuperDex lifts the penetrating spawn (asset fix tracked)")
     pos = state[0]["objects"]["bbq_sauce"]["pos"]
     rot = state[0]["objects"]["bbq_sauce"]["rot"]
     assert_close(pos, torch.Tensor(handler.scenario.objects[2].default_position), atol=1e-3, message="bbq_sauce pos")


### PR DESCRIPTION
`test_init_pose[superdex-1]` fails on main since #822: SuperDex now lifts a dynamic body whose collision hull would spawn inside the ground, and `bbq_sauce`'s URDF origin is mesh-centred while the scenario height (0.0094 m) was authored for the bottom-centred MJCF — on SuperDex it spawns 10.6 cm higher by design. The assertion is xfailed on superdex with that reason; the real fix is a consistent origin across the asset's URDF/MJCF/USD (tracked in PLAN C). I missed this in #822's verification, which ran replay / dof_control / state_consistency but not init_pose on SuperDex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw