### PR TITLE
ci: measure coverage on every PR with floors that only ratchet up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,11 +59,24 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install torch torchvision --index-url https://download.pytorch.org/whl/cpu
           python -m pip install -e "packages/metasim[dev,examples,mujoco]"
-      - name: Simulator-free test suite
+      - name: Simulator-free test suite (coverage floor ratchets up only)
         working-directory: packages/metasim
         env:
           MUJOCO_GL: disable
-        run: python -m pytest -k general -q -rs
+        # Baseline 2026-09-03: 36% of 27,378 statements. Raise the floor when coverage grows; never lower it.
+        run: python -m pytest -k general -q -rs --cov=metasim --cov-report=xml --cov-report=term --cov-fail-under=35
+      - name: Coverage summary
+        if: always()
+        working-directory: packages/metasim
+        run: |
+          echo "### MetaSim coverage (py${{ matrix.python-version }})" >> "$GITHUB_STEP_SUMMARY"
+          python -m coverage report --format=markdown --skip-covered --sort=cover | head -60 >> "$GITHUB_STEP_SUMMARY" || true
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-metasim-py${{ matrix.python-version }}
+          path: packages/metasim/coverage.xml
+          retention-days: 14
 
   tests:
     runs-on: ubuntu-latest
@@ -87,7 +100,19 @@ jobs:
           # (eglQueryString on a None library). `disable` skips GL context creation entirely;
           # nothing in tests/ renders on MuJoCo, and the suite is identical locally with this value.
           MUJOCO_GL: disable
-        run: python -m pytest tests/ -rs
+        # Baseline 2026-09-03: 61% of 30,237 statements across roboverse_pack + roboverse_learn.
+        run: python -m pytest tests/ -rs --cov=roboverse_pack --cov=roboverse_learn --cov-report=xml --cov-report=term --cov-fail-under=58
+      - name: Coverage summary
+        if: always()
+        run: |
+          echo "### RoboVerse coverage" >> "$GITHUB_STEP_SUMMARY"
+          python -m coverage report --format=markdown --skip-covered --sort=cover | head -60 >> "$GITHUB_STEP_SUMMARY" || true
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-roboverse
+          path: coverage.xml
+          retention-days: 14
 
   release-dry-run:
     # What release.yml will do on the next tag, run on every PR so a broken build or a git-URL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,9 @@ RoboVerse uses **ruff** (lint + format) and **pre-commit**. The authoritative co
 
 ## Testing
 
+- Coverage floors live in `.github/workflows/tests.yml` (`--cov-fail-under`): MetaSim's
+  simulator-free suite and the RoboVerse `tests/` suite each have one. They only move up. When a PR
+  lifts coverage, raise the floor in the same PR; a PR must not lower it to get green.
 - RoboVerse content/integration tests live in `tests/` (`test_*.py`, functions `test_*`); run with
   `python -m pytest tests/`. Core simulator tests live in `packages/metasim/metasim/test` — run them
   from `packages/metasim` (`python -m pytest -k general`), following that package's `AGENTS.md`.

--- a/packages/metasim/pyproject.toml
+++ b/packages/metasim/pyproject.toml
@@ -183,3 +183,10 @@ convention = "google"
 
 [tool.pytest.ini_options]
 testpaths = ["metasim/test"]
+
+[tool.coverage.run]
+omit = ["*/test/*", "*/tests/*", "*/__main__.py"]
+
+[tool.coverage.report]
+skip_empty = true
+precision = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -247,3 +247,10 @@ markers = [
     "requires_optional(*modules, extra=None): skip unless the optional dependencies are installed",
     "requires_asset(*relpaths): skip unless the roboverse_data assets are present",
 ]
+
+[tool.coverage.run]
+omit = ["*/test/*", "*/tests/*", "*/__main__.py"]
+
+[tool.coverage.report]
+skip_empty = true
+precision = 1


### PR DESCRIPTION
Quality baseline, test coverage. Measured today on main:

| suite | statements | coverage | floor |
|---|---:|---:|---:|
| MetaSim `-k general` (py3.10/3.11) | 27,378 | 36% | 35% |
| RoboVerse `tests/` (`roboverse_pack` + `roboverse_learn`) | 30,237 | 61% | 58% |

- `--cov-fail-under` floors in `tests.yml`; the rule in AGENTS.md is that they only move up.
- Per-file markdown report in the job summary (`--skip-covered --sort=cover`, worst files first) and `coverage.xml` artifacts (14 days) so a Codecov/SonarCloud upload can be added later without re-measuring.
- `[tool.coverage]` config in both pyprojects (omit tests and `__main__`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017i6VtKoovBNed815mWFqxw