### PR TITLE
ci: calibrate the MetaSim coverage floor from the CI job, not a workstation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,8 +63,10 @@ jobs:
         working-directory: packages/metasim
         env:
           MUJOCO_GL: disable
-        # Baseline 2026-09-03: 36% of 27,378 statements. Raise the floor when coverage grows; never lower it.
-        run: python -m pytest -k general -q -rs --cov=metasim --cov-report=xml --cov-report=term --cov-fail-under=35
+        # Baseline 2026-09-03 as measured by THIS job (py3.10 / py3.11, simulator-free): 23.8% of 21,001
+        # statements. A local run with more backends installed imports more files and reports higher, so
+        # calibrate the floor from the CI log, not from a workstation. Raise it when coverage grows; never lower it.
+        run: python -m pytest -k general -q -rs --cov=metasim --cov-report=xml --cov-report=term --cov-fail-under=22
       - name: Coverage summary
         if: always()
         working-directory: packages/metasim


### PR DESCRIPTION
The floor introduced in #857 (35%) was read off a local run that had extra backends installed and therefore imported more files (36% of 27,378 statements). The simulator-free CI job measures **23.8% of 21,001 statements**, so `metasim general (3.10/3.11)` has failed on every push to `main` since #857 with all 513 tests passing (e.g. run 33813806716: `FAIL Required test coverage of 35% not reached. Total coverage: 23.84%`).

Floor set to 22 from the CI log; the comment now says to calibrate from this job's output. The ratchet policy (floors only move up) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VqU5YzJ2uG3yUQXF52Jk2K