### PR TITLE
ci(dependabot): leave the deliberate simulator-stack pins alone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,17 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    ignore:
+      # Deliberate pins: numpy<2 is what the Isaac / PyBullet / SuperDex stacks are built against,
+      # setuptools==59.5.0 is the last release with distutils for the robosplatter build, and the
+      # torch/CUDA builds are chosen per simulator. The backend-compat workflow, not Dependabot,
+      # decides when a simulator stack moves (metasim/sim/_versions.py).
+      - dependency-name: "numpy"
+      - dependency-name: "setuptools"
+      - dependency-name: "torch"
+      - dependency-name: "torchvision"
+      - dependency-name: "opencv-python"
+      - dependency-name: "isaacsim"
     groups:
       simulators:
         patterns: ["mujoco*", "newton", "warp-lang", "sapien", "pybullet", "genesis-world", "superdex-*", "jax*", "dm-control"]


### PR DESCRIPTION
Dependabot's first MetaSim run (#846) rewrote `numpy<2` → 2.2.6 and `setuptools==59.5.0` → 84 — pins that exist because the Isaac / PyBullet / SuperDex stacks are built against numpy 1.x and the robosplatter build needs distutils — and the dependency-list contract test rejected it. Those stacks move through `metasim/sim/_versions.py` + the backend-compat workflow, so Dependabot now ignores numpy, setuptools, torch, torchvision, opencv-python and isaacsim in `packages/metasim`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw