### PR TITLE
fix(rerun): add missing f-string prefix to the replay hint

### DIFF
--- a/examples/rerun/rerun_demo.py
+++ b/examples/rerun/rerun_demo.py
@@ -387,7 +387,7 @@ def main():
 
     if args.save_recording:
         log.info(f"\nRecording saved to: {args.save_recording}")
-        log.info("You can replay it with: rerun {args.save_recording}")
+        log.info(f"You can replay it with: rerun {args.save_recording}")
 
     log.info("=" * 70)
 


### PR DESCRIPTION
### What

`examples/rerun/rerun_demo.py` prints how to replay a saved recording, but the
line was missing its `f` prefix:

```python
if args.save_recording:
    log.info(f"\nRecording saved to: {args.save_recording}")
    log.info("You can replay it with: rerun {args.save_recording}")   # <- no f
```

So instead of the actual path, the user sees the literal placeholder:

```
You can replay it with: rerun {args.save_recording}
```

### Fix

Add the missing `f` prefix so the path is interpolated. The immediately
preceding line (`f"\nRecording saved to: {args.save_recording}"`) is already an
f-string with the same variable, confirming the intended behavior. One-character
change, no logic touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
